### PR TITLE
Hide keyboard when switching to room infos

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -782,6 +782,9 @@ NSString * const NCChatViewControllerReplyPrivatelyNotification = @"NCChatViewCo
 {
     RoomInfoTableViewController *roomInfoVC = [[RoomInfoTableViewController alloc] initForRoom:_room fromChatViewController:self];
     [self.navigationController pushViewController:roomInfoVC animated:YES];
+    
+    // When returning from RoomInfoTableViewController the default keyboard will be shown, so the height might be wrong -> make sure the keyboard is hidden
+    [self dismissKeyboard:YES];
 }
 
 - (void)unreadMessagesButtonPressed:(id)sender


### PR DESCRIPTION
Otherwise we might end up in this state:
![image](https://user-images.githubusercontent.com/1580193/110247087-a8315b80-7f6a-11eb-80d5-d199ebffaea4.png)


(open emoji keyboard, switch to room info, go back)