### PR TITLE
Show errors when uploading failed

### DIFF
--- a/ShareExtension/ShareConfirmationViewController.m
+++ b/ShareExtension/ShareConfirmationViewController.m
@@ -46,6 +46,7 @@
     MBProgressHUD *_hud;
     dispatch_group_t _uploadGroup;
     BOOL _uploadFailed;
+    NSMutableArray *_uploadErrors;
 }
 
 @property (nonatomic, strong) UIImagePickerController *imagePicker;
@@ -374,6 +375,7 @@
     
     _uploadGroup = dispatch_group_create();
     _uploadFailed = NO;
+    _uploadErrors = [[NSMutableArray alloc] init];
     
     for (ShareItem *item in self.shareItemController.shareItems) {
         NSLog(@"Uploading %@", item.fileURL);
@@ -390,7 +392,20 @@
         
         // TODO: Do error reporting per item
         if (self->_uploadFailed) {
-            [self.delegate shareConfirmationViewControllerDidFailed:self];
+            UIAlertController * alert = [UIAlertController
+                                         alertControllerWithTitle:NSLocalizedString(@"Error uploading elements", nil)
+                                         message:[self->_uploadErrors componentsJoinedByString:@"\n"]
+                                         preferredStyle:UIAlertControllerStyleAlert];
+            
+            UIAlertAction* okButton = [UIAlertAction
+                                       actionWithTitle:NSLocalizedString(@"OK", nil)
+                                       style:UIAlertActionStyleDefault
+                                       handler:^(UIAlertAction * _Nonnull action) {
+                                            [self.delegate shareConfirmationViewControllerDidFailed:self];
+                                        }];
+            
+            [alert addAction:okButton];
+            [self presentViewController:alert animated:YES completion:nil];
         } else {
             [self.delegate shareConfirmationViewControllerDidFinish:self];
         }
@@ -411,9 +426,10 @@
         } else if (errorCode == 404) {
             [self uploadFileToServerURL:fileServerURL withFilePath:fileServerPath withItem:item];
         } else {
-            NSLog(@"Error checking file name");
+            NSLog(@"Error checking file name: %@", errorDescription);
             
             self->_uploadFailed = YES;
+            [self->_uploadErrors addObject:errorDescription];
             dispatch_group_leave(self->_uploadGroup);
         }
     }];
@@ -431,9 +447,10 @@
                 }
             }];
         } else {
-            NSLog(@"Error checking attachment folder");
+            NSLog(@"Error checking attachment folder: %@", errorDescription);
             
             self->_uploadFailed = YES;
+            [self->_uploadErrors addObject:errorDescription];
             dispatch_group_leave(self->_uploadGroup);
         }
     }];
@@ -453,15 +470,16 @@
                     NSLog(@"Failed to send shared file");
                     
                     self->_uploadFailed = YES;
-                    dispatch_group_leave(self->_uploadGroup);
-                } else {
-                    dispatch_group_leave(self->_uploadGroup);
+                    [self->_uploadErrors addObject:error.description];
                 }
+                
+                dispatch_group_leave(self->_uploadGroup);
             }];
         } else if (errorCode == 404) {
             [self checkAttachmentFolderAndUploadFileToServerURL:fileServerURL withFilePath:filePath withItem:item];
         } else {
             self->_uploadFailed = YES;
+            [self->_uploadErrors addObject:errorDescription];
             dispatch_group_leave(self->_uploadGroup);
         }
     }];

--- a/ShareExtension/ShareConfirmationViewController.m
+++ b/ShareExtension/ShareConfirmationViewController.m
@@ -393,7 +393,7 @@
         // TODO: Do error reporting per item
         if (self->_uploadFailed) {
             UIAlertController * alert = [UIAlertController
-                                         alertControllerWithTitle:NSLocalizedString(@"Error uploading elements", nil)
+                                         alertControllerWithTitle:NSLocalizedString(@"Upload failed", nil)
                                          message:[self->_uploadErrors componentsJoinedByString:@"\n"]
                                          preferredStyle:UIAlertControllerStyleAlert];
             


### PR DESCRIPTION
When uploading fails the viewcontroller currently only disappears, leaving the impression, that uploading was successful. Now the corresponding error messages are show.

This is by far not a perfect solution, because it's not clear which element exactly failed, in case there were multiple to be uploaded. But I think it's better than having no feedback at all.