### PR TITLE
Download and view shared files in talk-ios

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -13,6 +13,12 @@
 		1F4DD3EB2571C688007DC98E /* EmojiUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4DD3EA2571C688007DC98E /* EmojiUtils.swift */; };
 		1F4DD3EC2571C688007DC98E /* EmojiUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4DD3EA2571C688007DC98E /* EmojiUtils.swift */; };
 		1F4DD3ED2571C688007DC98E /* EmojiUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4DD3EA2571C688007DC98E /* EmojiUtils.swift */; };
+		1FEDE3C6257D439500853F79 /* NCChatFileController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FEDE3C4257D439500853F79 /* NCChatFileController.m */; };
+		1FEDE3C7257D439500853F79 /* NCChatFileController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FEDE3C4257D439500853F79 /* NCChatFileController.m */; };
+		1FEDE3C8257D439500853F79 /* NCChatFileController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FEDE3C4257D439500853F79 /* NCChatFileController.m */; };
+		1FEDE3CE257D43AB00853F79 /* NCMessageFileParameter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FEDE3CC257D43AB00853F79 /* NCMessageFileParameter.m */; };
+		1FEDE3CF257D43AB00853F79 /* NCMessageFileParameter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FEDE3CC257D43AB00853F79 /* NCMessageFileParameter.m */; };
+		1FEDE3D0257D43AB00853F79 /* NCMessageFileParameter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FEDE3CC257D43AB00853F79 /* NCMessageFileParameter.m */; };
 		2C0574821EDD9E8E00D9E7F2 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C0574811EDD9E8E00D9E7F2 /* main.m */; };
 		2C0574851EDD9E8E00D9E7F2 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C0574841EDD9E8E00D9E7F2 /* AppDelegate.m */; };
 		2C05748E1EDD9E8E00D9E7F2 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2C05748C1EDD9E8E00D9E7F2 /* Main.storyboard */; };
@@ -464,6 +470,10 @@
 		1F3D3B20255F109E00230DAE /* BarButtonItemWithActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BarButtonItemWithActivity.m; sourceTree = "<group>"; };
 		1F3D3B21255F109E00230DAE /* BarButtonItemWithActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BarButtonItemWithActivity.h; sourceTree = "<group>"; };
 		1F4DD3EA2571C688007DC98E /* EmojiUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiUtils.swift; sourceTree = "<group>"; };
+		1FEDE3C4257D439500853F79 /* NCChatFileController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NCChatFileController.m; sourceTree = "<group>"; };
+		1FEDE3C5257D439500853F79 /* NCChatFileController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCChatFileController.h; sourceTree = "<group>"; };
+		1FEDE3CC257D43AB00853F79 /* NCMessageFileParameter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NCMessageFileParameter.m; sourceTree = "<group>"; };
+		1FEDE3CD257D43AB00853F79 /* NCMessageFileParameter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCMessageFileParameter.h; sourceTree = "<group>"; };
 		2C05747D1EDD9E8E00D9E7F2 /* NextcloudTalk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NextcloudTalk.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C0574811EDD9E8E00D9E7F2 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2C0574831EDD9E8E00D9E7F2 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -1544,10 +1554,14 @@
 				2CA15540208E350300CE8EF0 /* NCChatMessage.m */,
 				2C42ADB220B58E6300296DEA /* NCChatController.h */,
 				2C42ADB320B58E6300296DEA /* NCChatController.m */,
+				1FEDE3C5257D439500853F79 /* NCChatFileController.h */,
+				1FEDE3C4257D439500853F79 /* NCChatFileController.m */,
 				2CA15543208E41B500CE8EF0 /* NCChatViewController.h */,
 				2CA15544208E41B500CE8EF0 /* NCChatViewController.m */,
 				2C43BA7421309A1000B3068A /* NCMessageParameter.h */,
 				2C43BA7521309A1000B3068A /* NCMessageParameter.m */,
+				1FEDE3CD257D43AB00853F79 /* NCMessageFileParameter.h */,
+				1FEDE3CC257D43AB00853F79 /* NCMessageFileParameter.m */,
 			);
 			name = Chat;
 			sourceTree = "<group>";
