### PR TITLE
Improve error messages when connection to server fails

### DIFF
--- a/NextcloudTalk/LoginViewController.m
+++ b/NextcloudTalk/LoginViewController.m
@@ -176,6 +176,18 @@
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [[CCCertificate sharedManager] presentViewControllerCertificateWithTitle:[error localizedDescription] viewController:self delegate:self];
                 });
+            } else if ([error code] == NSURLErrorAppTransportSecurityRequiresSecureConnection ||
+                       [error code] == NSURLErrorBadServerResponse ||
+                       [error code] == NSURLErrorCannotConnectToHost ||
+                       [error code] == NSURLErrorCannotFindHost ||
+                       [error code] == NSURLErrorClientCertificateRejected ||
+                       [error code] == NSURLErrorHTTPTooManyRedirects ||
+                       [error code] == NSURLErrorNetworkConnectionLost ||
+                       [error code] == NSURLErrorServerCertificateHasBadDate ||
+                       [error code] == NSURLErrorServerCertificateHasUnknownRoot ||
+                       [error code] == NSURLErrorTimedOut) {
+                NSString *errorMessage = [NSString stringWithFormat:@"%@\n%@", [error localizedDescription], NSLocalizedString(@"Please check that you entered the correct Nextcloud server address.", nil)];
+                [self showAlertWithTitle:NSLocalizedString(@"Nextcloud server not found", nil) andMessage:errorMessage];
             } else {
                 [self showAlertWithTitle:NSLocalizedString(@"Nextcloud server not found", nil) andMessage:NSLocalizedString(@"Please check that you entered the correct Nextcloud server address.", nil)];
             }


### PR DESCRIPTION
Improve error message when connection to server fails on login. 
I noticed that not all error messages are translated by apple (for example `NSURLErrorAppTransportSecurityRequiresSecureConnection` is not). Should we add them to translate or keep as "OS-native" as possible here?

Ref https://help.nextcloud.com/t/nextcloud-talk-funktioniert-unter-ios-nicht/109430