### PR TITLE
Fix scroll issue when opening the chat and there are unread messages.

### DIFF
--- a/VideoCalls/NCChatViewController.m
+++ b/VideoCalls/NCChatViewController.m
@@ -258,14 +258,6 @@ typedef enum NCChatMessageAction {
     }
 }
 
-- (void)viewDidAppear:(BOOL)animated
-{
-    [super viewDidAppear:animated];
-    
-    // Just in case the initial history was loaded from the DB
-    [self.tableView slk_scrollToBottomAnimated:NO];
-}
-
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];


### PR DESCRIPTION
Sometimes the chat was scrolled all the way to the bottom instead of staying where the unread message separator is.