### PR TITLE
Allow notifications to be dismissed

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -188,7 +188,7 @@
     UNNotificationCategory *chatCategory = [UNNotificationCategory categoryWithIdentifier:@"CATEGORY_CHAT"
                                                                               actions:@[replyAction]
                                                                     intentIdentifiers:@[]
-                                                                              options:UNNotificationCategoryOptionNone];
+                                                                              options:UNNotificationCategoryOptionCustomDismissAction];
     
     NSSet *categories = [NSSet setWithObject:chatCategory];
     [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:categories];

--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -270,6 +270,8 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
             pushNotification.responseUserText = textInputResponse.userText;
             
             [self handlePushNotificationResponseWithUserText:pushNotification withCompletionHandler:completionHandler];
+        } else if ([response.actionIdentifier isEqualToString:UNNotificationDismissActionIdentifier]) {
+            [self handlePushNotificationDismissResponse:pushNotification withCompletionHandler:completionHandler];
         } else {
             [self handlePushNotificationResponse:pushNotification withCompletionHandler:completionHandler];
         }
@@ -315,6 +317,17 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
 
 
     });
+    
+    completionHandler();
+}
+
+- (void)handlePushNotificationDismissResponse:(NCPushNotification *)pushNotification withCompletionHandler:(void (^)(void))completionHandler
+{
+    NSLog(@"Recevied push-notification with dismiss action");
+    
+    // The user actively dismissed the notification -> update the bade accordingly
+    [[NCDatabaseManager sharedInstance] decreaseUnreadBadgeNumberForAccountId:pushNotification.accountId];
+    [self updateAppIconBadgeNumber];
     
     completionHandler();
 }


### PR DESCRIPTION
When a notification is displayed to the user, he can dismiss it either by opening the notification and tapping the "X"-button or by swipping left and selecting "Clear". Until now this removes the notification from notification center, but doesn't change the bade on talk-ios. Now the badge is decreased when actively dismissing a notification.