### PR TITLE
Add background fetch

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -32,6 +32,10 @@
 
 #import <UserNotifications/UserNotifications.h>
 
+#import <BackgroundTasks/BGTaskScheduler.h>
+#import <BackgroundTasks/BGTaskRequest.h>
+#import <BackgroundTasks/BGTask.h>
+
 #import "NCAudioController.h"
 #import "NCAppBranding.h"
 #import "NCConnectionController.h"
@@ -82,6 +86,8 @@
         [[BKPasscodeLockScreenManager sharedManager] showLockScreen:NO];
     });
     
+    [self registerBackgroundFetchTask];
+    
     return YES;
 }
 
@@ -112,6 +118,10 @@
     // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     // show passcode view controller when enter background. Screen will be obscured from here.
     [[BKPasscodeLockScreenManager sharedManager] showLockScreen:NO];
+    
+    if (@available(iOS 13.0, *)) {
+        [self scheduleAppRefresh];
+    }
 }
 
 
@@ -307,5 +317,67 @@
     navigationController.modalPresentationStyle = UIModalPresentationFullScreen;
     return navigationController;
 }
+
+#pragma mark - BackgroundFetch / AppRefresh
+
+- (void)registerBackgroundFetchTask {
+    NSString *refreshTaskIdentifier = [NSString stringWithFormat:@"%@.refresh", NSBundle.mainBundle.bundleIdentifier];
+
+    if (@available(iOS 13.0, *)) {
+        // see: https://developer.apple.com/documentation/backgroundtasks/bgtaskscheduler?language=objc
+        [[BGTaskScheduler sharedScheduler] registerForTaskWithIdentifier:refreshTaskIdentifier
+                                                              usingQueue:nil
+                                                           launchHandler:^(__kindof BGTask * _Nonnull task) {
+            [self handleAppRefresh:task];
+        }];
+    } else {
+        [UIApplication.sharedApplication setMinimumBackgroundFetchInterval:UIApplicationBackgroundFetchIntervalMinimum];
+    }
+}
+
+- (void)scheduleAppRefresh API_AVAILABLE(ios(13.0))
+{
+    NSString *refreshTaskIdentifier = [NSString stringWithFormat:@"%@.refresh", NSBundle.mainBundle.bundleIdentifier];
+    
+    BGAppRefreshTaskRequest *request = [[BGAppRefreshTaskRequest alloc] initWithIdentifier:refreshTaskIdentifier];
+    request.earliestBeginDate = [NSDate dateWithTimeIntervalSinceNow:UIApplicationBackgroundFetchIntervalMinimum];
+    
+    NSError *error = nil;
+    [[BGTaskScheduler sharedScheduler] submitTaskRequest:request error:&error];
+    
+    if (error) {
+        NSLog(@"Failed to submit apprefresh request: %@", error);
+    }
+}
+
+- (void)handleAppRefresh:(BGTask *)task API_AVAILABLE(ios(13.0))
+{
+    NSLog(@"Performing background fetch -> handleAppRefresh");
+    
+    // With BGTasks (iOS >= 13) we need to schedule another refresh when running in background
+    [self scheduleAppRefresh];
+
+    [[NCRoomsManager sharedInstance] updateRoomsAndChatsUpdatingUserStatus:NO withCompletionBlock:^(NSError *error) {
+        if (error) {
+            [task setTaskCompletedWithSuccess:NO];
+        } else {
+            [task setTaskCompletedWithSuccess:YES];
+        }
+    }];
+}
+
+- (void)application:(UIApplication *)application performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
+{
+    NSLog(@"Performing background fetch -> performFetchWithCompletionHandler");
+    
+    [[NCRoomsManager sharedInstance] updateRoomsAndChatsUpdatingUserStatus:NO withCompletionBlock:^(NSError *error) {
+        if (error) {
+            completionHandler(UIBackgroundFetchResultFailed);
+        } else {
+            completionHandler(UIBackgroundFetchResultNewData);
+        }
+    }];
+}
+
 
 @end

