### PR TITLE
Fix image orientation in images picked from imagepicker

### DIFF
--- a/ShareExtension/ShareConfirmationViewController.m
+++ b/ShareExtension/ShareConfirmationViewController.m
@@ -182,9 +182,9 @@
     NSString *attachmentsFolder = _serverCapabilities.attachmentsFolder ? _serverCapabilities.attachmentsFolder : @"";
     NSString *filePath = [NSString stringWithFormat:@"%@/%@", attachmentsFolder, _sharedImageName];
     NSString *fileServerURL = [NSString stringWithFormat:@"%@/%@%@", _account.server, _serverCapabilities.webDAVRoot, filePath];
-    NSData *pngData = UIImagePNGRepresentation(_sharedImage);
+    NSData *pngData = UIImageJPEGRepresentation(_sharedImage, 1);
     NSURL *tmpDirURL = [NSURL fileURLWithPath:NSTemporaryDirectory() isDirectory:YES];
-    NSURL *fileLocalURL = [[tmpDirURL URLByAppendingPathComponent:@"image"] URLByAppendingPathExtension:@"png"];
+    NSURL *fileLocalURL = [[tmpDirURL URLByAppendingPathComponent:@"image"] URLByAppendingPathExtension:@"jpg"];
     [pngData writeToFile:[fileLocalURL path] atomically:YES];
     
     MBProgressHUD *hud = [MBProgressHUD showHUDAddedTo:self.view animated:YES];

--- a/VideoCalls/NCChatViewController.m
+++ b/VideoCalls/NCChatViewController.m
@@ -738,7 +738,7 @@ typedef enum NCChatMessageAction {
     NSString *mediaType = [info objectForKey:UIImagePickerControllerMediaType];
     if ([mediaType isEqualToString:@"public.image"]) {
         UIImage *image = [info objectForKey:UIImagePickerControllerOriginalImage];
-        NSString *imageName = [NSString stringWithFormat:@"IMG_%.f.png", [[NSDate date] timeIntervalSince1970] * 1000];
+        NSString *imageName = [NSString stringWithFormat:@"IMG_%.f.jpg", [[NSDate date] timeIntervalSince1970] * 1000];
         [self dismissViewControllerAnimated:YES completion:^{
             [self presentViewController:navigationController animated:YES completion:^{
                 [shareConfirmationVC setSharedImage:image withImageName:imageName];


### PR DESCRIPTION
Get JPEG representation from imagepicker images so the orientation flag is kept.
Fix #362 