### PR TITLE
Fix Custom Signaling server url

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,7 +33,7 @@ Tell us what happens instead
 
 **Talk version:** (see apps admin page: `/index.php/settings/apps`)
 
-**Custom Signaling server configured:** yes/no and version (see talk admin settings: `/index.php/index.php/settings/admin/talk#signaling_server`)
+**Custom Signaling server configured:** yes/no and version (see talk admin settings: `/index.php/settings/admin/talk#signaling_server`)
 
 **Custom TURN server configured:** yes/no (see talk admin settings: `/index.php/settings/admin/talk#turn_server`)
 


### PR DESCRIPTION
The Custom Signaling server URL in the issue-template is invalid because of the duplicate `/index.php` prefix.