--- a/NextcloudTalk/Info.plist
+++ b/NextcloudTalk/Info.plist
@@ -5,6 +5,7 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).refresh</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -134,7 +134,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 - (NSURLSessionDataTask *)leaveCall:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(LeaveCallCompletionBlock)block;
 
 // Chat Controller
-- (NSURLSessionDataTask *)receiveChatMessagesOfRoom:(NSString *)token fromLastMessageId:(NSInteger)messageId history:(BOOL)history includeLastMessage:(BOOL)include timeout:(BOOL)timeout lastCommonReadMessage:(NSInteger)lastCommonReadMessage forAccount:(TalkAccount *)account withCompletionBlock:(GetChatMessagesCompletionBlock)block;
+- (NSURLSessionDataTask *)receiveChatMessagesOfRoom:(NSString *)token fromLastMessageId:(NSInteger)messageId history:(BOOL)history includeLastMessage:(BOOL)include timeout:(BOOL)timeout lastCommonReadMessage:(NSInteger)lastCommonReadMessage setReadMarker:(BOOL)setReadMarker forAccount:(TalkAccount *)account withCompletionBlock:(GetChatMessagesCompletionBlock)block;
 - (NSURLSessionDataTask *)sendChatMessage:(NSString *)message toRoom:(NSString *)token displayName:(NSString *)displayName replyTo:(NSInteger)replyTo referenceId:(NSString *)referenceId forAccount:(TalkAccount *)account withCompletionBlock:(SendChatMessagesCompletionBlock)block;
 - (NSURLSessionDataTask *)getMentionSuggestionsInRoom:(NSString *)token forString:(NSString *)string forAccount:(TalkAccount *)account withCompletionBlock:(GetMentionSuggestionsCompletionBlock)block;
 - (NSURLSessionDataTask *)deleteChatMessageInRoom:(NSString *)token withMessageId:(NSInteger)messageId forAccount:(TalkAccount *)account withCompletionBlock:(DeleteChatMessageCompletionBlock)block;

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -810,7 +810,7 @@ NSInteger const kReceivedChatMessagesLimit = 100;
 
 #pragma mark - Chat Controller
 
