### PR TITLE
Periodically check if we accepted the call on another device

### DIFF
--- a/NextcloudTalk/CallKitManager.h
+++ b/NextcloudTalk/CallKitManager.h
@@ -37,6 +37,7 @@ extern NSString * const CallKitManagerWantsToUpgradeToVideoCall;
 @property (nonatomic, strong) NSString *accountId;
 @property (nonatomic, strong) CXCallUpdate *update;
 @property (nonatomic, assign) BOOL reportedWhileInCall;
+@property (nonatomic, assign) BOOL isRinging;
 
 @end
 


### PR DESCRIPTION
Fixes #433 

When receiving an incoming call we periodically check if we're already in that call (eg. when we answered the call on a second device).

Two things I'm wondering:

https://github.com/nextcloud/talk-ios/blob/ef1515fd465a2523581ed222d9ec82cc8de2a279/NextcloudTalk/CallKitManager.m#L316-L322

1. Could we check here if **any** participant has the `inCall` flag set and assume if **none** has the `inCall` flag, the call ended before we accepted it?

https://github.com/nextcloud/talk-ios/blob/ef1515fd465a2523581ed222d9ec82cc8de2a279/NextcloudTalk/CallKitManager.m#L325-L326

2. Is the `weakSelf` required here?