### PR TITLE
Fix missed call notification

### DIFF
--- a/VideoCalls/CallKitManager.h
+++ b/VideoCalls/CallKitManager.h
@@ -19,10 +19,11 @@ extern NSString * const CallKitManagerWantsToUpgradeToVideoCall;
 @property (nonatomic, strong) NSUUID *currentCallUUID;
 @property (nonatomic, strong) NSString *currentCallToken;
 @property (nonatomic, strong) NSString *currentCallDisplayName;
+@property (nonatomic, strong) NSString *currentCalleeAccountId;
 
 + (instancetype)sharedInstance;
 + (BOOL)isCallKitAvailable;
-- (void)reportIncomingCallForRoom:(NSString *)token withDisplayName:(NSString *)displayName;
+- (void)reportIncomingCallForRoom:(NSString *)token withDisplayName:(NSString *)displayName forAccountId:(NSString *)accountId;
 - (void)startCall:(NSString *)token withVideoEnabled:(BOOL)videoEnabled andDisplayName:(NSString *)displayName;
 - (void)endCurrentCall;
 

--- a/VideoCalls/NCNotificationController.m
+++ b/VideoCalls/NCNotificationController.m
@@ -184,7 +184,7 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
     // Set active account
     [[NCSettingsController sharedInstance] setActiveAccountWithAccountId:pushNotification.accountId];
     // Present call
-    [[CallKitManager sharedInstance] reportIncomingCallForRoom:roomToken withDisplayName:displayName];
+    [[CallKitManager sharedInstance] reportIncomingCallForRoom:roomToken withDisplayName:displayName forAccountId:pushNotification.accountId];
 }
 
 - (void)updateAppIconBadgeNumber:(NSInteger)update

--- a/VideoCalls/NCNotificationController.m
+++ b/VideoCalls/NCNotificationController.m
@@ -247,7 +247,7 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
     NCPushNotification *pushNotification = [NCPushNotification pushNotificationFromDecryptedString:notificationString withAccountId:notificationAccountId];
     
     // Change account if notification is from another account
-    if (![[[NCDatabaseManager sharedInstance] activeAccount].accountId isEqualToString:notificationAccountId]) {
+    if (notificationAccountId && ![[[NCDatabaseManager sharedInstance] activeAccount].accountId isEqualToString:notificationAccountId]) {
         // Leave chat before changing accounts
         if ([[NCRoomsManager sharedInstance] chatViewController]) {
             [[[NCRoomsManager sharedInstance] chatViewController] leaveChat];


### PR DESCRIPTION
**Before:**
When interacting with a missed call notification the app tried to set active a (null) account.

**Now:**
The missed call notification includes the accountId, so when interacting with the notification, the app will correctly change the active account and show the missed call conversation.