@@ -1642,7 +1656,7 @@
 				TargetAttributes = {
 					2C05747C1EDD9E8E00D9E7F2 = {
 						CreatedOnToolsVersion = 8.3.2;
-                        DevelopmentTeam = NKUJUXUJ3B;
+						DevelopmentTeam = NKUJUXUJ3B;
 						LastSwiftMigration = 1220;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -1662,13 +1676,13 @@
 					};
 					2C62AFA224C08845007E460A = {
 						CreatedOnToolsVersion = 11.5;
-                        DevelopmentTeam = NKUJUXUJ3B;
+						DevelopmentTeam = NKUJUXUJ3B;
 						LastSwiftMigration = 1220;
 						ProvisioningStyle = Automatic;
 					};
 					2CC0014E24A1F0E900A20167 = {
 						CreatedOnToolsVersion = 11.5;
-                        DevelopmentTeam = NKUJUXUJ3B;
+						DevelopmentTeam = NKUJUXUJ3B;
 						LastSwiftMigration = 1220;
 						ProvisioningStyle = Automatic;
 					};
@@ -1934,6 +1948,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				2C7C106221AF199300461817 /* SettingsViewController.m in Sources */,
+				1FEDE3C6257D439500853F79 /* NCChatFileController.m in Sources */,
+				1FEDE3CE257D43AB00853F79 /* NCMessageFileParameter.m in Sources */,
 				2C961E0C2216BF4B00F5C23F /* NCRichDocumentTemplate.m in Sources */,
 				2CA15545208E41B500CE8EF0 /* NCChatViewController.m in Sources */,
 				2C06BF6720AC647A0031EB46 /* DateHeaderView.m in Sources */,
@@ -2178,10 +2194,12 @@
 				2C1EF36D25505DCE007C9768 /* NCNavigationController.m in Sources */,
 				2C62B01924C1BDC6007E460A /* NCRoomParticipants.m in Sources */,
 				2C62AFD424C1BD7E007E460A /* NSDate+RFC1123.m in Sources */,
+				1FEDE3C8257D439500853F79 /* NCChatFileController.m in Sources */,
 				2C62B01A24C1BDC6007E460A /* RoomSearchTableViewController.m in Sources */,
 				2C62AFEB24C1BD99007E460A /* AvatarBackgroundImageView.m in Sources */,
 				2C62AFC324C1BD74007E460A /* SLKTypingIndicatorView.m in Sources */,
 				2C62AFF724C1BDA5007E460A /* NCMessageTextView.m in Sources */,
+				1FEDE3D0257D43AB00853F79 /* NCMessageFileParameter.m in Sources */,
 				2C62AFB924C1A4E6007E460A /* ShareViewController.m in Sources */,
 				2C62B03124C1BDDC007E460A /* NCSignalingController.m in Sources */,
 				2C62AFC224C1BD74007E460A /* SLKTextViewController.m in Sources */,
@@ -2198,6 +2216,7 @@
 				2CC001E724A37ADF00A20167 /* NCSignalingController.m in Sources */,
 				2CC001DA24A37AD000A20167 /* CCBKPasscode.m in Sources */,
 				2CC001DC24A37AD400A20167 /* NCAppBranding.m in Sources */,
+				1FEDE3C7257D439500853F79 /* NCChatFileController.m in Sources */,
 				2CC0017024A3792800A20167 /* NCPushProxySessionManager.m in Sources */,
 				2C694D9525010C0100DD0008 /* ShareConfirmationViewController.m in Sources */,
 				2CC0018024A37A5500A20167 /* UIResponder+SLKAdditions.m in Sources */,
@@ -2207,6 +2226,7 @@
 				2CC0017B24A37A4800A20167 /* SLKTextInputbar.m in Sources */,
 				2CC0015324A1F0E900A20167 /* NotificationService.m in Sources */,
 				2CC0017D24A37A4D00A20167 /* SLKTextView.m in Sources */,
+				1FEDE3CF257D43AB00853F79 /* NCMessageFileParameter.m in Sources */,
 				2CC001AE24A37A8F00A20167 /* MessageSeparatorTableViewCell.m in Sources */,
 				2CC001D124A37ACA00A20167 /* NCRoomsManager.m in Sources */,
 				2CC001C324A37AC500A20167 /* NCNotificationController.m in Sources */,

--- a/NextcloudTalk/FileMessageTableViewCell.h
+++ b/NextcloudTalk/FileMessageTableViewCell.h
@@ -23,6 +23,8 @@
 #import <UIKit/UIKit.h>
 #import "ChatTableViewCell.h"
 #import "MessageBodyTextView.h"
+#import "NCMessageFileParameter.h"
+#import "NCChatMessage.h"
 
 static CGFloat kFileMessageCellMinimumHeight        = 50.0;
 static CGFloat kFileMessageCellAvatarHeight         = 30.0;
@@ -34,19 +36,28 @@ static NSString *GroupedFileMessageCellIdentifier   = @"GroupedFileMessageCellId
 @interface FilePreviewImageView : UIImageView
 @end
 
+@class FileMessageTableViewCell;
+
+@protocol FileMessageTableViewCellDelegate <NSObject>
+
+- (void)cellWantsToDownloadFile:(NCMessageFileParameter *)fileParameter;
+
+@end
+
 @interface FileMessageTableViewCell : ChatTableViewCell
+
+@property (nonatomic, weak) id<FileMessageTableViewCellDelegate> delegate;
 
 @property (nonatomic, strong) UILabel *titleLabel;
 @property (nonatomic, strong) UILabel *dateLabel;
 @property (nonatomic, strong) FilePreviewImageView *previewImageView;
 @property (nonatomic, strong) MessageBodyTextView *bodyTextView;
 @property (nonatomic, strong) UIImageView *avatarView;
-@property (nonatomic, strong) NSString *fileLink;
-@property (nonatomic, strong) NSString *filePath;
 @property (nonatomic, strong) UIView *statusView;
+@property (nonatomic, strong) NCMessageFileParameter *fileParameter;
 
 + (CGFloat)defaultFontSize;
 - (void)setGuestAvatar:(NSString *)displayName;
-- (void)setDeliveryState:(ChatMessageDeliveryState)state;
+- (void)setupForMessage:(NCChatMessage *)message;
 
 @end

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -96,6 +96,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 
 + (instancetype)sharedInstance;
 - (void)createAPISessionManagerForAccount:(TalkAccount *)account;
+- (void)setupNCCommunicationForAccount:(TalkAccount *)account;
 
 // Contacts Controller
 - (NSURLSessionDataTask *)getContactsForAccount:(TalkAccount *)account forRoom:(NSString *)room groupRoom:(BOOL)groupRoom withSearchParam:(NSString *)search andCompletionBlock:(GetContactsCompletionBlock)block;

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -97,6 +97,16 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     [_apiSessionManagers setObject:apiSessionManager forKey:account.accountId];
 }
 
