### PR TITLE
Improve handling of received messages while in a room

### DIFF
--- a/NextcloudTalk/NCChatController.h
+++ b/NextcloudTalk/NCChatController.h
@@ -31,7 +31,6 @@ extern NSString * const NCChatControllerDidReceiveChatHistoryNotification;
 extern NSString * const NCChatControllerDidReceiveChatMessagesNotification;
 extern NSString * const NCChatControllerDidSendChatMessageNotification;
 extern NSString * const NCChatControllerDidReceiveChatBlockedNotification;
-extern NSString * const NCChatControllerDidRemoveTemporaryMessagesNotification;
 extern NSString * const NCChatControllerDidReceiveNewerCommonReadMessageNotification;
 
 @interface NCChatBlock : RLMObject
@@ -61,5 +60,6 @@ extern NSString * const NCChatControllerDidReceiveNewerCommonReadMessageNotifica
 - (void)stopReceivingNewChatMessages;
 - (void)stopChatController;
 - (BOOL)hasHistoryFromMessageId:(NSInteger)messageId;
+- (void)storeMessages:(NSArray *)messages withRealm:(RLMRealm *)realm;
 
 @end

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -500,8 +500,8 @@ NSString * const NCChatControllerDidReceiveNewerCommonReadMessageNotification   
                 [userInfo setObject:storedMessages forKey:@"messages"];
                 
                 // Update the current room with the new message
-                // The stored information about this room will be updates when leaving when saving
-                // pending messages -> a transaction wouldn't make sense here, as it would be overriden again
+                // The stored information about this room will be updated by calling savePendingMessage
+                // in NCChatViewController -> a transaction wouldn't make sense here, as it would be overriden again
                 for (NCChatMessage *message in storedMessages) {
                     if (message.messageId == lastKnownMessage && message.timestamp > self->_room.lastActivity) {
                         self->_room.lastMessageId = message.internalId;

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -33,7 +33,6 @@ NSString * const NCChatControllerDidReceiveChatHistoryNotification              
 NSString * const NCChatControllerDidReceiveChatMessagesNotification                 = @"NCChatControllerDidReceiveChatMessagesNotification";
 NSString * const NCChatControllerDidSendChatMessageNotification                     = @"NCChatControllerDidSendChatMessageNotification";
 NSString * const NCChatControllerDidReceiveChatBlockedNotification                  = @"NCChatControllerDidReceiveChatBlockedNotification";
-NSString * const NCChatControllerDidRemoveTemporaryMessagesNotification             = @"NCChatControllerDidRemoveTemporaryMessagesNotification";
 NSString * const NCChatControllerDidReceiveNewerCommonReadMessageNotification       = @"NCChatControllerDidReceiveNewerCommonReadMessageNotification";
 
 @interface NCChatController ()
@@ -114,50 +113,41 @@ NSString * const NCChatControllerDidReceiveNewerCommonReadMessageNotification   
     return sortedMessages;
 }
 
+- (void)storeMessages:(NSArray *)messages withRealm:(RLMRealm *)realm {
+    // Add or update messages
+    for (NSDictionary *messageDict in messages) {
+        NCChatMessage *message = [NCChatMessage messageWithDictionary:messageDict andAccountId:_account.accountId];
+        NCChatMessage *parent = [NCChatMessage messageWithDictionary:[messageDict objectForKey:@"parent"] andAccountId:_account.accountId];
+        message.parentId = parent.internalId;
+        
+        if (message.referenceId && ![message.referenceId isEqualToString:@""]) {
+            NCChatMessage *managedTemporaryMessage = [NCChatMessage objectsWhere:@"referenceId = %@ AND isTemporary = true", message.referenceId].firstObject;
+            if (managedTemporaryMessage) {
+                [realm deleteObject:managedTemporaryMessage];
+            }
+        }
+        
+        NCChatMessage *managedMessage = [NCChatMessage objectsWhere:@"internalId = %@", message.internalId].firstObject;
+        if (managedMessage) {
+            [NCChatMessage updateChatMessage:managedMessage withChatMessage:message];
+        } else if (message) {
+            [realm addObject:message];
+        }
+        
+        NCChatMessage *managedParentMessage = [NCChatMessage objectsWhere:@"internalId = %@", parent.internalId].firstObject;
+        if (managedParentMessage) {
+            [NCChatMessage updateChatMessage:managedParentMessage withChatMessage:parent];
+        } else if (parent) {
+            [realm addObject:parent];
+        }
+    }
+}
+
 - (void)storeMessages:(NSArray *)messages
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm transactionWithBlock:^{
-        NSMutableArray *removedTemporaryMessages = [NSMutableArray new];
-        // Add or update messages
-        for (NSDictionary *messageDict in messages) {
-            NCChatMessage *message = [NCChatMessage messageWithDictionary:messageDict andAccountId:_account.accountId];
-            NCChatMessage *parent = [NCChatMessage messageWithDictionary:[messageDict objectForKey:@"parent"] andAccountId:_account.accountId];
-            message.parentId = parent.internalId;
-            
-            if (message.referenceId && ![message.referenceId isEqualToString:@""]) {
-                NCChatMessage *managedTemporaryMessage = [NCChatMessage objectsWhere:@"referenceId = %@ AND isTemporary = true", message.referenceId].firstObject;
-                if (managedTemporaryMessage) {
-                    [realm deleteObject:managedTemporaryMessage];
-                    // Create a unmanaged copy of message, since 'message' will point to a managed object when added to the DB.
-                    NCChatMessage *unmanagedMessage = [[NCChatMessage alloc] initWithValue:message];
-                    [removedTemporaryMessages addObject:unmanagedMessage];
-                }
-            }
-            
-            NCChatMessage *managedMessage = [NCChatMessage objectsWhere:@"internalId = %@", message.internalId].firstObject;
-            if (managedMessage) {
-                [NCChatMessage updateChatMessage:managedMessage withChatMessage:message];
-            } else if (message) {
-                [realm addObject:message];
-            }
-            
-            NCChatMessage *managedParentMessage = [NCChatMessage objectsWhere:@"internalId = %@", parent.internalId].firstObject;
-            if (managedParentMessage) {
-                [NCChatMessage updateChatMessage:managedParentMessage withChatMessage:parent];
-            } else if (parent) {
-                [realm addObject:parent];
-            }
-        }
-        // Send notification with removed temprary messages
-        if (removedTemporaryMessages.count > 0) {
-            NSMutableDictionary *userInfo = [NSMutableDictionary new];
-            [userInfo setObject:_room.token forKey:@"room"];
-            [userInfo setObject:removedTemporaryMessages forKey:@"messages"];
-            [[NSNotificationCenter defaultCenter] postNotificationName:NCChatControllerDidRemoveTemporaryMessagesNotification
-                                                                object:self
-                                                              userInfo:userInfo];
-        }
+        [self storeMessages:messages withRealm:realm];
     }];
 }
 
