### PR TITLE
Explicitly disable left-/rightButton when room is not joined

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -460,6 +460,8 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
     [_videoCallButton setEnabled:NO];
     [_voiceCallButton setEnabled:NO];
     
+    [self.leftButton setEnabled:NO];
+    [self.rightButton setEnabled:NO];
     self.textInputbar.userInteractionEnabled = NO;
 }
 
@@ -470,6 +472,9 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
         _titleView.userInteractionEnabled = YES;
         [_videoCallButton setEnabled:YES];
         [_voiceCallButton setEnabled:YES];
+        
+        [self.leftButton setEnabled:YES];
+        [self.rightButton setEnabled:YES];
         self.textInputbar.userInteractionEnabled = YES;
     }
     


### PR DESCRIPTION
When a room is not joined (or we're in offline mode) the share/send button is still active, although touch interaction is disabled:
![image](https://user-images.githubusercontent.com/1580193/101292723-988e6380-3811-11eb-9aea-7f0f2bbf754b.png)

This PR disables both buttons in connection with touch interaction. 
(The send button could be shown as "active" if there's an unsend message in the textview)