### PR TITLE
Add interactive push notifications

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -30,6 +30,8 @@
 #import <WebRTC/RTCAudioSession.h>
 #import <WebRTC/RTCAudioSessionConfiguration.h>
 
+#import <UserNotifications/UserNotifications.h>
+
 #import "NCAudioController.h"
 #import "NCAppBranding.h"
 #import "NCConnectionController.h"
@@ -172,6 +174,22 @@
     
     normalPushToken = [self stringWithDeviceToken:deviceToken];
     [self checkForPushNotificationSubscription];
+    [self registerInteractivePushNotification];
+}
+
+- (void)registerInteractivePushNotification
+{
+    UNTextInputNotificationAction *replyAction = [UNTextInputNotificationAction actionWithIdentifier:@"REPLY_CHAT"
+                                                                                          title:NSLocalizedString(@"Reply", nil)
+                                                                                        options:UNNotificationActionOptionAuthenticationRequired];
+    
+    UNNotificationCategory *chatCategory = [UNNotificationCategory categoryWithIdentifier:@"CATEGORY_CHAT"
+                                                                              actions:@[replyAction]
+                                                                    intentIdentifiers:@[]
+                                                                              options:UNNotificationCategoryOptionNone];
+    
+    NSSet *categories = [NSSet setWithObject:chatCategory];
+    [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:categories];
 }
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler

--- a/NextcloudTalk/Info.plist
+++ b/NextcloudTalk/Info.plist
@@ -37,6 +37,7 @@
 	<array>
 		<string>audio</string>
 		<string>fetch</string>
+		<string>processing</string>
 		<string>remote-notification</string>
 		<string>voip</string>
 	</array>

--- a/NextcloudTalk/NCChatViewController.h
+++ b/NextcloudTalk/NCChatViewController.h
@@ -32,5 +32,6 @@
 - (void)stopChat;
 - (void)resumeChat;
 - (void)leaveChat;
+- (void)setChatMessage:(NSString *)message;
 
 @end

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -259,9 +259,7 @@ typedef enum NCChatMessageAction {
     
     // Check if there's a stored pending message
     if (_room.pendingMessage != nil) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            self.textView.text = self->_room.pendingMessage;
-        });
+        [self setChatMessage:self.room.pendingMessage];
     }
     
     NSDictionary *views = @{@"unreadMessagesButton": _unreadMessageButton,
@@ -346,6 +344,13 @@ typedef enum NCChatMessageAction {
     if ([NCRoomsManager sharedInstance].chatViewController == self) {
         [NCRoomsManager sharedInstance].chatViewController = nil;
     }
+}
+
+- (void)setChatMessage:(NSString *)message
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.textView.text = message;
+    });
 }
 
 #pragma mark - App lifecycle notifications

--- a/NextcloudTalk/NCNotificationController.h
+++ b/NextcloudTalk/NCNotificationController.h
@@ -29,7 +29,8 @@ extern NSString * const NCLocalNotificationJoinChatNotification;
 
 typedef enum {
     kNCLocalNotificationTypeMissedCall = 1,
-    kNCLocalNotificationTypeCancelledCall
+    kNCLocalNotificationTypeCancelledCall,
+    kNCLocalNotificationTypeFailedSendChat
 } NCLocalNotificationType;
 
 @interface NCNotificationController : NSObject

--- a/NextcloudTalk/NCPushNotification.h
+++ b/NextcloudTalk/NCPushNotification.h
@@ -54,6 +54,7 @@ extern NSString * const NCPushNotificationJoinVideoCallAcceptedNotification;
 @property (nonatomic, assign) NSInteger notificationId;
 @property (nonatomic, copy) NSString *accountId;
 @property (nonatomic, copy) NSString *jsonString;
+@property (nonatomic, copy) NSString *responseUserText;
 
 + (instancetype)pushNotificationFromDecryptedString:(NSString *)decryptedString withAccountId:(NSString *)accountId;
 - (NSString *)bodyForRemoteAlerts;

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -31,7 +31,6 @@
 #import "NCDatabaseManager.h"
 #import "NCChatMessage.h"
 #import "NCExternalSignalingController.h"
-#import "NCChatController.h"
 #import "NCSettingsController.h"
 #import "NCUserInterfaceController.h"
 #import "CallKitManager.h"
@@ -616,6 +615,13 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
     NSString *roomToken = [notification.userInfo objectForKey:@"roomToken"];
     if (roomToken) {
         [self startChatWithRoomToken:roomToken];
+        
+        // In case this notification occured because of a failed chat-sending event, make sure the text is not lost
+        // Note: This will override any stored pending message
+        NSString *responseUserText = [notification.userInfo objectForKey:@"responseUserText"];
+        if (_chatViewController && responseUserText) {
+            [_chatViewController setChatMessage:responseUserText];
+        }
     }
 }
 

--- a/NotificationServiceExtension/NotificationService.m
+++ b/NotificationServiceExtension/NotificationService.m
@@ -84,6 +84,12 @@
                     self.bestAttemptContent.threadIdentifier = pushNotification.roomToken;
                     self.bestAttemptContent.sound = [UNNotificationSound defaultSound];
                     self.bestAttemptContent.badge = @(unreadNotifications);
+                    
+                    if (pushNotification.type == NCPushNotificationTypeChat) {
+                        // Set category for chat messages to allow interactive notifications
+                        self.bestAttemptContent.categoryIdentifier = @"CATEGORY_CHAT";
+                    }
+                    
                     NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
                     [userInfo setObject:pushNotification.jsonString forKey:@"pushNotification"];
                     [userInfo setObject:pushNotification.accountId forKey:@"accountId"];


### PR DESCRIPTION
This PR adds interactive push-notifications. When receiving a push-notification of type `chat` the user has the ability to directly reply to the message - directly from the notification:

![image](https://user-images.githubusercontent.com/1580193/99153299-e1864880-26a7-11eb-997a-d510547c8b23.png)
![image](https://user-images.githubusercontent.com/1580193/99153301-e814c000-26a7-11eb-9e27-a5f7c95edd46.png)

I've done testing with my own push-implementation, so this needs testing with the NC-proxy, but should work out-of-the-box.