### PR TITLE
Disable timer to hide call buttons when presenting waiting view.

### DIFF
--- a/VideoCalls/CallViewController.m
+++ b/VideoCalls/CallViewController.m
@@ -239,6 +239,7 @@ typedef NS_ENUM(NSInteger, CallState) {
         case CallStateWaitingParticipants:
         {
             [self showWaitingScreen];
+            [self invalidateDetailedViewTimer];
             [self showDetailedView];
             [self removeTapGestureForDetailedView];
         }


### PR DESCRIPTION
Fix #186 