### PR TITLE
Return best attempt content when notification service extension time expires

### DIFF
--- a/NotificationServiceExtension/NotificationService.m
+++ b/NotificationServiceExtension/NotificationService.m
@@ -124,9 +124,6 @@
 - (void)serviceExtensionTimeWillExpire {
     // Called just before the extension will be terminated by the system.
     // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
-    self.bestAttemptContent.title = @"";
-    self.bestAttemptContent.body = NSLocalizedString(@"You received a new notification", nil);
-    
     self.contentHandler(self.bestAttemptContent);
 }
 


### PR DESCRIPTION
Instead of returning a default notification body, now we return the best attempt we had.
So for example, if the notification service extension time expires before getting the notification from the server, we can return at least the decrypted notification content.