### PR TITLE
Set the default realm-configuration when used in ShareExtension

### DIFF
--- a/ShareExtension/ShareViewController.m
+++ b/ShareExtension/ShareViewController.m
@@ -109,7 +109,11 @@
         // At the very minimum we need to update the version with an empty block to indicate that the schema has been upgraded (automatically) by Realm
     };
     NSError *error = nil;
+    
+    // Set the default configuration to make sure we always use the correct realm-file
+    [RLMRealmConfiguration setDefaultConfiguration:configuration];
     _realm = [RLMRealm realmWithConfiguration:configuration error:&error];
+    
     [self setupShareViewForAccount:nil];
     
     // Configure table views

--- a/ShareExtension/ShareViewController.m
+++ b/ShareExtension/ShareViewController.m
@@ -110,8 +110,10 @@
     };
     NSError *error = nil;
     
-    // Set the default configuration to make sure we always use the correct realm-file
-    [RLMRealmConfiguration setDefaultConfiguration:configuration];
+    // When running as an extension, set the default configuration to make sure we always use the correct realm-file
+    if ([[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"]) {
+        [RLMRealmConfiguration setDefaultConfiguration:configuration];
+    }
     _realm = [RLMRealm realmWithConfiguration:configuration error:&error];
     
     [self setupShareViewForAccount:nil];


### PR DESCRIPTION
This fixes the ShareExtension crashing with a "migration required" exception, although the log reports the same schema version.

This problem only occurs when multiple accounts are configured in talk-ios and a new version is installed with a higher schema version. The main problem comes from this line:
https://github.com/nextcloud/talk-ios/blob/901b57cd6237483817593532152bd328a2e2391d/ShareExtension/ShareViewController.m#L235
When multiple accounts are set up, NCAPIController is used to retrieve the profile image of the account. NCAPIController (when initalizing) iterates through the TalkAccounts, but with default configuration of realm (therefore creating a realm database in the ShareExtension folder and not using the one in the AppGroup). As realm isn't opened explicitly, no migration is happening on the database and the ShareExtension never loads. 

After removing accounts and making sure that there's only one account left, ShareExtension starts working again (basically confirming the above).

Stacktraces leading to the exception:
![image](https://user-images.githubusercontent.com/1580193/146610559-eb8e9481-0d31-4cd6-8cfa-46e9f854bf24.png)
![image](https://user-images.githubusercontent.com/1580193/146610568-bab2e36e-5e1c-4dc7-a65b-c645ec2e1e59.png)

Things to consider:
We might want to think about this explicit realm usage in ShareViewController (`_realm`), because (as far as I can see) this shouldn't be neccessary in this case anymore.
