### PR TITLE
Only assign optional attributes when they contain a value

### DIFF
--- a/NextcloudTalk/NCRoom.m
+++ b/NextcloudTalk/NCRoom.m
@@ -68,9 +68,6 @@ NSString * const NCRoomObjectTypeSharePassword  = @"share:password";
     room.hasCall = [[roomDict objectForKey:@"hasCall"] boolValue];
     room.canLeaveConversation = [[roomDict objectForKey:@"canLeaveConversation"] boolValue];
     room.canDeleteConversation = [[roomDict objectForKey:@"canDeleteConversation"] boolValue];
-    room.status = ([roomDict objectForKey:@"status"] != [NSNull null]) ? [[roomDict objectForKey:@"status"] stringValue] : @"";
-    room.statusIcon = ([roomDict objectForKey:@"statusIcon"] != [NSNull null]) ? [[roomDict objectForKey:@"statusIcon"] stringValue] : @"";
-    room.statusMessage = ([roomDict objectForKey:@"statusMessage"] != [NSNull null]) ? [[roomDict objectForKey:@"statusMessage"] stringValue] : @"";
     
     // Local-only field -> update only if there's actually a value
     if ([roomDict objectForKey:@"pendingMessage"] != nil) {
@@ -94,6 +91,24 @@ NSString * const NCRoomObjectTypeSharePassword  = @"share:password";
     id participants = [roomDict objectForKey:@"participants"];
     if ([participants isKindOfClass:[NSDictionary class]]) {
         room.participants = (RLMArray<RLMString> *)[participants allKeys];
+    }
+    
+    // Optional attribute
+    id status = [roomDict objectForKey:@"status"];
+    if ([status isKindOfClass:[NSString class]]) {
+        room.status = status;
+    }
+    
+    // Optional attribute
+    id statusIcon = [roomDict objectForKey:@"statusIcon"];
+    if ([statusIcon isKindOfClass:[NSString class]]) {
+        room.statusIcon = statusIcon;
+    }
+    
+    // Optional attribute
+    id statusMessage = [roomDict objectForKey:@"statusMessage"];
+    if ([statusMessage isKindOfClass:[NSString class]]) {
+        room.statusMessage = statusMessage;
     }
     
     return room;

--- a/NextcloudTalk/NCRoomParticipants.m
+++ b/NextcloudTalk/NCRoomParticipants.m
@@ -52,15 +52,30 @@ NSString * const NCAttendeeBridgeBotId  = @"bridge-bot";
     participant.sessionId = [participantDict objectForKey:@"sessionId"];
     participant.sessionIds = [participantDict objectForKey:@"sessionIds"];
     participant.userId = [participantDict objectForKey:@"userId"];
-    participant.status = ([participantDict objectForKey:@"status"] != [NSNull null]) ? [[participantDict objectForKey:@"status"] stringValue] : @"";
-    participant.statusIcon = ([participantDict objectForKey:@"statusIcon"] != [NSNull null]) ? [[participantDict objectForKey:@"statusIcon"] stringValue] : @"";
-    participant.statusMessage = ([participantDict objectForKey:@"statusMessage"] != [NSNull null]) ? [[participantDict objectForKey:@"statusMessage"] stringValue] : @"";
     
     id displayName = [participantDict objectForKey:@"displayName"];
     if ([displayName isKindOfClass:[NSString class]]) {
         participant.displayName = displayName;
     } else {
         participant.displayName = [displayName stringValue];
+    }
+    
+    // Optional attribute
+    id status = [participantDict objectForKey:@"status"];
+    if ([status isKindOfClass:[NSString class]]) {
+        participant.status = status;
+    }
+    
+    // Optional attribute
+    id statusIcon = [participantDict objectForKey:@"statusIcon"];
+    if ([statusIcon isKindOfClass:[NSString class]]) {
+        participant.statusIcon = statusIcon;
+    }
+    
+    // Optional attribute
+    id statusMessage = [participantDict objectForKey:@"statusMessage"];
+    if ([statusMessage isKindOfClass:[NSString class]]) {
+        participant.statusMessage = statusMessage;
     }
     
     return participant;


### PR DESCRIPTION
Only assign optional attributes when they contain a (expected type) value.


This PR also fixes a crash when trying to get stringValue of a NSString object:

When `([roomDict objectForKey:@"status"]` contained a NSString
`([roomDict objectForKey:@"status"] != [NSNull null])` was true 
so `[[roomDict objectForKey:@"statusIcon"] stringValue]` threw an exception
`Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSTaggedPointerString stringValue]: unrecognized selector sent to instance`

For some unknown reason, this exeption is not raised on iOS 13+ devices, but it is raised on iOS 12 (or lower) devices and apps running on M1 macs.