### PR TITLE
Fix add participants on iOS 13

### DIFF
--- a/VideoCalls/AddParticipantsTableViewController.h
+++ b/VideoCalls/AddParticipantsTableViewController.h
@@ -10,7 +10,16 @@
 
 #import "NCRoom.h"
 
+@class AddParticipantsTableViewController;
+@protocol AddParticipantsTableViewControllerDelegate <NSObject>
+
+- (void)addParticipantsTableViewControllerDidFinish:(AddParticipantsTableViewController *)viewController;
+
+@end
+
 @interface AddParticipantsTableViewController : UITableViewController
+
+@property (nonatomic, weak) id<AddParticipantsTableViewControllerDelegate> delegate;
 
 - (instancetype)initForRoom:(NCRoom *)room;
 

--- a/VideoCalls/AddParticipantsTableViewController.m
+++ b/VideoCalls/AddParticipantsTableViewController.m
@@ -168,6 +168,7 @@
 
 - (void)close
 {
+    [self.delegate addParticipantsTableViewControllerDidFinish:self];
     [self.navigationController dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/VideoCalls/RoomInfoTableViewController.m
+++ b/VideoCalls/RoomInfoTableViewController.m
@@ -69,7 +69,7 @@ typedef enum ModificationError {
 
 #define k_set_password_textfield_tag    98
 
-@interface RoomInfoTableViewController () <UITextFieldDelegate, UIGestureRecognizerDelegate>
+@interface RoomInfoTableViewController () <UITextFieldDelegate, UIGestureRecognizerDelegate, AddParticipantsTableViewControllerDelegate>
 
 @property (nonatomic, strong) NCRoom *room;
 @property (nonatomic, strong) NCChatViewController *chatViewController;
@@ -766,8 +766,14 @@ typedef enum ModificationError {
 - (void)addParticipantsButtonPressed
 {
     AddParticipantsTableViewController *addParticipantsVC = [[AddParticipantsTableViewController alloc] initForRoom:_room];
+    addParticipantsVC.delegate = self;
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:addParticipantsVC];
     [self presentViewController:navigationController animated:YES completion:nil];
+}
+
+- (void)addParticipantsTableViewControllerDidFinish:(AddParticipantsTableViewController *)viewController
+{
+    [self getRoomParticipants];
 }
 
 - (void)showModerationOptionsForParticipantAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
Before the participants list was reloaded after the addParticipants view controller was dismissed (since that triggered didAppear() in room info view controller).
On iOS 13 the addParticipants view controller is not presented full screen so it doesn't trigger didAppear() in room info view controller when is being dismissed.
That's why we need a delegate on addParticipants view controller.