### PR TITLE
Blur video of peer when the video stream is paused/frozen

### DIFF
--- a/NextcloudTalk/CallParticipantViewCell.h
+++ b/NextcloudTalk/CallParticipantViewCell.h
@@ -41,6 +41,7 @@ extern CGFloat const kCallParticipantCellMinHeight;
 @property (nonatomic, assign)  BOOL audioDisabled;
 @property (nonatomic, assign)  BOOL videoDisabled;
 @property (nonatomic, assign)  BOOL screenShared;
+@property (nonatomic, assign)  BOOL videoPaused;
 @property (nonatomic, assign)  RTCIceConnectionState connectionState;
 
 @property (nonatomic, weak) IBOutlet UIView *peerVideoView;

--- a/NextcloudTalk/CallParticipantViewCell.m
+++ b/NextcloudTalk/CallParticipantViewCell.m
@@ -42,6 +42,7 @@ CGFloat const kCallParticipantCellMinHeight = 128;
     BOOL _showOriginalSize;
     AvatarBackgroundImageView *_backgroundImageView;
     NSTimer *_disconnectedTimer;
+    UIVisualEffectView *_blurEffectView;
 }
 
 @end
@@ -79,6 +80,7 @@ CGFloat const kCallParticipantCellMinHeight = 128;
     _videoView = nil;
     _showOriginalSize = NO;
     self.layer.borderWidth = 0.0f;
+    [self removeVideoPausedBlurEffect];
 }
 
 - (void)toggleZoom
@@ -233,6 +235,7 @@ CGFloat const kCallParticipantCellMinHeight = 128;
     if (videoDisabled) {
         [_videoView setHidden:YES];
         [_peerAvatarImageView setHidden:NO];
+        [self removeVideoPausedBlurEffect];
     } else {
         [_peerAvatarImageView setHidden:YES];
         [_videoView setHidden:NO];
@@ -246,6 +249,44 @@ CGFloat const kCallParticipantCellMinHeight = 128;
         self.layer.borderWidth = 2.0f;
     } else {
         self.layer.borderWidth = 0.0f;
+    }
+}
+
+- (void)addVideoPausedBlurEffect
+{
+    [self removeVideoPausedBlurEffect];
+    
+    UIBlurEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
+    _blurEffectView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
+    _blurEffectView.frame = self.contentView.bounds;
+    _blurEffectView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    
+    UILabel *pausedLabel = [[UILabel alloc] initWithFrame:_blurEffectView.frame];
+    pausedLabel.textAlignment = NSTextAlignmentCenter;
+    pausedLabel.textColor = UIColor.whiteColor;
+    pausedLabel.text = NSLocalizedString(@"Paused", @"TRANSLATORS this is used when a video is paused eg. blurred");
+    pausedLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    
+    [_blurEffectView.contentView addSubview:pausedLabel];
+    [self.contentView addSubview:_blurEffectView];
+}
+
+- (void)removeVideoPausedBlurEffect
+{
+    if (_blurEffectView) {
+        [_blurEffectView removeFromSuperview];
+        _blurEffectView = nil;
+    }
+}
+
+- (void)setVideoPaused:(BOOL)videoPaused
+{
+    _videoPaused = videoPaused;
+    
+    if (videoPaused && !self.videoDisabled) {
+        [self addVideoPausedBlurEffect];
+    } else {
+        [self removeVideoPausedBlurEffect];
     }
 }
 

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1204,6 +1204,7 @@ typedef NS_ENUM(NSInteger, CallState) {
     [cell setAudioDisabled:peerConnection.isRemoteAudioDisabled];
     [cell setScreenShared:[_screenRenderersDict objectForKey:peerConnection.peerId]];
     [cell setVideoDisabled: (_isAudioOnly) ? YES : peerConnection.isRemoteVideoDisabled];
+    [cell setVideoPaused:peerConnection.isRemoteVideoPaused];
     [cell.peerNameLabel setAlpha:_isDetailedViewVisible ? 1.0 : 0.0];
     [cell.buttonsContainerView setAlpha:_isDetailedViewVisible ? 1.0 : 0.0];
     
@@ -1229,6 +1230,7 @@ typedef NS_ENUM(NSInteger, CallState) {
     [participantCell setAudioDisabled:peerConnection.isRemoteAudioDisabled];
     [participantCell setScreenShared:[_screenRenderersDict objectForKey:peerConnection.peerId]];
     [participantCell setVideoDisabled: (_isAudioOnly) ? YES : peerConnection.isRemoteVideoDisabled];
+    [participantCell setVideoPaused:peerConnection.isRemoteVideoPaused];
     [participantCell.peerNameLabel setAlpha:_isDetailedViewVisible ? 1.0 : 0.0];
     [participantCell.buttonsContainerView setAlpha:_isDetailedViewVisible ? 1.0 : 0.0];
 }
@@ -1378,6 +1380,13 @@ typedef NS_ENUM(NSInteger, CallState) {
     } else {
         NSLog(@"Peer was force muted: %@", peerId);
     }
+}
+
+- (void)callController:(NCCallController *)callController didChangeRemoteVideoPaused:(BOOL)isPaused ofPeer:(NCPeerConnection *)peer
+{
+    [self updatePeer:peer block:^(CallParticipantViewCell *cell) {
+        [cell setVideoPaused:isPaused];
+    }];
 }
 
 - (void)callControllerIsReconnectingCall:(NCCallController *)callController

