### PR TITLE
Fix temporary message history crash

### DIFF
--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -124,7 +124,7 @@ NSString * const NCChatControllerDidRemoveTemporaryMessagesNotification         
             message.parentId = parent.internalId;
             
             if (message.referenceId && ![message.referenceId isEqualToString:@""]) {
-                NCChatMessage *managedTemporaryMessage = [NCChatMessage objectsWhere:@"referenceId = %@", message.referenceId].firstObject;
+                NCChatMessage *managedTemporaryMessage = [NCChatMessage objectsWhere:@"referenceId = %@ AND isTemporary = true", message.referenceId].firstObject;
                 if (managedTemporaryMessage) {
                     [realm deleteObject:managedTemporaryMessage];
                     // Create a unmanaged copy of message, since 'message' will point to a managed object when added to the DB.
@@ -271,7 +271,7 @@ NSString * const NCChatControllerDidRemoveTemporaryMessagesNotification         
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm transactionWithBlock:^{
-        NCChatMessage *managedChatMessage = [NCChatMessage objectsWhere:@"referenceId = %@", referenceId].firstObject;
+        NCChatMessage *managedChatMessage = [NCChatMessage objectsWhere:@"referenceId = %@ AND isTemporary = true", referenceId].firstObject;
         managedChatMessage.sendingFailed = YES;
     }];
 }

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1299,7 +1299,10 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
         if (messages.count > 0) {
             NSIndexPath *lastHistoryMessageIP = [self prependMessages:messages addingBlockSeparator:shouldAddBlockSeparator];
             [self.tableView reloadData];
-            [self.tableView scrollToRowAtIndexPath:lastHistoryMessageIP atScrollPosition:UITableViewScrollPositionTop animated:NO];
+            
+            if ([NCUtils isValidIndexPath:lastHistoryMessageIP forTableView:self.tableView]) {
+                [self.tableView scrollToRowAtIndexPath:lastHistoryMessageIP atScrollPosition:UITableViewScrollPositionTop animated:NO];
+            }
         }
         
         BOOL noMoreStoredHistory = [[notification.userInfo objectForKey:@"noMoreStoredHistory"] boolValue];

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -563,6 +563,25 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
     return 0;
 }
 
+- (NCChatMessage *)getFirstRealMessage
+{
+    for (int section = 0; section < [_dateSections count]; section++) {
+        NSDate *dateSection = [_dateSections objectAtIndex:section];
+        NSMutableArray *messagesInSection = [_messages objectForKey:dateSection];
+        
+        for (int message = 0; message < [messagesInSection count]; message++) {
+            NCChatMessage *chatMessage = [messagesInSection objectAtIndex:message];
+            
+            // Ignore temporary messages
+            if (chatMessage && chatMessage.messageId > 0) {
+                return chatMessage;
+            }
+        }
+    }
+    
+    return nil;
+}
+
 - (NSString *)getHeaderStringFromDate:(NSDate *)date
 {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
@@ -1127,9 +1146,8 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
     
     if ([scrollView isEqual:self.tableView] && scrollView.contentOffset.y < 0) {
         if ([self couldRetireveHistory]) {
-            NSDate *dateSection = [_dateSections objectAtIndex:0];
-            NCChatMessage *firstMessage = [[_messages objectForKey:dateSection] objectAtIndex:0];
-            if ([_chatController hasHistoryFromMessageId:firstMessage.messageId]) {
+            NCChatMessage *firstMessage = [self getFirstRealMessage];
+            if (firstMessage && [_chatController hasHistoryFromMessageId:firstMessage.messageId]) {
                 _retrievingHistory = YES;
                 [self showLoadingHistoryView];
                 if (_offlineMode) {

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -654,7 +654,7 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm transactionWithBlock:^{
-        NCChatMessage *managedTemporaryMessage = [NCChatMessage objectsWhere:@"referenceId = %@", temporaryMessage.referenceId].firstObject;
+        NCChatMessage *managedTemporaryMessage = [NCChatMessage objectsWhere:@"referenceId = %@ AND isTemporary = true", temporaryMessage.referenceId].firstObject;
         if (managedTemporaryMessage) {
             [realm deleteObject:managedTemporaryMessage];
         }

--- a/NextcloudTalk/NCUtils.h
+++ b/NextcloudTalk/NCUtils.h
@@ -49,6 +49,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (CGFloat)calculateLumaFromColor:(UIColor *)color;
 + (UIColor *)colorFromHexString:(NSString *)hexString;
 
++ (BOOL)isValidIndexPath:(NSIndexPath *)indexPath forTableView:(UITableView *)tableView;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/NextcloudTalk/NCUtils.m
+++ b/NextcloudTalk/NCUtils.m
@@ -199,4 +199,9 @@ static NSString *const nextcloudScheme = @"nextcloud:";
     return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
 }
 
++ (BOOL)isValidIndexPath:(NSIndexPath *)indexPath forTableView:(UITableView *)tableView
+{
+    return indexPath.section < tableView.numberOfSections && indexPath.row < [tableView numberOfRowsInSection:indexPath.section];
+}
+
 @end


### PR DESCRIPTION
Messages received from the server are checked locally to remove their temporary counterpart, if present. Currently those messages are queried only using the `referenceId` which might be ambiguous when the real message was already stored. The first part of this PR makes sure we explicitly query for temporary messages.

The second part makes sure that when the user wants to load the history of a chat (by scrolling to the top of the tableview) that temporary messages are ignored. This could happen, because temporary messages were not deleted correctly (see above) which results in an api call to the server with messageId 0. The server will return 304, as there are no older messages available.
Also we make sure to not scroll to an invalid indexpath.

One issue remains: When the above happend to a chat, we update the corresponding NCChatBlock to `hasHistory = NO`. This means older history can't be retrieved for this chat. I don't think this is much of a problem at the moment, but we could add a migration step for realm to set `hasHistory = YES` on all NCChatBlocks.