### PR TITLE
Fixes when joining a call while in a chat from another conversation

### DIFF
--- a/NextcloudTalk/CallKitManager.m
+++ b/NextcloudTalk/CallKitManager.m
@@ -135,10 +135,10 @@ NSString * const CallKitManagerWantsToUpgradeToVideoCall        = @"CallKitManag
     BOOL ongoingCalls = _calls.count > 0;
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
     
-    // If the app is not active (e.g. in background) and there is an open chat from another conversation
+    // If the app is not active (e.g. in background) and there is an open chat
     BOOL isAppActive = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
     NCChatViewController *chatViewController = [[NCRoomsManager sharedInstance] chatViewController];
-    if (!isAppActive && chatViewController && ![chatViewController.room.token isEqualToString:token]) {
+    if (!isAppActive && chatViewController) {
         // Leave the chat so it doesn't try to join the chat conversation when the app becomes active.
         [chatViewController leaveChat];
         [[NCUserInterfaceController sharedInstance] presentConversationsList];

--- a/NextcloudTalk/CallKitManager.m
+++ b/NextcloudTalk/CallKitManager.m
@@ -30,6 +30,7 @@
 #import "NCNotificationController.h"
 #import "NCRoomsManager.h"
 #import "NCSettingsController.h"
+#import "NCUserInterfaceController.h"
 
 NSString * const CallKitManagerDidAnswerCallNotification        = @"CallKitManagerDidAnswerCallNotification";
 NSString * const CallKitManagerDidEndCallNotification           = @"CallKitManagerDidEndCallNotification";
@@ -133,6 +134,15 @@ NSString * const CallKitManagerWantsToUpgradeToVideoCall        = @"CallKitManag
 {
     BOOL ongoingCalls = _calls.count > 0;
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+    
+    // If the app is not active (e.g. in background) and there is an open chat from another conversation
+    BOOL isAppActive = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
+    NCChatViewController *chatViewController = [[NCRoomsManager sharedInstance] chatViewController];
+    if (!isAppActive && chatViewController && ![chatViewController.room.token isEqualToString:token]) {
+        // Leave the chat so it doesn't try to join the chat conversation when the app becomes active.
+        [chatViewController leaveChat];
+        [[NCUserInterfaceController sharedInstance] presentConversationsList];
+    }
     
     // If the incoming call is from a different account
     if (![activeAccount.accountId isEqualToString:accountId]) {

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -382,6 +382,9 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
         if ([extSignalingController isEnabled]) {
             NSString *currentRoom = extSignalingController.currentRoom;
             if (![currentRoom isEqualToString:room.token]) {
+                // Since we are going to join another conversation, we don't need to leaveRoom() in extSignalingController.
+                // That's why we set currentRoom = nil, so when leaveRoom() is called in extSignalingController the currentRoom
+                // is no longer the room we want to leave (so no message is sent to the external signaling server).
                 extSignalingController.currentRoom = nil;
             }
         }
@@ -436,6 +439,9 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
         if ([extSignalingController isEnabled]) {
             NSString *currentRoom = extSignalingController.currentRoom;
             if (![currentRoom isEqualToString:room.token] && [_chatViewController.room.token isEqualToString:currentRoom]) {
+                // Since we are going to join another conversation, we don't need to leaveRoom() in extSignalingController.
+                // That's why we set currentRoom = nil, so when leaveRoom() is called in extSignalingController the currentRoom
+                // is no longer the room we want to leave (so no message is sent to the external signaling server).
                 extSignalingController.currentRoom = nil;
                 [_chatViewController leaveChat];
                 [[NCUserInterfaceController sharedInstance] presentConversationsList];

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -435,12 +435,10 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
         NCExternalSignalingController *extSignalingController = [[NCSettingsController sharedInstance] externalSignalingControllerForAccountId:activeAccount.accountId];
         if ([extSignalingController isEnabled]) {
             NSString *currentRoom = extSignalingController.currentRoom;
-            if (![currentRoom isEqualToString:room.token]) {
-                [[NCUserInterfaceController sharedInstance] presentConversationsList];
-                if (currentRoom) {
-                    [self leaveChatInRoom:currentRoom];
-                }
+            if (![currentRoom isEqualToString:room.token] && [_chatViewController.room.token isEqualToString:currentRoom]) {
                 extSignalingController.currentRoom = nil;
+                [_chatViewController leaveChat];
+                [[NCUserInterfaceController sharedInstance] presentConversationsList];
             }
         }
         if ([_chatViewController.room.token isEqualToString:room.token]) {


### PR DESCRIPTION
This PR fixes 2 issues that occur when joining a call while being in a chat from another conversation.

1. The chat could not be enter after the call was picked or declined. Only restarting the app would allow to join that chat again.

2. If the app was in the background with an open chat and the call was picked, the call stayed in "Waiting for participants..." screen.