### PR TITLE
Add all peers as participants, even if they don't publish streams

### DIFF
--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -687,6 +687,10 @@ static NSString * const kNCVideoTrackKind = @"video";
         NSString *peerKey = [sessionId stringByAppendingString:kRoomTypeVideo];
         if (![_connectionsDict objectForKey:peerKey] && ![_userSessionId isEqualToString:sessionId]) {
             if ([_externalSignalingController hasMCU]) {
+                // We request an offer to the MCU, but in case there are no streams published, we won't get an offer
+                // Make sure we still add the peer connection, otherwise the participant will be invisible
+                [self getPeerConnectionWrapperForSessionId:sessionId ofType:kRoomTypeVideo];
+                
                 NSLog(@"Requesting offer to the MCU for session: %@", sessionId);
                 [_externalSignalingController requestOfferForSessionId:sessionId andRoomType:kRoomTypeVideo];
             } else {


### PR DESCRIPTION
Attempt to fix #401 

When there are participants without streams, they are invisible in talk-ios at the moment. Now we add the peer immediately, without waiting for streams. Also moved setting properties of `CallParticipantViewCell` to a single function.
This should only affect external signaling as of now. 

I think the same should work for internal signaling:

https://github.com/nextcloud/talk-ios/blob/47bf3ebba51733afa18422f0949e8b914655cb0d/NextcloudTalk/NCCallController.m#L697-L704

We could call `getPeerConnectionWrapperForSessionId` in all cases. Any insights about this @Ivansss ?