### PR TITLE
CancelImageDownloadTask for previewImageView on cell reuse

### DIFF
--- a/NextcloudTalk/FileMessageTableViewCell.m
+++ b/NextcloudTalk/FileMessageTableViewCell.m
@@ -142,6 +142,7 @@
     [self.avatarView cancelImageDownloadTask];
     self.avatarView.image = nil;
     
+    [self.previewImageView cancelImageDownloadTask];
     self.previewImageView.layer.borderWidth = 0.0f;
     self.previewImageView.image = nil;
     


### PR DESCRIPTION
Otherwise the placeholde image might get overriden when initally entering a room.

![image](https://user-images.githubusercontent.com/1580193/102728155-66f5bc00-432a-11eb-8d8d-39001c40143c.png)
![image](https://user-images.githubusercontent.com/1580193/102728160-707f2400-432a-11eb-8cf0-fd50f1875f71.png)
