### PR TITLE
Add push-to-talk functionality

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -591,16 +591,19 @@ typedef NS_ENUM(NSInteger, CallState) {
         [self->_audioMuteButton setImage:[UIImage imageNamed:@"audio-off"] forState:UIControlStateNormal];
         
         NSString *micDisabledString = NSLocalizedString(@"Microphone disabled", nil);
+        NSTimeInterval duration = 1.5;
         UIView *toast;
         
         if (reason) {
+            // Nextcloud uses a default timeout of 7s for toasts
+            duration = 7.0;
+
             toast = [self.view toastViewForMessage:reason title:micDisabledString image:nil style:nil];
         } else {
             toast = [self.view toastViewForMessage:micDisabledString title:nil image:nil style:nil];
         }
         
-        // Nextcloud uses a default timeout of 7s for toasts
-        [self.view showToast:toast duration:7.0 position:CSToastPositionCenter completion:nil];
+        [self.view showToast:toast duration:duration position:CSToastPositionCenter completion:nil];
     });
 }
 


### PR DESCRIPTION
Currently talk-ios uses a dialog to display a warning when participant is force-muted by a moderator. In contrast nextcloud talk web uses a toast to display the warning, which will disappear after 7s (default timeout for toasts in nextcloud).

This PR changes the behaviour in talk-ios to also use a toast which will disappear automatically but can be dismissed by the user as well.

Before

![image](https://user-images.githubusercontent.com/1580193/98035424-c3535980-1e18-11eb-9f6d-f8034d8e4861.png)


After


![image](https://user-images.githubusercontent.com/1580193/98035447-ccdcc180-1e18-11eb-960e-91669d587c7f.png)