@@ -501,12 +491,26 @@ NSString * const NCChatControllerDidReceiveNewerCommonReadMessageNotification   
         } else {
             // Update last chat block
             [self updateLastChatBlockWithNewestKnown:lastKnownMessage];
+            
             // Store new messages
             if (messages.count > 0) {
                 [self storeMessages:messages];
                 NCChatBlock *lastChatBlock = [self chatBlocksForRoom].lastObject;
                 NSArray *storedMessages = [self getNewStoredMessagesInBlock:lastChatBlock sinceMessageId:messageId];
                 [userInfo setObject:storedMessages forKey:@"messages"];
+                
+                // Update the current room with the new message
+                // The stored information about this room will be updates when leaving when saving
+                // pending messages -> a transaction wouldn't make sense here, as it would be overriden again
+                for (NCChatMessage *message in storedMessages) {
+                    if (message.messageId == lastKnownMessage && message.timestamp > self->_room.lastActivity) {
+                        self->_room.lastMessageId = message.internalId;
+                        self->_room.lastActivity = message.timestamp;
+                        self->_room.unreadMention = NO;
+                        self->_room.unreadMessages = 0;
+                        break;
+                    }
+                }
             }
         }
         [userInfo setObject:self->_room.token forKey:@"room"];

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -138,7 +138,6 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveChatMessages:) name:NCChatControllerDidReceiveChatMessagesNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didSendChatMessage:) name:NCChatControllerDidSendChatMessageNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveChatBlocked:) name:NCChatControllerDidReceiveChatBlockedNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didRemoveTemporaryMessages:) name:NCChatControllerDidRemoveTemporaryMessagesNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveNewerCommonReadMessage:) name:NCChatControllerDidReceiveNewerCommonReadMessageNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
@@ -1352,9 +1351,8 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
             // Otherwise longer messages will prevent scrolling
             BOOL shouldScrollOnNewMessages = [self shouldScrollOnNewMessages] ;
             
-            NSInteger lastSectionBeforeUpdate = self->_dateSections.count - 1;
-            BOOL unreadMessagesReceived = NO;
             // Check if unread messages separator should be added
