### PR TITLE
Try to get displayName as early as possible

### DIFF
--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -461,13 +461,6 @@ static NSString * const kNCVideoTrackKind = @"video";
         
         if (displayName) {
             [peerConnectionWrapper setPeerName:displayName];
-        } else {
-            // Fallback to userId, when displayName can't be resolved
-            NSString *userId = [self getUserIdFromSessionId:sessionId];
-            
-            if (userId) {
-                [peerConnectionWrapper setPeerName:userId];
-            }
         }
         
         if (![_externalSignalingController hasMCU] || !screensharingPeer) {

--- a/NextcloudTalk/NCExternalSignalingController.h
+++ b/NextcloudTalk/NCExternalSignalingController.h
@@ -51,6 +51,7 @@
 - (void)sendCallMessage:(NCSignalingMessage *)message;
 - (void)requestOfferForSessionId:(NSString *)sessionId andRoomType:(NSString *)roomType;
 - (NSString *)getUserIdFromSessionId:(NSString *)sessionId;
+- (NSString *)getDisplayNameFromSessionId:(NSString *)sessionId;
 - (void)disconnect;
 - (void)forceReconnect;
 

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -471,6 +471,20 @@ static NSTimeInterval kMaxReconnectInterval     = 16;
     return userId;
 }
 
+- (NSString *)getDisplayNameFromSessionId:(NSString *)sessionId
+{
+    NSString *displayName = nil;
+    NSDictionary *user = [_participantsMap objectForKey:sessionId];
+    if (user) {
+        NSDictionary *userSubKey = [user objectForKey:@"user"];
+        
+        if (userSubKey) {
+            displayName = [userSubKey objectForKey:@"displayname"];
+        }
+    }
+    return displayName;
+}
+
 - (NSDictionary *)getWebSocketMessageFromJSONData:(NSData *)jsonData
 {
     NSError *error;


### PR DESCRIPTION
Try to get the display name of the participant as soon as we init `NCPeerConnection`.

This does not work for guests (at least with external signaling), because the displayName property is not available from the participant received by the signaling server.