+- (void)setupNCCommunicationForAccount:(TalkAccount *)account
+{
+    ServerCapabilities *serverCapabilities = [[NCDatabaseManager sharedInstance] serverCapabilitiesForAccountId:account.accountId];
+    NSString *userToken = [[NCSettingsController sharedInstance] tokenForAccountId:account.accountId];
+    NSString *userAgent = [NSString stringWithFormat:@"Mozilla/5.0 (iOS) Nextcloud-Talk v%@", [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"]];
+    [[NCCommunicationCommon shared] setupWithAccount:account.accountId user:account.user userId:account.userId password:userToken
+                                             urlBase:account.server userAgent:userAgent webDav:serverCapabilities.webDAVRoot dav:nil
+                                    nextcloudVersion:serverCapabilities.versionMajor delegate:self];
+}
+
 - (void)initImageDownloaders
 {
     _imageDownloader = [[AFImageDownloader alloc]
@@ -1013,16 +1023,9 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     }];
 }
 
-- (void)getFileByFileId:(TalkAccount *)account fileId:(NSString *)fileId
-    withCompletionBlock:(GetFileByFileIdCompletionBlock)block
+- (void)getFileByFileId:(TalkAccount *)account fileId:(NSString *)fileId withCompletionBlock:(GetFileByFileIdCompletionBlock)block
 {
-    // Configure communication lib
-    ServerCapabilities *serverCapabilities = [[NCDatabaseManager sharedInstance] serverCapabilitiesForAccountId:account.accountId];
-    NSString *userToken = [[NCSettingsController sharedInstance] tokenForAccountId:account.accountId];
-    NSString *userAgent = [NSString stringWithFormat:@"Mozilla/5.0 (iOS) Nextcloud-Talk v%@", [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"]];
-    [[NCCommunicationCommon shared] setupWithAccount:account.accountId user:account.user userId:account.userId password:userToken
-                                             urlBase:account.server userAgent:userAgent webDav:serverCapabilities.webDAVRoot dav:nil
-                                    nextcloudVersion:serverCapabilities.versionMajor delegate:self];
+    [self setupNCCommunicationForAccount:account];
     
     NSString *body = @"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
     <d:searchrequest xmlns:d=\"DAV:\" xmlns:oc=\"http://nextcloud.com/ns\">\

--- a/NextcloudTalk/NCChatFileController.h
+++ b/NextcloudTalk/NCChatFileController.h
@@ -19,23 +19,31 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#import <Foundation/Foundation.h>
 
+#import "NCDatabaseManager.h"
 #import "NCMessageFileParameter.h"
 
-@implementation NCMessageFileParameter
+NS_ASSUME_NONNULL_BEGIN
 
-- (instancetype)initWithDictionary:(NSDictionary *)parameterDict
-{
-    self = [super initWithDictionary:parameterDict];
-    if (self) {      
-        self.path = [parameterDict objectForKey:@"path"];
-        self.mimetype = [parameterDict objectForKey:@"mimetype"];
-        self.previewAvailable = [[parameterDict objectForKey:@"preview-available"] boolValue];
-        self.isDownloading = NO;
-        self.downloadProgress = 0;
-    }
-    
-    return self;
-}
+extern NSString * const NCChatFileControllerDidChangeIsDownloadingNotification;
+extern NSString * const NCChatFileControllerDidChangeDownloadProgressNotification;
+
+@class NCChatFileController;
+
+@protocol NCChatFileControllerDelegate<NSObject>
+
+- (void)fileControllerDidLoadFile:(NCChatFileController *)fileController withFileParameter:(NCMessageFileParameter *)parameter withFilePath:(NSString *)path;
 
 @end
+
+@interface NCChatFileController : NSObject
+
+@property (nonatomic, weak) id<NCChatFileControllerDelegate> delegate;
+
+- (void)downloadFileFromMessage:(NCMessageFileParameter *)fileParameter;
+- (void)deleteDownloadDirectoryForAccount:(TalkAccount *)account;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/NextcloudTalk/NCChatFileController.m
+++ b/NextcloudTalk/NCChatFileController.m
@@ -175,7 +175,7 @@ int const kNCChatFileControllerDeleteFilesOlderThanDays = 7;
 
 - (void)didChangeIsDownloadingNotification:(BOOL)isDownloading
 {
-    _fileParameter.isDownloading = NO;
+    _fileParameter.isDownloading = isDownloading;
     
     NSMutableDictionary *userInfo = [NSMutableDictionary new];
     [userInfo setObject:_account forKey:@"account"];

--- a/NextcloudTalk/NCChatFileController.m
+++ b/NextcloudTalk/NCChatFileController.m
@@ -1,0 +1,203 @@
+/**
+ * @copyright Copyright (c) 2020 Marcel Müller <marcel-mueller@gmx.de>
+ *
+ * @author Marcel Müller <marcel-mueller@gmx.de>
+ *
+ * @license GNU GPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#import "NCChatFileController.h"
+#import "NCDatabaseManager.h"
+#import "NCSettingsController.h"
+#import "NCAPIController.h"
+
+NSString * const NCChatFileControllerDidChangeIsDownloadingNotification     = @"NCChatFileControllerDidChangeIsDownloadingNotification";
+NSString * const NCChatFileControllerDidChangeDownloadProgressNotification  = @"NCChatFileControllerDidChangeDownloadProgressNotification";
+
+int const kNCChatFileControllerDeleteFilesOlderThanDays = 7;
+
+@interface NCChatFileController ()
+
+@property (nonatomic, strong) TalkAccount *account;
+@property (nonatomic, strong) NCMessageFileParameter *fileParameter;
+@property (nonatomic, strong) NSString *tempDirectoryPath;
+@property (nonatomic, strong) NSString *fileLocalPath;
+
+@end
+
+
+@implementation NCChatFileController
+
+- (void)initDownloadDirectoryForAccount:(TalkAccount *)account
+{
+    _account = account;
+    
+    NSString *encodedAccountId = [account.accountId stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLHostAllowedCharacterSet];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    _tempDirectoryPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"/download/"];
+    _tempDirectoryPath = [_tempDirectoryPath stringByAppendingPathComponent:encodedAccountId];
+    
+    NSLog(@"Directory for downloads: %@", _tempDirectoryPath);
+    
+    if (![fileManager fileExistsAtPath:_tempDirectoryPath]) {
+        // Make sure our download directory exists
+        [fileManager createDirectoryAtPath:_tempDirectoryPath withIntermediateDirectories:YES attributes:nil error:nil];
+    }
+    
+    [self removeOldFilesFromCache:kNCChatFileControllerDeleteFilesOlderThanDays];
+}
+
+- (void)removeOldFilesFromCache:(int)thresholdDays
+{
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSDirectoryEnumerator *enumerator = [fileManager enumeratorAtPath:_tempDirectoryPath];
+    
+    NSDateComponents *dayComponent = [[NSDateComponents alloc] init];
+    dayComponent.day = -thresholdDays;
+
+    NSDate *thresholdDate = [[NSCalendar currentCalendar] dateByAddingComponents:dayComponent toDate:[NSDate date] options:0];
+    NSString *file;
+    
+    while (file = [enumerator nextObject])
+    {
+        NSString *filePath = [_tempDirectoryPath stringByAppendingPathComponent:file];
+        NSDate *creationDate = [[fileManager attributesOfItemAtPath:filePath error:nil] fileCreationDate];
+        
+        if ([creationDate compare:thresholdDate] == NSOrderedAscending) {
+            NSLog(@"Deleting file from cache: %@", filePath);
+        
+            [fileManager removeItemAtPath:filePath error:nil];
+        }
+    }
+}
+
+- (void)deleteDownloadDirectoryForAccount:(TalkAccount *)account
+{
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    
+    [self initDownloadDirectoryForAccount:account];
+    [fileManager removeItemAtPath:_tempDirectoryPath error:nil];
+    
+    NSLog(@"Deleted download directory: %@", _tempDirectoryPath);
+}
+
+- (BOOL)isFileInCache:(NSString *)filePath withModificationDate:(NSDate *)date withSize:(double)size
+{
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    
+    if (![fileManager fileExistsAtPath:filePath]) {
+        return NO;
+    }
+    
+    NSError *error = nil;
+    NSDictionary<NSFileAttributeKey, id> *fileAttributes = [fileManager attributesOfItemAtPath:filePath error:&error];
+    
+    NSDate *modificationDate = [fileAttributes fileModificationDate];
+    long long fileSize = [fileAttributes fileSize];
+    
+    if ([date compare:modificationDate] == NSOrderedSame && fileSize == (long long)size) {
+        return YES;
+    }
+    
+    // At this point there's a file in our cache but there's a newer one available
+    NSLog(@"Deleting file from cache: %@", filePath);
+    [fileManager removeItemAtPath:filePath error:nil];
+    
+    return NO;
+}
+
+- (void)setModificationDateOnFile:(NSString *)filePath withModificationDate:(NSDate *)date
+{
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    
+    NSDictionary *modificationDateAttr = [NSDictionary dictionaryWithObjectsAndKeys:date, NSFileModificationDate, nil];
+    [fileManager setAttributes:modificationDateAttr ofItemAtPath:filePath error:nil];
+}
+
+- (void)downloadFileFromMessage:(NCMessageFileParameter *)fileParameter
+{
+    TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+    ServerCapabilities *serverCapabilities = [[NCDatabaseManager sharedInstance] serverCapabilitiesForAccountId:activeAccount.accountId];
+    
+    [[NCAPIController sharedInstance] setupNCCommunicationForAccount:activeAccount];
+    [self initDownloadDirectoryForAccount:activeAccount];
+    
+    NSString *serverUrlFileName = [NSString stringWithFormat:@"%@/%@/%@", activeAccount.server, serverCapabilities.webDAVRoot, fileParameter.path];
+    _account = activeAccount;
+    _fileParameter = fileParameter;
+    _fileLocalPath = [_tempDirectoryPath stringByAppendingPathComponent:fileParameter.name];
+    
+    // Setting just isDownloading without a concrete progress will show an indeterminate activity indicator
+    [self didChangeIsDownloadingNotification:YES];
+    
+    // First read metadata from the file and check if we already downloaded it
+    [[NCCommunication shared] readFileOrFolderWithServerUrlFileName:serverUrlFileName depth:@"0" showHiddenFiles:NO requestBody:nil customUserAgent:nil addCustomHeaders:nil completionHandler:^(NSString *accounts, NSArray<NCCommunicationFile *> *files, NSData *responseData, NSInteger errorCode, NSString *errorDescription) {
+        if (errorCode == 0 && files.count == 1) {
+            // File exists on server -> check our cache
+            NCCommunicationFile *file = files.firstObject;
+            
+            if ([self isFileInCache:self->_fileLocalPath withModificationDate:file.date withSize:file.size]) {
+                NSLog(@"Found file in cache: %@", self->_fileLocalPath);
+                
+                [self didChangeIsDownloadingNotification:NO];
+                [self.delegate fileControllerDidLoadFile:self withFileParameter:self->_fileParameter withFilePath:self->_fileLocalPath];
+                
+                return;
+            }
+
+            [[NCCommunication shared] downloadWithServerUrlFileName:serverUrlFileName fileNameLocalPath:self->_fileLocalPath customUserAgent:nil addCustomHeaders:nil progressHandler:^(NSProgress *progress) {
+                [self didChangeDownloadProgressNotification:progress.fractionCompleted];
+            } completionHandler:^(NSString *account, NSString *etag, NSDate *date, double length, NSDictionary *allHeaderFields, NSInteger errorCode, NSString * errorDescription) {
+                [self setModificationDateOnFile:self->_fileLocalPath withModificationDate:file.date];
+                [self didChangeIsDownloadingNotification:NO];
+                [self.delegate fileControllerDidLoadFile:self withFileParameter:self->_fileParameter withFilePath:self->_fileLocalPath];
+            }];
+        } else {
+            [self didChangeIsDownloadingNotification:NO];
+            NSLog(@"Error reading file: %ld", errorCode);
+        }
+    }];
+}
+
+- (void)didChangeIsDownloadingNotification:(BOOL)isDownloading
+{
+    _fileParameter.isDownloading = NO;
+    
+    NSMutableDictionary *userInfo = [NSMutableDictionary new];
+    [userInfo setObject:_account forKey:@"account"];
+    [userInfo setObject:_fileParameter forKey:@"fileParameter"];
+    [userInfo setObject:@(isDownloading) forKey:@"isDownloading"];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:NCChatFileControllerDidChangeIsDownloadingNotification
+                                                        object:self
+                                                      userInfo:userInfo];
+}
+
+- (void)didChangeDownloadProgressNotification:(double)progress
+{
+    _fileParameter.downloadProgress = progress;
+    
+    NSMutableDictionary *userInfo = [NSMutableDictionary new];
+    [userInfo setObject:_account forKey:@"account"];
+    [userInfo setObject:_fileParameter forKey:@"fileParameter"];
+    [userInfo setObject:@(progress) forKey:@"progress"];
+    [[NSNotificationCenter defaultCenter] postNotificationName:NCChatFileControllerDidChangeDownloadProgressNotification
+                                                        object:self
+                                                      userInfo:userInfo];
+}
+
+@end

--- a/NextcloudTalk/NCChatMessage.h
+++ b/NextcloudTalk/NCChatMessage.h
@@ -24,6 +24,7 @@
 #import <UIKit/UIKit.h>
 #import <Realm/Realm.h>
 #import "NCMessageParameter.h"
+#import "NCMessageFileParameter.h"
 
 extern NSInteger const kChatMessageGroupTimeDifference;
 
@@ -53,7 +54,7 @@ extern NSInteger const kChatMessageGroupTimeDifference;
 
 - (BOOL)isSystemMessage;
 - (BOOL)isEmojiMessage;
-- (NCMessageParameter *)file;
+- (NCMessageFileParameter *)file;
 - (NSDictionary *)messageParameters;
 - (NSMutableAttributedString *)parsedMessage;
 - (NSMutableAttributedString *)systemMessageFormat;

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -28,6 +28,13 @@
 
 NSInteger const kChatMessageGroupTimeDifference = 30;
 
+@interface NCChatMessage ()
+{
+    NCMessageFileParameter *_fileParameter;
+}
+
+@end
+
 @implementation NCChatMessage
 
 + (instancetype)messageWithDictionary:(NSDictionary *)messageDict
@@ -124,20 +131,25 @@ NSInteger const kChatMessageGroupTimeDifference = 30;
 
 - (NCMessageParameter *)file;
 {
-    NCMessageParameter *fileParam = nil;
-    for (NSDictionary *parameterDict in [[self messageParameters] allValues]) {
-        NCMessageParameter *parameter = [NCMessageParameter parameterWithDictionary:parameterDict] ;
-        if ([parameter.type isEqualToString:@"file"]) {
-            if (!fileParam) {
-                fileParam = parameter;
+    if (!_fileParameter) {
+        for (NSDictionary *parameterDict in [[self messageParameters] allValues]) {
+            NCMessageFileParameter *parameter = [[NCMessageFileParameter alloc] initWithDictionary:parameterDict] ;
+            if (![parameter.type isEqualToString:@"file"]) {
+                continue;
+            }
+            
+            if (!_fileParameter) {
+                _fileParameter = parameter;
             } else {
                 // If there is more than one file in the message,
                 // we don't display any preview.
+                _fileParameter = nil;
                 return nil;
             }
         }
     }
-    return fileParam;
+
+    return _fileParameter;
 }
 
 - (NSDictionary *)messageParameters
@@ -181,7 +193,7 @@ NSInteger const kChatMessageGroupTimeDifference = 30;
                                  stringByReplacingOccurrencesOfString:@"}" withString:@""];
         NSDictionary *parameterDict = [[self messageParameters] objectForKey:parameterKey];
         if (parameterDict) {
-            NCMessageParameter *messageParameter = [NCMessageParameter parameterWithDictionary:parameterDict] ;
+            NCMessageParameter *messageParameter = [[NCMessageParameter alloc] initWithDictionary:parameterDict] ;
             // Default replacement string is the parameter name
             NSString *replaceString = messageParameter.name;
             // Format user and call mentions

--- a/NextcloudTalk/NCMessageFileParameter.h
+++ b/NextcloudTalk/NCMessageFileParameter.h
@@ -1,7 +1,7 @@
 /**
- * @copyright Copyright (c) 2020 Ivan Sein <ivan@nextcloud.com>
+ * @copyright Copyright (c) 2020 Marcel Müller <marcel-mueller@gmx.de>
  *
- * @author Ivan Sein <ivan@nextcloud.com>
+ * @author Marcel Müller <marcel-mueller@gmx.de>
  *
  * @license GNU GPL version 3 or any later version
  *
@@ -21,16 +21,20 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
-@interface NCMessageParameter : NSObject
+#import "NCMessageParameter.h"
 
-@property (nonatomic, strong) NSString *parameterId;
-@property (nonatomic, strong) NSString *name;
-@property (nonatomic, strong) NSString *link;
-@property (nonatomic, strong) NSString *type;
-@property (nonatomic, assign) NSRange range;
+NS_ASSUME_NONNULL_BEGIN
 
-- (instancetype)initWithDictionary:(NSDictionary *)parameterDict;
-- (BOOL)shouldBeHighlighted;
+@interface NCMessageFileParameter : NCMessageParameter
+
+@property (nonatomic, strong) NSString *path;
+@property (nonatomic, strong) NSString *mimetype;
+@property (nonatomic, assign) BOOL previewAvailable;
+@property (nonatomic, assign) BOOL isDownloading;
+@property (nonatomic, assign) CGFloat downloadProgress;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/NextcloudTalk/NCMessageFileParameter.m
+++ b/NextcloudTalk/NCMessageFileParameter.m
@@ -1,0 +1,24 @@
+//
+//  NCMessageFileParameter.m
+//  NextcloudTalk
+//
+//  Created by Marcel Müller on 05.12.20.
+//
+
+#import "NCMessageFileParameter.h"
+
+@implementation NCMessageFileParameter
+
+- (instancetype)initWithDictionary:(NSDictionary *)parameterDict
+{
+    self = [super initWithDictionary:parameterDict];
+    if (self) {      
+        self.path = [parameterDict objectForKey:@"path"];
+        self.mimetype = [parameterDict objectForKey:@"mimetype"];
+        self.previewAvailable = [[parameterDict objectForKey:@"preview-available"] boolValue];
+    }
+    
+    return self;
+}
+
+@end

--- a/NextcloudTalk/NCMessageParameter.m
+++ b/NextcloudTalk/NCMessageParameter.m
@@ -26,29 +26,28 @@
 
 @implementation NCMessageParameter
 
-+ (instancetype)parameterWithDictionary:(NSDictionary *)parameterDict
+- (instancetype)initWithDictionary:(NSDictionary *)parameterDict
 {
-    if (!parameterDict || ![parameterDict isKindOfClass:[NSDictionary class]]) {
-        return nil;
+    self = [super init];
+    if (self) {
+        if (!parameterDict || ![parameterDict isKindOfClass:[NSDictionary class]]) {
+            return nil;
+        }
+        
+        self.parameterId = [parameterDict objectForKey:@"id"];
+        self.name = [parameterDict objectForKey:@"name"];
+        self.link = [parameterDict objectForKey:@"link"];
+        self.type = [parameterDict objectForKey:@"type"];
+        
+        id parameterId = [parameterDict objectForKey:@"id"];
+        if ([parameterId isKindOfClass:[NSString class]]) {
+            self.parameterId = parameterId;
+        } else {
+            self.parameterId = [parameterId stringValue];
+        }
     }
     
-    NCMessageParameter *messageParameter = [[NCMessageParameter alloc] init];
-    messageParameter.parameterId = [parameterDict objectForKey:@"id"];
-    messageParameter.name = [parameterDict objectForKey:@"name"];
-    messageParameter.type = [parameterDict objectForKey:@"type"];
-    messageParameter.path = [parameterDict objectForKey:@"path"];
-    messageParameter.link = [parameterDict objectForKey:@"link"];
-    messageParameter.mimetype = [parameterDict objectForKey:@"mimetype"];
-    messageParameter.previewAvailable = [[parameterDict objectForKey:@"preview-available"] boolValue];
-    
-    id parameterId = [parameterDict objectForKey:@"id"];
-    if ([parameterId isKindOfClass:[NSString class]]) {
-        messageParameter.parameterId = parameterId;
-    } else {
-        messageParameter.parameterId = [parameterId stringValue];
-    }
-    
-    return messageParameter;
+    return self;
 }
 
 - (BOOL)shouldBeHighlighted

--- a/NextcloudTalk/NCSettingsController.m
+++ b/NextcloudTalk/NCSettingsController.m
@@ -37,6 +37,7 @@
 #import "NCExternalSignalingController.h"
 #import "NCUserInterfaceController.h"
 #import "JDStatusBarNotification.h"
+#import "NCChatFileController.h"
 
 @interface NCSettingsController ()
 {
@@ -320,6 +321,7 @@ NSString * const NCUserProfileImageUpdatedNotification = @"NCUserProfileImageUpd
     [[NCSettingsController sharedInstance] cleanUserAndServerStoredValues];
     [[NCAPIController sharedInstance] removeProfileImageForAccount:removingAccount];
     [[NCDatabaseManager sharedInstance] removeAccountWithAccountId:removingAccount.accountId];
+    [[[NCChatFileController alloc] init] deleteDownloadDirectoryForAccount:removingAccount];
     
     // Activate any of the inactive accounts
     NSArray *inactiveAccounts = [[NCDatabaseManager sharedInstance] inactiveAccounts];

--- a/NextcloudTalk/NCUtils.h
+++ b/NextcloudTalk/NCUtils.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSDate *)dateFromDateAtomFormat:(NSString *)dateAtomFormatString;
 + (NSString *)dateAtomFormatFromDate:(NSDate *)date;
 + (NSString *)readableDateFromDate:(NSDate *)date;
++ (NSString *)getTimeFromDate:(NSDate *)date;
 
 + (NSString *)sha1FromString:(NSString *)string;
 

--- a/NextcloudTalk/NCUtils.m
+++ b/NextcloudTalk/NCUtils.m
@@ -131,6 +131,13 @@ static NSString *const nextcloudScheme = @"nextcloud:";
     return [dateFormatter stringFromDate:date];
 }
 
++ (NSString *)getTimeFromDate:(NSDate *)date
+{
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    [formatter setDateFormat:@"HH:mm"];
+    return [formatter stringFromDate:date];
+}
+
 + (NSString *)sha1FromString:(NSString *)string
 {
     NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];


### PR DESCRIPTION
This PR implements directly downloading and viewing files in talk-ios.

**Caching**
* A cache directory is created per account
* Files older than 7 days are automatically deleted
* Server is checked for newer versions of a file prior to using the cache
* Cache directory is removed upon account removal

**General**
* ActivityIndicator shows download progress
* File will be opened after download if 
  * The room wasn't left in between download start and finish
  * The corresponding cell which the file belongs to is still visible (not scrolled away)
* Not implemented for room-files currently, should be done in a follow-up
* Added "Open in Nextcloud" to context-menu