+            BOOL unreadMessagesReceived = NO;
             if (firstNewMessagesAfterHistory && [self getLastReadMessage] > 0) {
                 unreadMessagesReceived = YES;
                 NSMutableArray *messagesForLastDateBeforeUpdate = [self->_messages objectForKey:[self->_dateSections lastObject]];
@@ -1370,19 +1368,7 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
             NSIndexPath *lastMessageIndexPath = [NSIndexPath indexPathForRow:messagesForLastDate.count - 1 inSection:self->_dateSections.count - 1];
             
             // Load messages in chat view
-            if (messages.count > 1 || unreadMessagesReceived) {
-                [self.tableView reloadData];
-            } else if (messages.count == 1) {
-                [self.tableView beginUpdates];
-                NSInteger newLastSection = self->_dateSections.count - 1;
-                BOOL newSection = lastSectionBeforeUpdate != newLastSection;
-                if (newSection) {
-                    [self.tableView insertSections:[NSIndexSet indexSetWithIndex:newLastSection] withRowAnimation:UITableViewRowAnimationNone];
-                } else {
-                    [self.tableView insertRowsAtIndexPaths:@[lastMessageIndexPath] withRowAnimation:UITableViewRowAnimationNone];
-                }
-                [self.tableView endUpdates];
-            }
+            [self.tableView reloadData];
             
             BOOL newMessagesContainUserMessage = [self newMessagesContainUserMessage:messages];
             // Remove unread messages separator when user writes a message
@@ -1472,16 +1458,6 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
     }
     
     [self startObservingRoomLobbyFlag];
-}
-
-- (void)didRemoveTemporaryMessages:(NSNotification *)notification
-{
-    if (notification.object != _chatController) {
-        return;
-    }
-    
-    NSArray *removedTemporaryMessages = [notification.userInfo objectForKey:@"messages"];
-    [self removeTemporaryMessages:removedTemporaryMessages];
 }
 
 - (void)didReceiveNewerCommonReadMessage:(NSNotification *)notification
@@ -1590,10 +1566,28 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
         NSDate *newMessageDate = [NSDate dateWithTimeIntervalSince1970: newMessage.timestamp];
         NSDate *keyDate = [self getKeyForDate:newMessageDate inDictionary:dictionary];
         NSMutableArray *messagesForDate = [dictionary objectForKey:keyDate];
+
         if (messagesForDate) {
-            NCChatMessage *lastMessage = [messagesForDate lastObject];
-            newMessage.isGroupMessage = [self shouldGroupMessage:newMessage withMessage:lastMessage];
-            [messagesForDate addObject:newMessage];
+            BOOL messageUpdated = NO;
+            
+            // Check if we can update the message instead of adding a new one
+            for (int i = 0; i < messagesForDate.count; i++) {
+                NCChatMessage *currentMessage = messagesForDate[i];
+                if ((!currentMessage.isTemporary && currentMessage.messageId == newMessage.messageId) ||
+                    (currentMessage.isTemporary && [currentMessage.referenceId isEqualToString:newMessage.referenceId])) {
+                    // The newly received message either already exists or its temporary counterpart exists -> update
+                    newMessage.isGroupMessage = currentMessage.isGroupMessage;
+                    messagesForDate[i] = newMessage;
+                    messageUpdated = YES;
+                    break;
+                }
+            }
+            
+            if (!messageUpdated) {
+                NCChatMessage *lastMessage = [messagesForDate lastObject];
+                newMessage.isGroupMessage = [self shouldGroupMessage:newMessage withMessage:lastMessage];
+                [messagesForDate addObject:newMessage];
+            }
         } else {
             NSMutableArray *newMessagesInDate = [NSMutableArray new];
             [dictionary setObject:newMessagesInDate forKey:newMessageDate];


### PR DESCRIPTION
* Currently when replying to a message, the temporary message is created without a reference to the quoted message. This is now added, resulting in temporary messages correctly showing a quoted view.
* When you receive new messages while in a room the room object now gets updated. When switching back to conversation list, the room is is already up-to-date with the last received message.
* When receiving an update while in conversationlist the current behaviour was to add a message directly to the db. Now we go through NCChatController and correctly process those messages (eg. removing temporary messages from the db)
* When receiving messages in NCChatViewController we check if the message (or the temporary counterpart) is already in the tableview and reference the new message directly. Therefore we can now remove the NCChatControllerDidRemoveTemporaryMessagesNotification (it's all done when receiving NCChatControllerDidReceiveChatMessagesNotification, which will be sent directly after the previous event). This prevents bouncing in the tableview when replacing the temporary message with a real message.
