### PR TITLE
Correctly process test notifications

### DIFF
--- a/NextcloudTalk/NCPushNotification.h
+++ b/NextcloudTalk/NCPushNotification.h
@@ -28,7 +28,8 @@ typedef NS_ENUM(NSInteger, NCPushNotificationType) {
     NCPushNotificationTypeRoom,
     NCPushNotificationTypeChat,
     NCPushNotificationTypeDelete,
-    NCPushNotificationTypeDeleteAll
+    NCPushNotificationTypeDeleteAll,
+    NCPushNotificationTypeAdminNotification
 };
 
 extern NSString * const kNCPNAppKey;

--- a/NextcloudTalk/NCPushNotification.m
+++ b/NextcloudTalk/NCPushNotification.m
@@ -24,17 +24,18 @@
 
 @implementation NCPushNotification
 
-NSString * const kNCPNAppKey            = @"app";
-NSString * const kNCPNAppIdKey          = @"spreed";
-NSString * const kNCPNTypeKey           = @"type";
-NSString * const kNCPNSubjectKey        = @"subject";
-NSString * const kNCPNIdKey             = @"id";
-NSString * const kNCPNNotifIdKey        = @"nid";
-NSString * const kNCPNTypeCallKey       = @"call";
-NSString * const kNCPNTypeRoomKey       = @"room";
-NSString * const kNCPNTypeChatKey       = @"chat";
-NSString * const kNCPNTypeDeleteKey     = @"delete";
-NSString * const kNCPNTypeDeleteAllKey  = @"delete-all";
+NSString * const kNCPNAppKey                    = @"app";
+NSString * const kNCPNAppIdKey                  = @"spreed";
+NSString * const kNCPNTypeKey                   = @"type";
+NSString * const kNCPNSubjectKey                = @"subject";
+NSString * const kNCPNIdKey                     = @"id";
+NSString * const kNCPNNotifIdKey                = @"nid";
+NSString * const kNCPNTypeCallKey               = @"call";
+NSString * const kNCPNTypeRoomKey               = @"room";
+NSString * const kNCPNTypeChatKey               = @"chat";
+NSString * const kNCPNTypeDeleteKey             = @"delete";
+NSString * const kNCPNTypeDeleteAllKey          = @"delete-all";
+NSString * const kNCPNAppIdAdminNotificationKey = @"admin_notification_talk";
 
 NSString * const NCPushNotificationJoinChatNotification                 = @"NCPushNotificationJoinChatNotification";
 NSString * const NCPushNotificationJoinAudioCallAcceptedNotification    = @"NCPushNotificationJoinAudioCallAcceptedNotification";
@@ -87,8 +88,17 @@ NSString * const NCPushNotificationJoinVideoCallAcceptedNotification    = @"NCPu
     } else if ([jsonNotification objectForKey:kNCPNTypeDeleteAllKey]) {
         pushNotification.type = NCPushNotificationTypeDeleteAll;
     } else {
-        return nil;
+        NSString *app = [jsonNotification objectForKey:kNCPNAppKey];
+        
+        if (![app isEqualToString:kNCPNAppIdAdminNotificationKey]) {
+            return nil;
+        }
+    
+        pushNotification.subject = [jsonNotification objectForKey:kNCPNSubjectKey];
+        pushNotification.notificationId = [[jsonNotification objectForKey:kNCPNNotifIdKey] integerValue];
+        pushNotification.type = NCPushNotificationTypeAdminNotification;
     }
+    
     pushNotification.accountId = accountId;
     return pushNotification;
 }

--- a/NotificationServiceExtension/NotificationService.m
+++ b/NotificationServiceExtension/NotificationService.m
@@ -99,6 +99,15 @@
                 if (decryptedMessage) {
                     NCPushNotification *pushNotification = [NCPushNotification pushNotificationFromDecryptedString:decryptedMessage withAccountId:account.accountId];
                     
+                    if (pushNotification.type == NCPushNotificationTypeAdminNotification) {
+                        // Test notification send through "occ notification:test-push --talk <userid>"
+                        // No need to increase the badge or query the server about it
+                        
+                        self.bestAttemptContent.body = pushNotification.subject;
+                        self.contentHandler(self.bestAttemptContent);
+                        return;
+                    }
+                    
                     // Update unread notifications counter for push notification account
                     [realm beginWriteTransaction];
                     NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@", account.accountId];

--- a/NotificationServiceExtension/NotificationService.m
+++ b/NotificationServiceExtension/NotificationService.m
@@ -88,6 +88,8 @@
     NSError *error = nil;
     RLMRealm *realm = [RLMRealm realmWithConfiguration:configuration error:&error];
     
+    BOOL foundDecryptableMessage = NO;
+    
     // Decrypt message
     NSString *message = [self.bestAttemptContent.userInfo objectForKey:@"subject"];
     for (TalkAccount *talkAccount in [TalkAccount allObjectsInRealm:realm]) {
@@ -107,6 +109,8 @@
                         self.contentHandler(self.bestAttemptContent);
                         return;
                     }
+                    
+                    foundDecryptableMessage = YES;
                     
                     // Update unread notifications counter for push notification account
                     [realm beginWriteTransaction];
@@ -178,6 +182,12 @@
                 NSLog(@"An error ocurred decrypting the message. %@", exception);
             }
         }
+    }
+    
+    if (!foundDecryptableMessage) {
+        // At this point we tried everything to decrypt the received message
+        // No need to wait for the extension timeout, nothing is happening anymore
+        self.contentHandler(self.bestAttemptContent);
     }
 }
 


### PR DESCRIPTION
Sending a test-notification through the following command: `occ notification:test-push --talk <userid>` results in "You received a new notification that could not be decrypted". This PR correctly processes those notifications. It makes also sure, that we don't wait for the extension timeout when we already know that nothing is happening anymore.

Related #693 

For reference, this is the payload which is send via the notification app:
```json
{
   "nid":32530,
   "app":"admin_notification_talk",
   "subject":"Testing push notifications",
   "type":"admin_notifications",
   "id":"61bc80a9"
}
```