### PR TITLE
Add missing localization in RoomNameTableViewCell

### DIFF
--- a/NextcloudTalk/RoomNameTableViewCell.m
+++ b/NextcloudTalk/RoomNameTableViewCell.m
@@ -32,6 +32,7 @@ NSString *const kRoomNameTableCellNibName   = @"RoomNameTableViewCell";
     self.roomImage.layer.cornerRadius = 24.0;
     self.roomImage.layer.masksToBounds = YES;
     self.favoriteImage.contentMode = UIViewContentModeCenter;
+    self.roomNameTextField.placeholder = NSLocalizedString(@"Conversation name", nil);
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {


### PR DESCRIPTION
Placeholder is not localized when creating a new group/public conversation