### PR TITLE
Remember zoom-state per participant

### DIFF
--- a/NextcloudTalk/CallParticipantViewCell.h
+++ b/NextcloudTalk/CallParticipantViewCell.h
@@ -30,6 +30,7 @@ extern CGFloat const kCallParticipantCellMinHeight;
 @class CallParticipantViewCell;
 @protocol CallParticipantViewCellDelegate <NSObject>
 - (void)cellWantsToPresentScreenSharing:(CallParticipantViewCell *)participantCell;
+- (void)cellWantsToChangeZoom:(CallParticipantViewCell *)participantCell showOriginalSize:(BOOL)showOriginalSize;
 @end
 
 @interface CallParticipantViewCell : UICollectionViewCell
@@ -41,6 +42,7 @@ extern CGFloat const kCallParticipantCellMinHeight;
 @property (nonatomic, assign)  BOOL audioDisabled;
 @property (nonatomic, assign)  BOOL videoDisabled;
 @property (nonatomic, assign)  BOOL screenShared;
+@property (nonatomic, assign)  BOOL showOriginalSize;
 @property (nonatomic, assign)  RTCIceConnectionState connectionState;
 
 @property (nonatomic, weak) IBOutlet UIView *peerVideoView;

--- a/NextcloudTalk/CallParticipantViewCell.m
+++ b/NextcloudTalk/CallParticipantViewCell.m
@@ -39,7 +39,6 @@ CGFloat const kCallParticipantCellMinHeight = 128;
 {
     UIView<RTCVideoRenderer> *_videoView;
     CGSize _remoteVideoSize;
-    BOOL _showOriginalSize;
     AvatarBackgroundImageView *_backgroundImageView;
     NSTimer *_disconnectedTimer;
 }
@@ -84,6 +83,7 @@ CGFloat const kCallParticipantCellMinHeight = 128;
 - (void)toggleZoom
 {
     _showOriginalSize = !_showOriginalSize;
+    [self.actionsDelegate cellWantsToChangeZoom:self showOriginalSize:_showOriginalSize];
     [self resizeRemoteVideoView];
 }
 

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1183,6 +1183,15 @@ typedef NS_ENUM(NSInteger, CallState) {
     [self showScreenOfPeerId:participantCell.peerId];
 }
 
+- (void)cellWantsToChangeZoom:(CallParticipantViewCell *)participantCell showOriginalSize:(BOOL)showOriginalSize
+{
+    NCPeerConnection *peer = [self peerConnectionForPeerId:participantCell.peerId];
+    
+    if (peer) {
+        [peer setShowRemoteVideoInOriginalSize:showOriginalSize];
+    }
+}
+
 #pragma mark - UICollectionView Datasource
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section
@@ -1204,6 +1213,7 @@ typedef NS_ENUM(NSInteger, CallState) {
     [cell setAudioDisabled:peerConnection.isRemoteAudioDisabled];
     [cell setScreenShared:[_screenRenderersDict objectForKey:peerConnection.peerId]];
     [cell setVideoDisabled: (_isAudioOnly) ? YES : peerConnection.isRemoteVideoDisabled];
+    [cell setShowOriginalSize:peerConnection.showRemoteVideoInOriginalSize];
     [cell.peerNameLabel setAlpha:_isDetailedViewVisible ? 1.0 : 0.0];
     [cell.buttonsContainerView setAlpha:_isDetailedViewVisible ? 1.0 : 0.0];
     
@@ -1229,6 +1239,7 @@ typedef NS_ENUM(NSInteger, CallState) {
     [participantCell setAudioDisabled:peerConnection.isRemoteAudioDisabled];
     [participantCell setScreenShared:[_screenRenderersDict objectForKey:peerConnection.peerId]];
     [participantCell setVideoDisabled: (_isAudioOnly) ? YES : peerConnection.isRemoteVideoDisabled];
+    [participantCell setShowOriginalSize:peerConnection.showRemoteVideoInOriginalSize];
     [participantCell.peerNameLabel setAlpha:_isDetailedViewVisible ? 1.0 : 0.0];
     [participantCell.buttonsContainerView setAlpha:_isDetailedViewVisible ? 1.0 : 0.0];
 }
@@ -1491,6 +1502,16 @@ typedef NS_ENUM(NSInteger, CallState) {
         CallParticipantViewCell *cell = (id)[self.collectionView cellForItemAtIndexPath:indexPath];
         block(cell);
     });
+}
+
+- (NCPeerConnection *)peerConnectionForPeerId:(NSString *)peerId {
+    for (NCPeerConnection *peerConnection in self->_peersInCall) {
+        if ([peerConnection.peerId isEqualToString:peerId]) {
+            return peerConnection;
+        }
+    }
+    
+    return nil;
 }
 
 - (void)showPeersInfo

--- a/NextcloudTalk/NCPeerConnection.h
+++ b/NextcloudTalk/NCPeerConnection.h
@@ -69,6 +69,7 @@
 @property (nonatomic, assign) BOOL isRemoteAudioDisabled;
 @property (nonatomic, assign) BOOL isRemoteVideoDisabled;
 @property (nonatomic, assign) BOOL isPeerSpeaking;
+@property (nonatomic, assign) BOOL showRemoteVideoInOriginalSize;
 @property (nonatomic, strong, readonly) NSMutableArray *queuedRemoteCandidates;
 @property (nonatomic, strong) RTCMediaStream *remoteStream;
 


### PR DESCRIPTION
Fixes #647 

The zoom-state of a participant can be toggled by double-tapping on the corresponding CallParticipantViewCell. The state is remembered _per cell_, which means it gets set back to default whenever the cell is reused (for example when a participant joins or leaves the call). We now store the zoom-state in the NCPeerConnection and can therefore restore it, when a cell is reused.

Not sure if we should dispatch the following to the main-thread?

https://github.com/nextcloud/talk-ios/blob/8e904206264bbdbeb3fb2e9b0ce1922f2d6c27a8/NextcloudTalk/CallViewController.m#L1186-L1193