### PR TITLE
Fix scrolling on new messages when receiving long messages

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1329,6 +1329,10 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
         
         NSMutableArray *messages = [notification.userInfo objectForKey:@"messages"];
         if (messages.count > 0) {
+            // Detect if we should scroll to new messages before we issue a reloadData
+            // Otherwise longer messages will prevent scrolling
+            BOOL shouldScrollOnNewMessages = [self shouldScrollOnNewMessages] ;
+            
             NSInteger lastSectionBeforeUpdate = self->_dateSections.count - 1;
             BOOL unreadMessagesReceived = NO;
             // Check if unread messages separator should be added
@@ -1382,7 +1386,7 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [self.tableView scrollToRowAtIndexPath:firstMessageIndexPath atScrollPosition:UITableViewScrollPositionMiddle animated:NO];
                 });
-            } else if ([self shouldScrollOnNewMessages] || newMessagesContainUserMessage) {
+            } else if (shouldScrollOnNewMessages || newMessagesContainUserMessage) {
                 [self.tableView scrollToRowAtIndexPath:lastMessageIndexPath atScrollPosition:UITableViewScrollPositionNone animated:YES];
             } else if (!self->_firstUnreadMessageIP && areReallyNewMessages) {
                 [self showNewMessagesViewUntilIndexPath:firstMessageIndexPath];


### PR DESCRIPTION
**How to reproduce** 

* Device1: Join room, make sure you're at the bottom of the tableView
* Device2: Send a message with `Test` -> tableView on Device1 is correctly scrolled to the bottom
* Device2: Send a long message (atleast 4 paragraphs, or just send a picture) -> tableView on Device1 is _not_ scrolled but instead `New Message`-Indicator is displayed
