### PR TITLE
Remove unread messages separator before resending a failed message

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -942,6 +942,9 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
 }
 
 - (void)didPressResend:(NCChatMessage *)message {
+    // Make sure there's no unread message separator, as the indexpath could be invalid after removing a message
+    [self removeUnreadMessagesSeparator];
+    
     [self removePermanentlyTemporaryMessage:message];
     [self sendChatMessage:message.message fromInputField:NO];
 }


### PR DESCRIPTION
Fixes #474 