### PR TITLE
Close popover when coming to foreground

### DIFF
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -258,6 +258,8 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
         [[NCRoomsManager sharedInstance] updateRoomsUpdatingUserStatus:YES];
         [self setUnreadMessageForInactiveAccountsIndicator];
     }
+    
+    [FTPopOverMenu dismiss];
 }
 
 #pragma mark - Interface Builder Actions


### PR DESCRIPTION
Close the popover menu when the app gets active again. When not doing this, we can end up with a popover menu while inside a chat (when opening the chat via notification and popover was open before).