### PR TITLE
Add "Go to file" to file-conversations

### DIFF
--- a/NextcloudTalk/FileMessageTableViewCell.m
+++ b/NextcloudTalk/FileMessageTableViewCell.m
@@ -23,9 +23,7 @@
 #import "FileMessageTableViewCell.h"
 #import "SLKUIConstants.h"
 #import "MaterialActivityIndicator.h"
-#import "NCSettingsController.h"
 #import "NCUtils.h"
-#import "OpenInFirefoxControllerObjC.h"
 #import "UIImageView+AFNetworking.h"
 #import "UIImageView+Letters.h"
 
@@ -176,16 +174,7 @@
 
 - (void)previewTapped:(UITapGestureRecognizer *)recognizer
 {
-    if (_fileLink && _filePath) {
-        NSURL *url = [NSURL URLWithString:_fileLink];
-        if ([NCUtils isNextcloudAppInstalled]) {
-            [NCUtils openFileInNextcloudApp:_filePath withFileLink:_fileLink];
-        } else if ([[NCSettingsController sharedInstance].defaultBrowser isEqualToString:@"Firefox"] && [[OpenInFirefoxControllerObjC sharedInstance] isFirefoxInstalled]) {
-            [[OpenInFirefoxControllerObjC sharedInstance] openInFirefox:url];
-        } else {
-            [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
-        }
-    }
+    [NCUtils openFileInNextcloudAppOrBrowser:_filePath withFileLink:_fileLink];
 }
 
 - (void)setGuestAvatar:(NSString *)displayName

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -21,6 +21,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <NCCommunication/NCCommunication.h>
 
 #import "AFNetworking.h"
 #import "AFImageDownloader.h"
@@ -66,6 +67,7 @@ typedef void (^GetSignalingSettingsCompletionBlock)(NSDictionary *settings, NSEr
 
 typedef void (^ReadFolderCompletionBlock)(NSArray *items, NSError *error);
 typedef void (^ShareFileOrFolderCompletionBlock)(NSError *error);
+typedef void (^GetFileByFileIdCompletionBlock)(NCCommunicationFile *file, NSInteger error, NSString *errorDescription);
 
 typedef void (^GetUserProfileCompletionBlock)(NSDictionary *userProfile, NSError *error);
 
@@ -144,6 +146,8 @@ extern NSInteger const kReceivedChatMessagesLimit;
 // WebDAV client
 - (void)readFolderForAccount:(TalkAccount *)account atPath:(NSString *)path depth:(NSString *)depth withCompletionBlock:(ReadFolderCompletionBlock)block;
 - (void)shareFileOrFolderForAccount:(TalkAccount *)account atPath:(NSString *)path toRoom:(NSString *)token withCompletionBlock:(ShareFileOrFolderCompletionBlock)block;
+- (void)getFileByFileId:(TalkAccount *)account fileId:(NSString *)fileId
+    withCompletionBlock:(GetFileByFileIdCompletionBlock)block;
 
 // User avatars
 - (NSURLRequest *)createAvatarRequestForUser:(NSString *)userId andSize:(NSInteger)size usingAccount:(TalkAccount *)account;

--- a/NextcloudTalk/NCUtils.h
+++ b/NextcloudTalk/NCUtils.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)isNextcloudAppInstalled;
 + (void)openFileInNextcloudApp:(NSString *)path withFileLink:(NSString *)link;
++ (void)openFileInNextcloudAppOrBrowser:(NSString *)path withFileLink:(NSString *)link;
 
 // https://www.php.net/manual/en/class.datetimeinterface.php#datetime.constants.atom
 + (NSDate *)dateFromDateAtomFormat:(NSString *)dateAtomFormatString;

--- a/NextcloudTalk/NCUtils.m
+++ b/NextcloudTalk/NCUtils.m
@@ -26,6 +26,8 @@
 #import <CommonCrypto/CommonDigest.h>
 
 #import "NCDatabaseManager.h"
+#import "NCSettingsController.h"
+#import "OpenInFirefoxControllerObjC.h"
 
 static NSString *const nextcloudScheme = @"nextcloud:";
 
@@ -85,6 +87,20 @@ static NSString *const nextcloudScheme = @"nextcloud:";
     NSString *nextcloudURLString = [NSString stringWithFormat:@"%@//open-file?path=%@&user=%@&link=%@", nextcloudScheme, path, activeAccount.user, link];
     NSURL *nextcloudURL = [NSURL URLWithString:[nextcloudURLString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
     [[UIApplication sharedApplication] openURL:nextcloudURL options:@{} completionHandler:nil];
+}
+
++ (void)openFileInNextcloudAppOrBrowser:(NSString *)path withFileLink:(NSString *)link
+{
+    if (path && link) {
+        NSURL *url = [NSURL URLWithString:link];
+        if ([NCUtils isNextcloudAppInstalled]) {
+            [NCUtils openFileInNextcloudApp:path withFileLink:link];
+        } else if ([[NCSettingsController sharedInstance].defaultBrowser isEqualToString:@"Firefox"] && [[OpenInFirefoxControllerObjC sharedInstance] isFirefoxInstalled]) {
+            [[OpenInFirefoxControllerObjC sharedInstance] openInFirefox:url];
+        } else {
+            [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+        }
+    }
 }
 
 + (NSDate *)dateFromDateAtomFormat:(NSString *)dateAtomFormatString

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -680,9 +680,16 @@ typedef enum ModificationError {
 
 - (void)gotoRoomFile
 {
+    [self setModifyingRoomUI];
+    
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
     
     [[NCAPIController sharedInstance] getFileByFileId:activeAccount fileId:_room.objectId withCompletionBlock:^(NCCommunicationFile *file, NSInteger error, NSString *errorDescription) {
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self removeModifyingRoomUI];
+        });
+        
         if (file) {
             NSString *remoteDavPrefix = [NSString stringWithFormat:@"/remote.php/dav/files/%@/", activeAccount.userId];
             NSString *directoryPath = [file.path componentsSeparatedByString:remoteDavPrefix].lastObject;

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -51,7 +51,8 @@ typedef enum RoomInfoSection {
 typedef enum RoomAction {
     kRoomActionFavorite = 0,
     kRoomActionNotifications,
-    kRoomActionSendLink
+    kRoomActionSendLink,
+    kRoomActionGotoFile
 } RoomAction;
 
 typedef enum PublicAction {
@@ -263,6 +264,12 @@ typedef enum ModificationError {
     if (_room.isPublic) {
         [actions addObject:[NSNumber numberWithInt:kRoomActionSendLink]];
     }
+    
+    // Action for file-rooms
+    if ([_room.objectType isEqualToString:NCRoomObjectTypeFile]) {
+        [actions addObject:[NSNumber numberWithInt:kRoomActionGotoFile]];
+    }
+    
     return [NSArray arrayWithArray:actions];
 }
 
@@ -669,6 +676,14 @@ typedef enum ModificationError {
             NSLog(@"An Error occured sharing room: %@, %@", error.localizedDescription, error.localizedFailureReason);
         }
     };
+}
+
+- (void)gotoRoomFile
+{
+    TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+    NSString *urlString = [NSString stringWithFormat:@"%@/index.php/f/%@", activeAccount.server, _room.objectId];
+
+    [NCUtils openFileInNextcloudAppOrBrowser:_room.name withFileLink:urlString];
 }
 
 - (void)leaveRoom
@@ -1082,6 +1097,7 @@ typedef enum ModificationError {
     static NSString *shareLinkCellIdentifier = @"ShareLinkCellIdentifier";
     static NSString *passwordCellIdentifier = @"PasswordCellIdentifier";
     static NSString *sendLinkCellIdentifier = @"SendLinkCellIdentifier";
+    static NSString *gotoFileCellIdentifier = @"GotoFileCellIdentifier";
     static NSString *lobbyCellIdentifier = @"LobbyCellIdentifier";
     static NSString *lobbyTimerCellIdentifier = @"LobbyTimerCellIdentifier";
     static NSString *leaveRoomCellIdentifier = @"LeaveRoomCellIdentifier";
@@ -1194,6 +1210,31 @@ typedef enum ModificationError {
                     
                     cell.textLabel.text = NSLocalizedString(@"Send conversation link", nil);
                     [cell.imageView setImage:[UIImage imageNamed:@"share-settings"]];
+                    
+                    return cell;
+                }
+                    break;
+                case kRoomActionGotoFile:
+                {
+                    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:gotoFileCellIdentifier];
+                    if (!cell) {
+                        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:gotoFileCellIdentifier];
+                    }
+                    
+                    cell.textLabel.text = NSLocalizedString(@"Go to file", nil);
+                    NSString *fileName = _room.name;
+                    NSString *fileExt = [fileName pathExtension];
+                    
+                    [cell.imageView setImage:[UIImage imageNamed:[NCUtils previewImageForFileExtension:fileExt]]];
+                    
+                    // Make sure the file icon has the same size as all other cell-images
+                    // https://stackoverflow.com/questions/2788028/
+                    CGSize itemSize = CGSizeMake(24, 24);
+                    UIGraphicsBeginImageContextWithOptions(itemSize, NO, UIScreen.mainScreen.scale);
+                    CGRect imageRect = CGRectMake(0.0, 0.0, itemSize.width, itemSize.height);
+                    [cell.imageView.image drawInRect:imageRect];
+                    cell.imageView.image = UIGraphicsGetImageFromCurrentImageContext();
+                    UIGraphicsEndImageContext();
                     
                     return cell;
                 }
@@ -1390,6 +1431,9 @@ typedef enum ModificationError {
                     break;
                 case kRoomActionSendLink:
                     [self shareRoomLinkFromIndexPath:indexPath];
+                    break;
+                case kRoomActionGotoFile:
+                    [self gotoRoomFile];
                     break;
             }
         }


### PR DESCRIPTION
Currently there's no way to open the file which belongs to a file-conversation. This PR adds a "Go to file" action to the room info which opens the file in nextcloud app.

**ToDo**
-  Figure out how we can get the file path with just the fileID.  To open a file in the iOS Nextcloud App, we need the internal link (done) and the path of the file. I've yet to figure out how to retrieve the path. Files which are shared in a room automatically have a path attribute, doesn't look like there's something like this for a file-room
- Check if it's ok to show the image of the filetype or if we need a dedicated icon here

![image](https://user-images.githubusercontent.com/1580193/98423033-b3907b00-208d-11eb-8a87-3b1454695b81.png)

![image](https://user-images.githubusercontent.com/1580193/98423068-cc009580-208d-11eb-92ab-50579f864229.png)

