### PR TITLE
Fix user agent used for login flow.

### DIFF
--- a/VideoCalls/AuthenticationViewController.m
+++ b/VideoCalls/AuthenticationViewController.m
@@ -52,10 +52,8 @@ NSString * const kNCAuthTokenFlowEndpoint               = @"/index.php/login/flo
     
     _webView = [[WKWebView alloc] initWithFrame:self.view.frame
                                   configuration:configuration];
-    
-    NSString *appDisplayName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"];
-    NSString *deviceName = [[UIDevice currentDevice] name];
-    _webView.customUserAgent = [NSString stringWithFormat:@"%@ (%@)", deviceName, appDisplayName];
+    _webView.customUserAgent = [NSString stringWithFormat:@"Mozilla/5.0 (iOS) Nextcloud-Talk v%@",
+                                [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"]];
     _webView.navigationDelegate = self;
     
     [_webView loadRequest:request];


### PR DESCRIPTION
Before:
`{device name} (Nextcloud Talk)`

After:
`Mozilla/5.0 (iOS) Nextcloud-Talk {version}`

This way client sessions can have the following format in Settings https://github.com/nextcloud/server/pull/12485
Also fixes https://github.com/nextcloud/server/issues/11177