### PR TITLE
Show user status icon in conversations list 

### DIFF
--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -253,7 +253,10 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     NSInteger conversationAPIVersion = [self conversationAPIVersionForAccount:account];
     NSString *URLString = [self getRequestURLForEndpoint:endpoint withAPIVersion:conversationAPIVersion forAccount:account];
     NSDictionary *parameters = @{@"noStatusUpdate" : @(!updateStatus)};
-    
+    ServerCapabilities *serverCapabilities = [[NCDatabaseManager sharedInstance] serverCapabilitiesForAccountId:account.accountId];
+    if (serverCapabilities.userStatus) {
+        URLString = [URLString stringByAppendingString:@"?includeStatus=true"];
+    }
     NCAPISessionManager *apiSessionManager = [_apiSessionManagers objectForKey:account.accountId];
     NSURLSessionDataTask *task = [apiSessionManager GET:URLString parameters:parameters progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nonnull responseObject) {
         NSArray *responseRooms = [[responseObject objectForKey:@"ocs"] objectForKey:@"data"];

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -89,11 +89,6 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
         configuration.schemaVersion = kTalkDatabaseSchemaVersion;
         configuration.migrationBlock = ^(RLMMigration *migration, uint64_t oldSchemaVersion) {
             // At the very minimum we need to update the version with an empty block to indicate that the schema has been upgraded (automatically) by Realm
-            if (oldSchemaVersion < kTalkDatabaseSchemaVersion) {
-                   // Nothing to do!
-                   // Realm will automatically detect new properties and removed properties
-                   // And will update the schema on disk automatically
-               }
         };
         
         // Tell Realm to use this new configuration object for the default Realm

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -31,7 +31,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 26;
+uint64_t const kTalkDatabaseSchemaVersion           = 27;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";
@@ -89,6 +89,11 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
         configuration.schemaVersion = kTalkDatabaseSchemaVersion;
         configuration.migrationBlock = ^(RLMMigration *migration, uint64_t oldSchemaVersion) {
             // At the very minimum we need to update the version with an empty block to indicate that the schema has been upgraded (automatically) by Realm
+            if (oldSchemaVersion < kTalkDatabaseSchemaVersion) {
+                   // Nothing to do!
+                   // Realm will automatically detect new properties and removed properties
+                   // And will update the schema on disk automatically
+               }
         };
         
         // Tell Realm to use this new configuration object for the default Realm

--- a/NextcloudTalk/NCRoom.h
+++ b/NextcloudTalk/NCRoom.h
@@ -95,6 +95,9 @@ extern NSString * const NCRoomObjectTypeSharePassword;
 @property (nonatomic, copy) NSString *pendingMessage;
 @property (nonatomic, assign) BOOL canLeaveConversation;
 @property (nonatomic, assign) BOOL canDeleteConversation;
+@property (nonatomic, copy) NSString *status;
+@property (nonatomic, copy) NSString *statusIcon;
+@property (nonatomic, copy) NSString *statusMessage;
 
 + (instancetype)roomWithDictionary:(NSDictionary *)roomDict;
 + (instancetype)roomWithDictionary:(NSDictionary *)roomDict andAccountId:(NSString *)accountId;

--- a/NextcloudTalk/NCRoom.m
+++ b/NextcloudTalk/NCRoom.m
@@ -68,6 +68,9 @@ NSString * const NCRoomObjectTypeSharePassword  = @"share:password";
     room.hasCall = [[roomDict objectForKey:@"hasCall"] boolValue];
     room.canLeaveConversation = [[roomDict objectForKey:@"canLeaveConversation"] boolValue];
     room.canDeleteConversation = [[roomDict objectForKey:@"canDeleteConversation"] boolValue];
+    room.status = ([roomDict objectForKey:@"status"] != [NSNull null]) ? [[roomDict objectForKey:@"status"] stringValue] : @"";
+    room.statusIcon = ([roomDict objectForKey:@"statusIcon"] != [NSNull null]) ? [[roomDict objectForKey:@"statusIcon"] stringValue] : @"";
+    room.statusMessage = ([roomDict objectForKey:@"statusMessage"] != [NSNull null]) ? [[roomDict objectForKey:@"statusMessage"] stringValue] : @"";
     
     // Local-only field -> update only if there's actually a value
     if ([roomDict objectForKey:@"pendingMessage"] != nil) {
@@ -144,6 +147,9 @@ NSString * const NCRoomObjectTypeSharePassword  = @"share:password";
     managedRoom.lastUpdate = room.lastUpdate;
     managedRoom.canLeaveConversation = room.canLeaveConversation;
     managedRoom.canDeleteConversation = room.canDeleteConversation;
+    managedRoom.status = room.status;
+    managedRoom.statusIcon = room.statusIcon;
+    managedRoom.statusMessage = room.statusMessage;
 }
 
 + (NSString *)primaryKey {

--- a/NextcloudTalk/RoomTableViewCell.h
+++ b/NextcloudTalk/RoomTableViewCell.h
@@ -36,10 +36,11 @@ extern CGFloat const kRoomTableCellHeight;
 @property (nonatomic, weak) IBOutlet UILabel *dateLabel;
 @property (weak, nonatomic) IBOutlet UIImageView *favoriteImage;
 @property (weak, nonatomic) IBOutlet UIImageView *userStatusImageView;
+@property (weak, nonatomic) IBOutlet UILabel *userStatusLabel;
 
 @property (nonatomic, assign) BOOL titleOnly;
 
 - (void)setUnreadMessages:(NSInteger)number mentioned:(BOOL)mentioned groupMentioned:(BOOL)groupMentioned;
 - (void)setUserStatus:(NSString *)userStatus;
-
+-(void)setUserStatusIcon:(NSString *)userStatusIcon;
 @end

--- a/NextcloudTalk/RoomTableViewCell.h
+++ b/NextcloudTalk/RoomTableViewCell.h
@@ -42,5 +42,5 @@ extern CGFloat const kRoomTableCellHeight;
 
 - (void)setUnreadMessages:(NSInteger)number mentioned:(BOOL)mentioned groupMentioned:(BOOL)groupMentioned;
 - (void)setUserStatus:(NSString *)userStatus;
--(void)setUserStatusIcon:(NSString *)userStatusIcon;
+- (void)setUserStatusIcon:(NSString *)userStatusIcon;
 @end

--- a/NextcloudTalk/RoomTableViewCell.m
+++ b/NextcloudTalk/RoomTableViewCell.m
@@ -103,6 +103,8 @@ CGFloat const kRoomTableCellHeight = 74.0f;
     self.userStatusImageView.image = nil;
     self.userStatusImageView.backgroundColor = [UIColor clearColor];
     
+    [self.userStatusLabel setHidden:YES];
+    
     _unreadMessagesBadge = nil;
     for (UIView *subview in [self.unreadMessagesView subviews]) {
         [subview removeFromSuperview];
@@ -141,6 +143,11 @@ CGFloat const kRoomTableCellHeight = 74.0f;
     if (mentioned) {
         _highlightType = kHighlightTypeImportant;
     }
+}
+
+-(void)setUserStatusIcon:(NSString *)userStatusIcon {
+    _userStatusLabel.text = userStatusIcon;
+    [_userStatusLabel setHidden:NO];
 }
 
 - (void)setUserStatus:(NSString *)userStatus

--- a/NextcloudTalk/RoomTableViewCell.xib
+++ b/NextcloudTalk/RoomTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -77,6 +77,17 @@
                             <constraint firstAttribute="width" constant="20" id="iwo-ml-eCL"/>
                         </constraints>
                     </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IAW-Df-Q2p">
+                        <rect key="frame" x="45" y="48" width="20" height="20"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="20" id="9H9-OY-FwF"/>
+                            <constraint firstAttribute="width" constant="20" id="E1R-qY-JVY"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
                 </subviews>
                 <viewLayoutGuide key="safeArea" id="hTO-u0-vdH"/>
                 <constraints>
@@ -87,9 +98,11 @@
                     <constraint firstItem="eUE-Vb-afX" firstAttribute="leading" secondItem="hTO-u0-vdH" secondAttribute="leading" constant="45" id="H1a-CQ-Rs2"/>
                     <constraint firstItem="Tc2-b5-oRl" firstAttribute="top" secondItem="hTO-u0-vdH" secondAttribute="top" constant="40" id="J8O-Vc-Fdv"/>
                     <constraint firstItem="Xb6-vq-E0C" firstAttribute="leading" secondItem="Tc2-b5-oRl" secondAttribute="trailing" constant="2" id="PwU-4t-4q5"/>
+                    <constraint firstItem="IAW-Df-Q2p" firstAttribute="top" secondItem="hTO-u0-vdH" secondAttribute="top" constant="48" id="UTs-bM-4rK"/>
                     <constraint firstItem="j70-Qd-IKC" firstAttribute="leading" secondItem="hTO-u0-vdH" secondAttribute="leading" constant="12" id="VLJ-ka-a3c"/>
                     <constraint firstItem="Xb6-vq-E0C" firstAttribute="top" secondItem="hTO-u0-vdH" secondAttribute="top" constant="35" id="Vbn-nE-8gk"/>
                     <constraint firstItem="mxr-4b-6AO" firstAttribute="leading" secondItem="hTO-u0-vdH" secondAttribute="leading" constant="45" id="Vn7-Zn-ft5"/>
+                    <constraint firstItem="IAW-Df-Q2p" firstAttribute="leading" secondItem="hTO-u0-vdH" secondAttribute="leading" constant="45" id="YhT-4g-4nL"/>
                     <constraint firstItem="4oj-Ge-nSq" firstAttribute="leading" secondItem="hTO-u0-vdH" secondAttribute="leading" constant="72" id="k3r-2g-iB6"/>
                     <constraint firstItem="4oj-Ge-nSq" firstAttribute="top" secondItem="hTO-u0-vdH" secondAttribute="top" constant="12" id="mha-g7-USc"/>
                     <constraint firstItem="j70-Qd-IKC" firstAttribute="top" secondItem="hTO-u0-vdH" secondAttribute="top" constant="12" id="s9G-jv-sKe"/>
@@ -106,6 +119,7 @@
                 <outlet property="titleLabel" destination="4oj-Ge-nSq" id="SPq-KL-y2z"/>
                 <outlet property="unreadMessagesView" destination="Xb6-vq-E0C" id="wXP-Vy-8sF"/>
                 <outlet property="userStatusImageView" destination="mxr-4b-6AO" id="MJo-C9-yUh"/>
+                <outlet property="userStatusLabel" destination="IAW-Df-Q2p" id="z9s-DV-2UV"/>
             </connections>
             <point key="canvasLocation" x="-71.200000000000003" y="-44.07796101949026"/>
         </tableViewCell>

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1139,6 +1139,22 @@ API_AVAILABLE(ios(11.0)){
         default:
             break;
     }
+
+    //Show User Status
+    if (room.type == kNCRoomTypeOneToOne) {
+        if ([room.status length] != 0) {
+            if (![room.status isEqual:@"dnd"]) {
+                if ([room.statusIcon length] != 0) {
+                    [cell setUserStatusIcon:room.statusIcon];
+                }
+                else {
+                    [cell setUserStatus:room.status];
+                }
+            }else {
+                    [cell setUserStatus:room.status];
+                }
+            }
+        }
     
     // Set objectType image
     if ([room.objectType isEqualToString:NCRoomObjectTypeFile]) {

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1141,20 +1141,13 @@ API_AVAILABLE(ios(11.0)){
     }
 
     //Show User Status
-    if (room.type == kNCRoomTypeOneToOne) {
-        if ([room.status length] != 0) {
-            if (![room.status isEqual:@"dnd"]) {
-                if ([room.statusIcon length] != 0) {
-                    [cell setUserStatusIcon:room.statusIcon];
-                }
-                else {
-                    [cell setUserStatus:room.status];
-                }
-            }else {
-                    [cell setUserStatus:room.status];
-                }
-            }
+    if (room.type == kNCRoomTypeOneToOne && [room.status length] != 0) {
+        if (![room.status isEqual:@"dnd"] && [room.statusIcon length] != 0) {
+            [cell setUserStatusIcon:room.statusIcon];
+        } else {
+            [cell setUserStatus:room.status];
         }
+    }
     
     // Set objectType image
     if ([room.objectType isEqualToString:NCRoomObjectTypeFile]) {


### PR DESCRIPTION
Show user status icon in conversations list like in the web Talk app.
When status is everything instead do not disturb and somebody set custom status with emoji  (for e.g. working 💻) , emoji will be shown. In other cases status will be shown (online, away, dnd)
<img width="335" alt="Screenshot 2021-11-12 at 15 02 30" src="https://user-images.githubusercontent.com/86428327/141479227-f69914ec-a894-430d-8da7-029f52c25bcb.png">
<img width="335" alt="Screenshot 2021-11-12 at 15 01 55" src="https://user-images.githubusercontent.com/86428327/141479232-e390e875-fd3c-4aae-ac91-ff94a9033105.png">
<img width="337" alt="Screenshot 2021-11-12 at 15 01 35" src="https://user-images.githubusercontent.com/86428327/141479233-0bc848ca-9b26-45d0-993e-7bccc8e8512e.png">
.
