### PR TITLE
Set a different cookie storage for each user.

### DIFF
--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -90,7 +90,6 @@ extern NSInteger const kReceivedChatMessagesLimit;
 @interface NCAPIController : NSObject
 
 @property (nonatomic, strong) NSMutableDictionary *apiSessionManagers;
-@property (nonatomic, strong) NSMutableDictionary *apiUsingCookiesSessionManagers;
 @property (nonatomic, strong) AFImageDownloader *imageDownloader;
 @property (nonatomic, strong) AFImageDownloader *imageDownloaderNoCache;
 

--- a/NextcloudTalk/NCSettingsController.m
+++ b/NextcloudTalk/NCSettingsController.m
@@ -191,7 +191,6 @@ NSString * const NCUserProfileImageUpdatedNotification = @"NCUserProfileImageUpd
     [[NCDatabaseManager sharedInstance] setActiveAccountWithAccountId:accountId];
     [[NCDatabaseManager sharedInstance] resetUnreadBadgeNumberForAccountId:accountId];
     [[NCNotificationController sharedInstance] removeAllNotificationsForAccountId:accountId];
-    [[NSHTTPCookieStorage sharedHTTPCookieStorage] removeCookiesSinceDate:[NSDate dateWithTimeIntervalSince1970:0]];
     [[NCConnectionController sharedInstance] checkAppState];
 }
 


### PR DESCRIPTION
In this PR we set a different cookie storage for each user. Also we now send cookies on every api request.

This fixes the problem of missing push notifications after leaving a conversation.
The app was not sending the session cookie in leaveRoom(), so the user was not notified on new messages in that conversation until the session was removed by the server after a timeout.

Fixes #508
Fixes https://github.com/nextcloud/spreed/issues/5299