### PR TITLE
Actively dismiss the keyboard before showing the preview controller

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -2236,6 +2236,9 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
     dispatch_async(dispatch_get_main_queue(), ^{
         self->_isPreviewControllerShown = YES;
         self->_previewControllerFilePath = fileStatus.fileLocalPath;
+        
+        // When the keyboard is not dismissed, dismissing the previewController might result in a corrupted keyboardView
+        [self dismissKeyboard:NO];
 
         QLPreviewController * preview = [[QLPreviewController alloc] init];
         UIColor *themeColor = [NCAppBranding themeColor];


### PR DESCRIPTION
* Show the keyboard
* Tap on an image
* Close image with swipe-down gesture
* Keyboard is not visible, but you're still able to tap on the keys