### PR TITLE
Improve error message "Could not join call/conversation"

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -232,7 +232,7 @@ typedef NS_ENUM(NSInteger, CallState) {
     
     NSError *error = [notification.userInfo objectForKey:@"error"];
     if (error) {
-        [self presentJoinRoomError:[notification.userInfo objectForKey:@"errorReason"]];
+        [self presentJoinError:[notification.userInfo objectForKey:@"errorReason"]];
         return;
     }
     
@@ -537,7 +537,7 @@ typedef NS_ENUM(NSInteger, CallState) {
     _detailedViewTimer = nil;
 }
 
-- (void)presentJoinErrorMessage:(NSString *)alertMessage
+- (void)presentJoinError:(NSString *)alertMessage
 {
     NSString *alertTitle = [NSString stringWithFormat:NSLocalizedString(@"Could not join %@ call", nil), _room.displayName];
     if (_room.type == kNCRoomTypeOneToOne) {
@@ -557,20 +557,6 @@ typedef NS_ENUM(NSInteger, CallState) {
     dispatch_async(dispatch_get_main_queue(), ^{
         [self presentViewController:alert animated:YES completion:nil];
     });
-}
-
-- (void)presentJoinRoomError:(NSString *)errorReason
-{
-    NSString *alertMessage = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while joining the conversation: %@", nil), errorReason];
-    
-    [self presentJoinErrorMessage:alertMessage];
-}
-
-- (void)presentJoinCallError:(NSString *)errorReason
-{
-    NSString *alertMessage = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while joining the call: %@", nil), errorReason];
-    
-    [self presentJoinErrorMessage:alertMessage];
 }
 
 #pragma mark - Call actions
@@ -897,7 +883,7 @@ typedef NS_ENUM(NSInteger, CallState) {
 
 - (void)callControllerDidFailedJoiningCall:(NCCallController *)callController statusCode:(NSNumber *)statusCode errorReason:(NSString *) errorReason
 {
-    [self presentJoinCallError:errorReason];
+    [self presentJoinError:errorReason];
 }
 
 - (void)callControllerDidEndCall:(NCCallController *)callController

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -232,7 +232,7 @@ typedef NS_ENUM(NSInteger, CallState) {
     
     NSError *error = [notification.userInfo objectForKey:@"error"];
     if (error) {
-        [self presentJoinCallError];
+        [self presentJoinRoomError:[notification.userInfo objectForKey:@"errorReason"]];
         return;
     }
     
@@ -537,15 +537,17 @@ typedef NS_ENUM(NSInteger, CallState) {
     _detailedViewTimer = nil;
 }
 
-- (void)presentJoinCallError
+- (void)presentJoinErrorMessage:(NSString *)alertMessage
 {
     NSString *alertTitle = [NSString stringWithFormat:NSLocalizedString(@"Could not join %@ call", nil), _room.displayName];
     if (_room.type == kNCRoomTypeOneToOne) {
         alertTitle = [NSString stringWithFormat:NSLocalizedString(@"Could not join call with %@", nil), _room.displayName];
     }
+    
     UIAlertController * alert = [UIAlertController alertControllerWithTitle:alertTitle
-                                                                    message:NSLocalizedString(@"An error occurred while joining the call", nil)
+                                                                    message:alertMessage
                                                              preferredStyle:UIAlertControllerStyleAlert];
+    
     UIAlertAction* okButton = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
                                                        style:UIAlertActionStyleDefault
                                                      handler:^(UIAlertAction * _Nonnull action) {
@@ -555,6 +557,20 @@ typedef NS_ENUM(NSInteger, CallState) {
     dispatch_async(dispatch_get_main_queue(), ^{
         [self presentViewController:alert animated:YES completion:nil];
     });
+}
+
+- (void)presentJoinRoomError:(NSString *)errorReason
+{
+    NSString *alertMessage = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while joining the conversation: %@", nil), errorReason];
+    
+    [self presentJoinErrorMessage:alertMessage];
+}
+
+- (void)presentJoinCallError:(NSString *)errorReason
+{
+    NSString *alertMessage = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while joining the call: %@", nil), errorReason];
+    
+    [self presentJoinErrorMessage:alertMessage];
 }
 
 #pragma mark - Call actions
@@ -879,9 +895,9 @@ typedef NS_ENUM(NSInteger, CallState) {
     [self setCallState:CallStateWaitingParticipants];
 }
 
-- (void)callControllerDidFailedJoiningCall:(NCCallController *)callController
+- (void)callControllerDidFailedJoiningCall:(NCCallController *)callController statusCode:(NSNumber *)statusCode errorReason:(NSString *) errorReason
 {
-    [self presentJoinCallError];
+    [self presentJoinCallError:errorReason];
 }
 
 - (void)callControllerDidEndCall:(NCCallController *)callController

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -53,7 +53,7 @@ typedef void (^LeaveRoomCompletionBlock)(NSInteger errorCode, NSError *error);
 typedef void (^ParticipantModificationCompletionBlock)(NSError *error);
 
 typedef void (^GetPeersForCallCompletionBlock)(NSMutableArray *peers, NSError *error);
-typedef void (^JoinCallCompletionBlock)(NSError *error);
+typedef void (^JoinCallCompletionBlock)(NSError *error, NSInteger statusCode);
 typedef void (^LeaveCallCompletionBlock)(NSError *error);
 
 typedef void (^GetChatMessagesCompletionBlock)(NSArray *messages, NSInteger lastKnownMessage, NSError *error, NSInteger statusCode);

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -762,11 +762,17 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     NCAPISessionManager *apiSessionManager = [_apiSessionManagers objectForKey:account.accountId];
     NSURLSessionDataTask *task = [apiSessionManager POST:URLString parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         if (block) {
-            block(nil);
+            block(nil, 0);
         }
     } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
+        NSInteger statusCode = 0;
+        if ([task.response isKindOfClass:[NSHTTPURLResponse class]]) {
+            NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)task.response;
+            statusCode = httpResponse.statusCode;
+        }
+        
         if (block) {
-            block(error);
+            block(error, statusCode);
         }
     }];
     

--- a/NextcloudTalk/NCCallController.h
+++ b/NextcloudTalk/NCCallController.h
@@ -33,7 +33,7 @@ typedef void (^GetUserIdForSessionIdCompletionBlock)(NSString *userId, NSError *
 @protocol NCCallControllerDelegate<NSObject>
 
 - (void)callControllerDidJoinCall:(NCCallController *)callController;
-- (void)callControllerDidFailedJoiningCall:(NCCallController *)callController;
+- (void)callControllerDidFailedJoiningCall:(NCCallController *)callController statusCode:(NSNumber *)statusCode errorReason:(NSString *)errorReason;
 - (void)callControllerDidEndCall:(NCCallController *)callController;
 - (void)callController:(NCCallController *)callController peerJoined:(NCPeerConnection *)peer;
 - (void)callController:(NCCallController *)callController peerLeft:(NCPeerConnection *)peer;

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -542,15 +542,19 @@ typedef enum NCChatMessageAction {
     return sendingMessage;
 }
 
-- (void)presentJoinRoomError
+- (void)presentJoinRoomError:(NSString *)errorReason
 {
     NSString *alertTitle = [NSString stringWithFormat:NSLocalizedString(@"Could not join %@", nil), _room.displayName];
     if (_room.type == kNCRoomTypeOneToOne) {
         alertTitle = [NSString stringWithFormat:NSLocalizedString(@"Could not join conversation with %@", nil), _room.displayName];
     }
+    
+    NSString *alertMessage = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while joining the conversation: %@", nil), errorReason];
+    
     UIAlertController * alert = [UIAlertController alertControllerWithTitle:alertTitle
-                                                                    message:NSLocalizedString(@"An error occurred while joining the conversation", nil)
+                                                                    message:alertMessage
                                                              preferredStyle:UIAlertControllerStyleAlert];
+    
     UIAlertAction* okButton = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
                                                        style:UIAlertActionStyleDefault
                                                      handler:nil];
@@ -1045,7 +1049,7 @@ typedef enum NCChatMessageAction {
         _offlineMode = YES;
         [self setOfflineFooterView];
         [_chatController stopReceivingNewChatMessages];
-        [self presentJoinRoomError];
+        [self presentJoinRoomError:[notification.userInfo objectForKey:@"errorReason"]];
         return;
     }
     

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -542,15 +542,13 @@ typedef enum NCChatMessageAction {
     return sendingMessage;
 }
 
-- (void)presentJoinRoomError:(NSString *)errorReason
+- (void)presentJoinError:(NSString *)alertMessage
 {
     NSString *alertTitle = [NSString stringWithFormat:NSLocalizedString(@"Could not join %@", nil), _room.displayName];
     if (_room.type == kNCRoomTypeOneToOne) {
         alertTitle = [NSString stringWithFormat:NSLocalizedString(@"Could not join conversation with %@", nil), _room.displayName];
     }
-    
-    NSString *alertMessage = [NSString stringWithFormat:NSLocalizedString(@"An error occurred while joining the conversation: %@", nil), errorReason];
-    
+
     UIAlertController * alert = [UIAlertController alertControllerWithTitle:alertTitle
                                                                     message:alertMessage
                                                              preferredStyle:UIAlertControllerStyleAlert];
@@ -1049,7 +1047,7 @@ typedef enum NCChatMessageAction {
         _offlineMode = YES;
         [self setOfflineFooterView];
         [_chatController stopReceivingNewChatMessages];
-        [self presentJoinRoomError:[notification.userInfo objectForKey:@"errorReason"]];
+        [self presentJoinError:[notification.userInfo objectForKey:@"errorReason"]];
         return;
     }
     

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -133,6 +133,7 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
                 }
                 [userInfo setObject:error forKey:@"error"];
                 [userInfo setObject:@(statusCode) forKey:@"statusCode"];
+                [userInfo setObject:[self getJoinRoomErrorReason:statusCode] forKey:@"errorReason"];
                 NSLog(@"Could not join room. Status code: %ld. Error: %@", (long)statusCode, error.description);
             }
             _joiningRoom = nil;
@@ -153,6 +154,32 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
                                                             object:self
                                                           userInfo:userInfo];
     }
+}
+
+- (NSString *)getJoinRoomErrorReason:(NSInteger)statusCode
+{
+    NSString *errorReason = NSLocalizedString(@"Unknown error occurred", nil);
+    
+    switch (statusCode) {
+        case 0:
+            errorReason = NSLocalizedString(@"No response from server", nil);
+            break;
+            
+        case 403:
+            errorReason = NSLocalizedString(@"The password is wrong", nil);
+            break;
+            
+        case 404:
+            errorReason = NSLocalizedString(@"Conversation not found", nil);
+            break;
+            
+        case 409:
+            // Currently not triggered, needs to be enabled in API with sending force=false
+            errorReason = NSLocalizedString(@"Duplicate session", nil);
+            break;
+    }
+    
+    return errorReason;
 }
 
 - (void)joinRoom:(NSString *)token


### PR DESCRIPTION
Currently when something goes wrong when joining a conversation/room or a call there's just a generic error message "Could not join conversation". When joining a call it's not even clear if the error comes from joining the room or joining the call.

This PR improves those error messages so it's clear what went wrong.