--- a/NextcloudTalk/NCCallController.h
+++ b/NextcloudTalk/NCCallController.h
@@ -46,6 +46,7 @@
 - (void)callController:(NCCallController *)callController didReceiveNick:(NSString *)nick fromPeer:(NCPeerConnection *)peer;
 - (void)callController:(NCCallController *)callController didReceiveUnshareScreenFromPeer:(NCPeerConnection *)peer;
 - (void)callController:(NCCallController *)callController didReceiveForceMuteActionForPeerId:(NSString *)peerId;
+- (void)callController:(NCCallController *)callController didChangeRemoteVideoPaused:(BOOL)isPaused ofPeer:(NCPeerConnection *)peer;
 - (void)callControllerIsReconnectingCall:(NCCallController *)callController;
 
 @end

--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -848,5 +848,9 @@ static NSString * const kNCVideoTrackKind = @"video";
     [self.delegate callController:self didReceiveNick:nick fromPeer:peerConnection];
 }
 
+- (void)peerConnection:(NCPeerConnection *)peerConnection didChangeRemoteVideoPaused:(BOOL)isPaused
+{
+    [self.delegate callController:self didChangeRemoteVideoPaused:isPaused ofPeer:peerConnection];
+}
 
 @end

--- a/NextcloudTalk/NCPeerConnection.h
+++ b/NextcloudTalk/NCPeerConnection.h
@@ -52,6 +52,9 @@
 /** Called when a peer connection creates session description */
 - (void)peerConnection:(NCPeerConnection *)peerConnection needsToSendSessionDescription:(RTCSessionDescription *)sessionDescription;
 
+/** Called when a peer with enabled video did not send new video frames for a few seconds */
+- (void)peerConnection:(NCPeerConnection *)peerConnection didChangeRemoteVideoPaused:(BOOL)isPaused;
+
 @end
 
 @interface NCPeerConnection : NSObject
@@ -69,6 +72,7 @@
 @property (nonatomic, assign) BOOL isRemoteAudioDisabled;
 @property (nonatomic, assign) BOOL isRemoteVideoDisabled;
 @property (nonatomic, assign) BOOL isPeerSpeaking;
+@property (nonatomic, assign) BOOL isRemoteVideoPaused;
 @property (nonatomic, strong, readonly) NSMutableArray *queuedRemoteCandidates;
 @property (nonatomic, strong) RTCMediaStream *remoteStream;
 

--- a/NextcloudTalk/NCPeerConnection.m
+++ b/NextcloudTalk/NCPeerConnection.m
@@ -257,6 +257,7 @@ NSTimeInterval const kNCPeerConnectionCheckVideoPausedStateWhilePausedEverySecon
                 }
                                 
                 self.videoBytesReceivedByPeer = bytesReceived;
+                return;
             }
         }
     }];


### PR DESCRIPTION
Fixes #431 

When a peer with enabled video did not send video frames for a few seconds the view gets blurred like it is with other apps.

![image](https://user-images.githubusercontent.com/1580193/135720671-ea5b7d27-e906-415b-a301-dbae6479bf25.png)
