### PR TITLE
Fix sharing images from mail

### DIFF
--- a/ShareExtension/ShareViewController.m
+++ b/ShareExtension/ShareViewController.m
@@ -192,6 +192,8 @@
 
 - (void)setSharedItemToShareConfirmationViewController:(ShareConfirmationViewController *)shareConfirmationVC
 {
+    NSLog(@"Received %lu files to share", [self.extensionContext.inputItems count]);
+    
     [self.extensionContext.inputItems enumerateObjectsUsingBlock:^(NSExtensionItem * _Nonnull extItem, NSUInteger idx, BOOL * _Nonnull stop) {
         [extItem.attachments enumerateObjectsUsingBlock:^(NSItemProvider * _Nonnull itemProvider, NSUInteger idx, BOOL * _Nonnull stop) {
             // Check if shared video
@@ -211,20 +213,8 @@
                                       }];
                 return;
             }
-            // Check if shared image
-            if ([itemProvider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
-                [itemProvider loadItemForTypeIdentifier:(NSString *)kUTTypeImage
-                                                options:nil
-                                      completionHandler:^(id<NSSecureCoding>  _Nullable item, NSError * _Null_unspecified error) {
-                                          if ([(NSObject *)item isKindOfClass:[NSURL class]]) {
-                                              NSLog(@"Shared Image = %@", item);
-                                              NSURL *imageURL = (NSURL *)item;
-                                              [shareConfirmationVC setSharedFileWithFileURL:imageURL];
-                                          }
-                                      }];
-                return;
-            }
             // Check if shared file
+            // Make sure this is checked before image! Otherwise sharing images from Mail won't work >= iOS 13
             if ([itemProvider hasItemConformingToTypeIdentifier:@"public.file-url"]) {
                 [itemProvider loadItemForTypeIdentifier:@"public.file-url"
                                                 options:nil
@@ -237,6 +227,19 @@
                                               [coordinator coordinateReadingItemAtURL:fileUrl options:NSFileCoordinatorReadingForUploading error:&error byAccessor:^(NSURL *newURL) {
                                                   [shareConfirmationVC setSharedFileWithFileURL:newURL];
                                               }];
+                                          }
+                                      }];
+                return;
+            }
+            // Check if shared image
+            if ([itemProvider hasItemConformingToTypeIdentifier:(NSString *)kUTTypeImage]) {
+                [itemProvider loadItemForTypeIdentifier:(NSString *)kUTTypeImage
+                                                options:nil
+                                      completionHandler:^(id<NSSecureCoding>  _Nullable item, NSError * _Null_unspecified error) {
+                                          if ([(NSObject *)item isKindOfClass:[NSURL class]]) {
+                                              NSLog(@"Shared Image = %@", item);
+                                              NSURL *imageURL = (NSURL *)item;
+                                              [shareConfirmationVC setSharedFileWithFileURL:imageURL];
                                           }
                                       }];
                 return;

--- a/ShareExtension/ShareViewController.m
+++ b/ShareExtension/ShareViewController.m
@@ -240,6 +240,12 @@
                                               NSLog(@"Shared Image = %@", item);
                                               NSURL *imageURL = (NSURL *)item;
                                               [shareConfirmationVC setSharedFileWithFileURL:imageURL];
+                                          } else if ([(NSObject *)item isKindOfClass:[UIImage class]]) {
+                                              // Occurs when sharing a screenshot
+                                              NSLog(@"Shared UIImage = %@", item);
+                                              UIImage *image = (UIImage *)item;
+                                              NSString *imageName = [NSString stringWithFormat:@"IMG_%.f.jpg", [[NSDate date] timeIntervalSince1970] * 1000];
+                                              [shareConfirmationVC setSharedImage:image withImageName:imageName];
                                           }
                                       }];
                 return;


### PR DESCRIPTION
When trying to share an image which was received by mail, you get an empty ShareConfirmationView:

![image](https://user-images.githubusercontent.com/1580193/99146966-20eb6f80-267d-11eb-84a6-5a3899abf542.png)

This happens because the following check for NSURL fails (_NSItemProviderSandboxedResource is returned instead):
https://github.com/nextcloud/talk-ios/blob/99a0b59f0118bc168d74d94e2f343b0e9781b32d/ShareExtension/ShareViewController.m#L219-L223

Looks like this is happening since iOS 13: https://stackoverflow.com/a/58099390/2512312

Checking for `public.file-url` works perfectly, so this PR just changes the order of the checks. Sharing images from `Photos` or `WhatsApp` still worked after this in my tests.

After:
![image](https://user-images.githubusercontent.com/1580193/99147041-bb4bb300-267d-11eb-90db-2cf896923613.png)