-- (NSURLSessionDataTask *)receiveChatMessagesOfRoom:(NSString *)token fromLastMessageId:(NSInteger)messageId history:(BOOL)history includeLastMessage:(BOOL)include timeout:(BOOL)timeout lastCommonReadMessage:(NSInteger)lastCommonReadMessage forAccount:(TalkAccount *)account withCompletionBlock:(GetChatMessagesCompletionBlock)block
+- (NSURLSessionDataTask *)receiveChatMessagesOfRoom:(NSString *)token fromLastMessageId:(NSInteger)messageId history:(BOOL)history includeLastMessage:(BOOL)include timeout:(BOOL)timeout lastCommonReadMessage:(NSInteger)lastCommonReadMessage setReadMarker:(BOOL)setReadMarker forAccount:(TalkAccount *)account withCompletionBlock:(GetChatMessagesCompletionBlock)block
 {
     NSString *URLString = [self getRequestURLForAccount:account withEndpoint:[NSString stringWithFormat:@"chat/%@", token]];
     NSDictionary *parameters = @{@"lookIntoFuture" : history ? @(0) : @(1),
@@ -818,7 +818,7 @@ NSInteger const kReceivedChatMessagesLimit = 100;
                                  @"timeout" : timeout ? @(30) : @(0),
                                  @"lastKnownMessageId" : @(messageId),
                                  @"lastCommonReadId" : @(lastCommonReadMessage),
-                                 @"setReadMarker" : @(1),
+                                 @"setReadMarker" : setReadMarker ? @(1) : @(0),
                                  @"includeLastKnown" : include ? @(1) : @(0)};
     
     NCAPISessionManager *apiSessionManager = [_apiSessionManagers objectForKey:account.accountId];

--- a/NextcloudTalk/NCChatController.h
+++ b/NextcloudTalk/NCChatController.h
@@ -23,6 +23,8 @@
 #import <Foundation/Foundation.h>
 #import <Realm/Realm.h>
 
+typedef void (^UpdateHistoryInBackgroundCompletionBlock)(NSError *error);
+
 @class NCRoom;
 
 extern NSString * const NCChatControllerDidReceiveInitialChatHistoryNotification;
@@ -56,6 +58,7 @@ extern NSString * const NCChatControllerDidReceiveDeletedMessageNotification;
 - (void)getInitialChatHistoryForOfflineMode;
 - (void)getHistoryBatchFromMessagesId:(NSInteger)messageId;
 - (void)getHistoryBatchOfflineFromMessagesId:(NSInteger)messageId;
+- (void)updateHistoryInBackgroundWithCompletionBlock:(UpdateHistoryInBackgroundCompletionBlock)block;
 - (void)startReceivingNewChatMessages;
 - (void)stopReceivingNewChatMessages;
 - (void)stopChatController;

--- a/NextcloudTalk/NCChatController.h
+++ b/NextcloudTalk/NCChatController.h
@@ -58,6 +58,7 @@ extern NSString * const NCChatControllerDidReceiveDeletedMessageNotification;
 - (void)getInitialChatHistoryForOfflineMode;
 - (void)getHistoryBatchFromMessagesId:(NSInteger)messageId;
 - (void)getHistoryBatchOfflineFromMessagesId:(NSInteger)messageId;
+- (void)checkForNewMessagesFromMessageId:(NSInteger)messageId;
 - (void)updateHistoryInBackgroundWithCompletionBlock:(UpdateHistoryInBackgroundCompletionBlock)block;
 - (void)startReceivingNewChatMessages;
 - (void)stopReceivingNewChatMessages;

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -328,7 +328,7 @@ NSString * const NCChatControllerDidReceiveDeletedMessageNotification           
                                                             object:self
                                                           userInfo:userInfo];
     } else {
-        _pullMessagesTask = [[NCAPIController sharedInstance] receiveChatMessagesOfRoom:_room.token fromLastMessageId:lastReadMessageId history:YES includeLastMessage:YES timeout:NO lastCommonReadMessage:_room.lastCommonReadMessage forAccount:_account withCompletionBlock:^(NSArray *messages, NSInteger lastKnownMessage, NSInteger lastCommonReadMessage, NSError *error, NSInteger statusCode) {
+        _pullMessagesTask = [[NCAPIController sharedInstance] receiveChatMessagesOfRoom:_room.token fromLastMessageId:lastReadMessageId history:YES includeLastMessage:YES timeout:NO lastCommonReadMessage:_room.lastCommonReadMessage setReadMarker:YES forAccount:_account withCompletionBlock:^(NSArray *messages, NSInteger lastKnownMessage, NSInteger lastCommonReadMessage, NSError *error, NSInteger statusCode) {
             if (self->_stopChatMessagesPoll) {
                 return;
             }
@@ -392,7 +392,7 @@ NSString * const NCChatControllerDidReceiveDeletedMessageNotification           
                                                             object:self
                                                           userInfo:userInfo];
     } else {
-        _getHistoryTask = [[NCAPIController sharedInstance] receiveChatMessagesOfRoom:_room.token fromLastMessageId:messageId history:YES includeLastMessage:NO timeout:NO lastCommonReadMessage:_room.lastCommonReadMessage forAccount:_account withCompletionBlock:^(NSArray *messages, NSInteger lastKnownMessage, NSInteger lastCommonReadMessage, NSError *error, NSInteger statusCode) {
+        _getHistoryTask = [[NCAPIController sharedInstance] receiveChatMessagesOfRoom:_room.token fromLastMessageId:messageId history:YES includeLastMessage:NO timeout:NO lastCommonReadMessage:_room.lastCommonReadMessage setReadMarker:YES forAccount:_account withCompletionBlock:^(NSArray *messages, NSInteger lastKnownMessage, NSInteger lastCommonReadMessage, NSError *error, NSInteger statusCode) {
             if (statusCode == 304) {
                 [self updateHistoryFlagInFirstBlock];
             }
@@ -474,7 +474,7 @@ NSString * const NCChatControllerDidReceiveDeletedMessageNotification           
 {
     _stopChatMessagesPoll = NO;
     [_pullMessagesTask cancel];
-    _pullMessagesTask = [[NCAPIController sharedInstance] receiveChatMessagesOfRoom:_room.token fromLastMessageId:messageId history:NO includeLastMessage:NO timeout:timeout lastCommonReadMessage:_room.lastCommonReadMessage forAccount:_account withCompletionBlock:^(NSArray *messages, NSInteger lastKnownMessage, NSInteger lastCommonReadMessage, NSError *error, NSInteger statusCode) {
+    _pullMessagesTask = [[NCAPIController sharedInstance] receiveChatMessagesOfRoom:_room.token fromLastMessageId:messageId history:NO includeLastMessage:NO timeout:timeout lastCommonReadMessage:_room.lastCommonReadMessage setReadMarker:YES forAccount:_account withCompletionBlock:^(NSArray *messages, NSInteger lastKnownMessage, NSInteger lastCommonReadMessage, NSError *error, NSInteger statusCode) {
         if (self->_stopChatMessagesPoll) {
             return;
         }

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -378,6 +378,15 @@ NSString * const NCChatControllerDidReceiveDeletedMessageNotification           
         [[NSNotificationCenter defaultCenter] postNotificationName:NCChatControllerDidReceiveInitialChatHistoryNotification
                                                             object:self
                                                           userInfo:userInfo];
+        
+        // Messages are already sorted by messageId here
+        NCChatMessage *lastMessage = [storedMessages lastObject];
+        
+        // Make sure we update the unread flags for the room (lastMessage can already be set, but there still might be unread flags)
+        if (lastMessage.timestamp >= self->_room.lastActivity) {
+            self->_room.lastActivity = lastMessage.timestamp;
+            [[NCRoomsManager sharedInstance] updateLastMessage:lastMessage withNoUnreadMessages:YES forRoom:self->_room];
+        }
     } else {
         _pullMessagesTask = [[NCAPIController sharedInstance] receiveChatMessagesOfRoom:_room.token fromLastMessageId:lastReadMessageId history:YES includeLastMessage:YES timeout:NO lastCommonReadMessage:_room.lastCommonReadMessage setReadMarker:YES forAccount:_account withCompletionBlock:^(NSArray *messages, NSInteger lastKnownMessage, NSInteger lastCommonReadMessage, NSError *error, NSInteger statusCode) {
             if (self->_stopChatMessagesPoll) {

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -343,6 +343,18 @@ NSString * const NCChatControllerDidReceiveDeletedMessageNotification           
     
     if (storedMessages.count > 0) {
         NSMutableDictionary *userInfo = [NSMutableDictionary new];
+        
+        for (NCChatMessage *message in storedMessages) {
+            // Notify if "deleted messages" have been received
+            if ([message.systemMessage isEqualToString:@"message_deleted"]) {
+                [userInfo setObject:message forKey:@"deleteMessage"];
+                [[NSNotificationCenter defaultCenter] postNotificationName:NCChatControllerDidReceiveDeletedMessageNotification
+                                                                    object:self
+                                                                  userInfo:userInfo];
+            }
+        }
+        
+        [userInfo removeAllObjects];
         [userInfo setObject:self->_room.token forKey:@"room"];
         [userInfo setObject:storedMessages forKey:@"messages"];
         

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -355,8 +355,11 @@ NSString * const NCChatControllerDidReceiveDeletedMessageNotification           
                                                               userInfo:userInfo];
             if (lastCommonReadMessage > 0) {
                 BOOL newerCommonReadReceived = lastCommonReadMessage > self->_room.lastCommonReadMessage;
-                self->_room.lastCommonReadMessage = lastCommonReadMessage;
+                
                 if (newerCommonReadReceived) {
+                    self->_room.lastCommonReadMessage = lastCommonReadMessage;
+                    [[NCRoomsManager sharedInstance] updateLastCommonReadMessage:lastCommonReadMessage forRoom:self->_room];
+                    
                     [[NSNotificationCenter defaultCenter] postNotificationName:NCChatControllerDidReceiveNewerCommonReadMessageNotification
                                                                         object:self
                                                                       userInfo:userInfo];
@@ -502,14 +505,11 @@ NSString * const NCChatControllerDidReceiveDeletedMessageNotification           
                 
                 for (NCChatMessage *message in storedMessages) {
                     // Update the current room with the new message
-                    // The stored information about this room will be updated by calling savePendingMessage
-                    // in NCChatViewController -> a transaction wouldn't make sense here, as it would be overriden again
                     if (message.messageId == lastKnownMessage && message.timestamp > self->_room.lastActivity) {
-                        self->_room.lastMessageId = message.internalId;
                         self->_room.lastActivity = message.timestamp;
-                        self->_room.unreadMention = NO;
-                        self->_room.unreadMessages = 0;
+                        [[NCRoomsManager sharedInstance] updateLastMessage:message withNoUnreadMessages:YES forRoom:self->_room];
                     }
+                    
                     // Notify if "deleted messages" have been received
                     if ([message.systemMessage isEqualToString:@"message_deleted"]) {
                         [userInfo setObject:message forKey:@"deleteMessage"];
@@ -525,8 +525,11 @@ NSString * const NCChatControllerDidReceiveDeletedMessageNotification           
                                                           userInfo:userInfo];
         if (lastCommonReadMessage > 0) {
             BOOL newerCommonReadReceived = lastCommonReadMessage > self->_room.lastCommonReadMessage;
-            self->_room.lastCommonReadMessage = lastCommonReadMessage;
+            
             if (newerCommonReadReceived) {
+                self->_room.lastCommonReadMessage = lastCommonReadMessage;
+                [[NCRoomsManager sharedInstance] updateLastCommonReadMessage:lastCommonReadMessage forRoom:self->_room];
+                
                 [[NSNotificationCenter defaultCenter] postNotificationName:NCChatControllerDidReceiveNewerCommonReadMessageNotification
                                                                     object:self
                                                                   userInfo:userInfo];

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -392,7 +392,14 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
 
 -(void)appDidBecomeActive:(NSNotification*)notification
 {
-    [self removeUnreadMessagesSeparator];
+    // Check if new messages were added while the app was inactive (eg. via background-refresh)
+    NCChatMessage *lastMessage = [[self->_messages objectForKey:[self->_dateSections lastObject]] lastObject];
+    
+    if (lastMessage) {
+        [self.chatController checkForNewMessagesFromMessageId:lastMessage.messageId];
+        [self checkLastCommonReadMessage];
+    }
+    
     if (!_offlineMode) {
         [[NCRoomsManager sharedInstance] joinRoom:_room.token];
     }
@@ -402,6 +409,7 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
 {
     _hasReceiveNewMessages = NO;
     _leftChatWithVisibleChatVC = YES;
+    [self removeUnreadMessagesSeparator];
     [_chatController stopChatController];
     [[NCRoomsManager sharedInstance] leaveChatInRoom:_room.token];
 }

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1513,16 +1513,6 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
             // Set last received message as last read message
             NCChatMessage *lastReceivedMessage = [messages objectAtIndex:messages.count - 1];
             self->_lastReadMessage = lastReceivedMessage.messageId;
-        } else if (firstNewMessagesAfterHistory) {
-            // Now the chat is loaded after getting the initial history and the first new messages block.
-            // Even if there are no new messages, tableview should be reloaded and scrolled to the bottom
-            // as it was done when only initial history was loaded.
-            [self.tableView reloadData];
-            NSMutableArray *messagesForLastDate = [self->_messages objectForKey:[self->_dateSections lastObject]];
-            if (messagesForLastDate.count > 0) {
-                NSIndexPath *lastMessageIndexPath = [NSIndexPath indexPathForRow:messagesForLastDate.count - 1 inSection:self->_dateSections.count - 1];
-                [self.tableView scrollToRowAtIndexPath:lastMessageIndexPath atScrollPosition:UITableViewScrollPositionNone animated:NO];
-            }
         }
         
         if (firstNewMessagesAfterHistory) {

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1936,7 +1936,7 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
 - (void)savePendingMessage
 {
     _room.pendingMessage = self.textView.text;
-    [[NCRoomsManager sharedInstance] updateRoomLocal:_room];
+    [[NCRoomsManager sharedInstance] updatePendingMessage:_room.pendingMessage forRoom:_room];
 }
 
 #pragma mark - Autocompletion

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1407,7 +1407,7 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
                 if (indexPathUnreadMessageSeparator) {
                     // It is possible that temporary messages are added which add new sections
                     // In this case the indexPath of the unreadMessageSeparator would be invalid and could lead to a crash
-                    // Therefore me need to make sure that got the correct indexPath here
+                    // Therefore we need to make sure we got the correct indexPath here
                     indexPathUnreadMessageSeparator = [self getIndexPathOfUnreadMessageSeparator];
                 }
             }

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1569,20 +1569,7 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
         return;
     }
     
-    dispatch_async(dispatch_get_main_queue(), ^{
-        NSMutableArray *reloadCells = [NSMutableArray new];
-        for (NSIndexPath *visibleIndexPath in self.tableView.indexPathsForVisibleRows) {
-            NSDate *sectionDate = [self->_dateSections objectAtIndex:visibleIndexPath.section];
-            NCChatMessage *message = [[self->_messages objectForKey:sectionDate] objectAtIndex:visibleIndexPath.row];
-            if (message.messageId > 0 && message.messageId <= self->_room.lastCommonReadMessage) {
-                [reloadCells addObject:visibleIndexPath];
-            }
-        }
-        
-        [self.tableView beginUpdates];
-        [self.tableView reloadRowsAtIndexPaths:reloadCells withRowAnimation:UITableViewRowAnimationNone];
-        [self.tableView endUpdates];
-    });
+    [self checkLastCommonReadMessage];
 }
 
 - (void)didReceiveDeletedMessage:(NSNotification *)notification
@@ -1935,6 +1922,26 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
     if ([visibleCellsIPs containsObject:_firstUnreadMessageIP]) {
          [self hideNewMessagesView];
     }
+}
+
+- (void)checkLastCommonReadMessage
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSMutableArray *reloadCells = [NSMutableArray new];
+        for (NSIndexPath *visibleIndexPath in self.tableView.indexPathsForVisibleRows) {
+            NSDate *sectionDate = [self->_dateSections objectAtIndex:visibleIndexPath.section];
+            NCChatMessage *message = [[self->_messages objectForKey:sectionDate] objectAtIndex:visibleIndexPath.row];
+            if (message.messageId > 0 && message.messageId <= self->_room.lastCommonReadMessage) {
+                [reloadCells addObject:visibleIndexPath];
+            }
+        }
+        
+        if (reloadCells.count > 0) {
+            [self.tableView beginUpdates];
+            [self.tableView reloadRowsAtIndexPaths:reloadCells withRowAnimation:UITableViewRowAnimationNone];
+            [self.tableView endUpdates];
+        }
+    });
 }
 
 - (void)cleanChat

--- a/NextcloudTalk/NCRoom.m
+++ b/NextcloudTalk/NCRoom.m
@@ -127,11 +127,6 @@ NSString * const NCRoomObjectTypeSharePassword  = @"share:password";
     managedRoom.canStartCall = room.canStartCall;
     managedRoom.hasCall = room.hasCall;
     managedRoom.lastUpdate = room.lastUpdate;
-    
-    // Local-only field -> update only if there's actually a value
-    if (room.pendingMessage != nil) {
-        managedRoom.pendingMessage = room.pendingMessage;
-    }
 }
 
 + (NSString *)primaryKey {

--- a/NextcloudTalk/NCRoomsManager.h
+++ b/NextcloudTalk/NCRoomsManager.h
@@ -35,6 +35,9 @@ extern NSString * const NCRoomsManagerDidUpdateRoomNotification;
 // Call
 extern NSString * const NCRoomsManagerDidStartCallNotification;
 
+typedef void (^UpdateRoomsCompletionBlock)(NSArray *roomsWithNewMessages, NSError *error);
+typedef void (^UpdateRoomsAndChatsCompletionBlock)(NSError *error);
+
 @interface NCRoomController : NSObject
 
 @property (nonatomic, strong) NSString *userSessionId;
@@ -52,6 +55,7 @@ extern NSString * const NCRoomsManagerDidStartCallNotification;
 // Room
 - (NSArray *)roomsForAccountId:(NSString *)accountId witRealm:(RLMRealm *)realm;
 - (NCRoom *)roomWithToken:(NSString *)token forAccountId:(NSString *)accountId;
+- (void)updateRoomsAndChatsUpdatingUserStatus:(BOOL)updateStatus withCompletionBlock:(UpdateRoomsAndChatsCompletionBlock)block;
 - (void)updateRoomsUpdatingUserStatus:(BOOL)updateStatus;
 - (void)updateRoom:(NSString *)token;
 - (void)updateRoomLocal:(NCRoom *) room;

--- a/NextcloudTalk/NCRoomsManager.h
+++ b/NextcloudTalk/NCRoomsManager.h
@@ -59,6 +59,8 @@ typedef void (^UpdateRoomsAndChatsCompletionBlock)(NSError *error);
 - (void)updateRoomsUpdatingUserStatus:(BOOL)updateStatus;
 - (void)updateRoom:(NSString *)token;
 - (void)updatePendingMessage:(NSString *)message forRoom:(NCRoom *)room;
+- (void)updateLastMessage:(NCChatMessage *)message withNoUnreadMessages:(BOOL)noUnreadMessages forRoom:(NCRoom *)room;
+- (void)updateLastCommonReadMessage:(NSInteger)messageId forRoom:(NCRoom *)room;
 - (void)joinRoom:(NSString *)token;
 - (void)rejoinRoom:(NSString *)token;
 // Chat

--- a/NextcloudTalk/NCRoomsManager.h
+++ b/NextcloudTalk/NCRoomsManager.h
@@ -58,7 +58,7 @@ typedef void (^UpdateRoomsAndChatsCompletionBlock)(NSError *error);
 - (void)updateRoomsAndChatsUpdatingUserStatus:(BOOL)updateStatus withCompletionBlock:(UpdateRoomsAndChatsCompletionBlock)block;
 - (void)updateRoomsUpdatingUserStatus:(BOOL)updateStatus;
 - (void)updateRoom:(NSString *)token;
-- (void)updateRoomLocal:(NCRoom *) room;
+- (void)updatePendingMessage:(NSString *)message forRoom:(NCRoom *)room;
 - (void)joinRoom:(NSString *)token;
 - (void)rejoinRoom:(NSString *)token;
 // Chat

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -437,6 +437,34 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
     }];
 }
 
+- (void)updateLastMessage:(NCChatMessage *)message withNoUnreadMessages:(BOOL)noUnreadMessages forRoom:(NCRoom *)room
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm transactionWithBlock:^{
+        NCRoom *managedRoom = [NCRoom objectsWhere:@"internalId = %@", room.internalId].firstObject;
+        if (managedRoom) {
+            managedRoom.lastMessageId = message.internalId;
+            managedRoom.lastActivity = message.timestamp;
+            
+            if (noUnreadMessages) {
+                managedRoom.unreadMention = NO;
+                managedRoom.unreadMessages = 0;
+            }
+        }
+    }];
+}
+
+- (void)updateLastCommonReadMessage:(NSInteger)messageId forRoom:(NCRoom *)room
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm transactionWithBlock:^{
+        NCRoom *managedRoom = [NCRoom objectsWhere:@"internalId = %@", room.internalId].firstObject;
+        if (managedRoom && messageId > managedRoom.lastCommonReadMessage) {
+            managedRoom.lastCommonReadMessage = messageId;
+        }
+    }];
+}
+
 #pragma mark - Chat
 
 - (void)startChatInRoom:(NCRoom *)room

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -307,7 +307,7 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
             return;
         }
         
-        NSLog(@"Finished rooms update with %d rooms with new messages", [roomsWithNewMessages count]);
+        NSLog(@"Finished rooms update with %lu rooms with new messages", [roomsWithNewMessages count]);
         dispatch_group_t chatUpdateGroup = dispatch_group_create();
         
         // When in low power mode, we only update the conversation list and don't load new messages for each room

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -426,13 +426,13 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
     return roomContainsNewMessages;
 }
 
-- (void)updateRoomLocal:(NCRoom *)room
+- (void)updatePendingMessage:(NSString *)message forRoom:(NCRoom *)room
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm transactionWithBlock:^{
         NCRoom *managedRoom = [NCRoom objectsWhere:@"internalId = %@", room.internalId].firstObject;
         if (managedRoom) {
-            [NCRoom updateRoom:managedRoom withRoom:room];
+            managedRoom.pendingMessage = message;
         }
     }];
 }

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -238,7 +238,7 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
 
 - (void)notificationWillBePresented:(NSNotification *)notification
 {
-    [[NCRoomsManager sharedInstance] updateRoomsUpdatingUserStatus:NO];
+    [[NCRoomsManager sharedInstance] updateRoomsAndChatsUpdatingUserStatus:NO withCompletionBlock:nil];
     [self setUnreadMessageForInactiveAccountsIndicator];
 }
 
@@ -255,7 +255,7 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
 - (void)appWillEnterForeground:(NSNotification *)notification
 {
     if ([NCConnectionController sharedInstance].appState == kAppStateReady) {
-        [[NCRoomsManager sharedInstance] updateRoomsUpdatingUserStatus:YES];
+        [[NCRoomsManager sharedInstance] updateRoomsAndChatsUpdatingUserStatus:YES withCompletionBlock:nil];
         [self setUnreadMessageForInactiveAccountsIndicator];
     }
 }
@@ -292,7 +292,7 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
 
 - (void)refreshControlTarget
 {
-    [[NCRoomsManager sharedInstance] updateRoomsUpdatingUserStatus:YES];
+    [[NCRoomsManager sharedInstance] updateRoomsAndChatsUpdatingUserStatus:YES withCompletionBlock:nil];
     // Actuate `Peek` feedback (weak boom)
     AudioServicesPlaySystemSound(1519);
 }


### PR DESCRIPTION
This PR adds the ability to fetch new messages in the background when enabled (Settings -> General -> Background App Refresh). 

Some remarks:
* When a background fetch occurs is up to iOS (when in low power mode background fetch might be disabled by the OS)
* When a background fetch occurs in normal operations, we update the rooms and update each chat for rooms that changed since the last sync (so viewing new messages should be instantaneous now)
* When rooms need to be updates while the app is in foreground (eg. update control, recevied push, ...) we do the same thing and directly load the new messages
* When in low power mode and a background fetch occurs, we only update the rooms, not the chats
* This can be tested in Xcode via Debug -> Simulate background fetch (note that even if you use a device >= iOS 13 this will trigger `performFetchWithCompletionHandler` instead of `handleAppRefresh`


I really don't get why this code was neccessary before https://github.com/nextcloud/talk-ios/commit/13ef2c73eaf9688fe2f3e8a5c92500974f013d18. We could re-introduce it again if there's a reason, but there need to be changes because we now add the unreadMessagesSeparator before the first request from the API is done.

Fixes #516 