### PR TITLE
Handle error while requesting call transaction.

### DIFF
--- a/NextcloudTalk/CallKitManager.h
+++ b/NextcloudTalk/CallKitManager.h
@@ -28,6 +28,7 @@ extern NSString * const CallKitManagerDidEndCallNotification;
 extern NSString * const CallKitManagerDidStartCallNotification;
 extern NSString * const CallKitManagerDidChangeAudioMuteNotification;
 extern NSString * const CallKitManagerWantsToUpgradeToVideoCall;
+extern NSString * const CallKitManagerDidFailRequestingCallTransaction;
 
 @interface CallKitCall : NSObject
 

--- a/NextcloudTalk/CallKitManager.m
+++ b/NextcloudTalk/CallKitManager.m
@@ -38,6 +38,7 @@ NSString * const CallKitManagerDidEndCallNotification           = @"CallKitManag
 NSString * const CallKitManagerDidStartCallNotification         = @"CallKitManagerDidStartCallNotification";
 NSString * const CallKitManagerDidChangeAudioMuteNotification   = @"CallKitManagerDidChangeAudioMuteNotification";
 NSString * const CallKitManagerWantsToUpgradeToVideoCall        = @"CallKitManagerWantsToUpgradeToVideoCall";
+NSString * const CallKitManagerDidFailRequestingCallTransaction = @"CallKitManagerDidFailRequestingCallTransaction";
 
 NSTimeInterval const kCallKitManagerMaxRingingTimeSeconds       = 45.0;
 NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 3.0;
@@ -400,6 +401,10 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 3.0;
                 [weakSelf.calls setObject:call forKey:callUUID];
             } else {
                 NSLog(@"%@", error.localizedDescription);
+                NSDictionary *userInfo = [NSDictionary dictionaryWithObject:token forKey:@"roomToken"];
+                [[NSNotificationCenter defaultCenter] postNotificationName:CallKitManagerDidFailRequestingCallTransaction
+                                                                    object:self
+                                                                  userInfo:userInfo];
             }
         }];
     // Send notification for video call upgrade.

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -2180,7 +2180,9 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         return;
     }
     
-    [self configureActionItems];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self configureActionItems];
+    });
 }
 
 #pragma mark - Chat Controller notifications

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -179,6 +179,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(connectionStateHasChanged:) name:NCConnectionStateHasChangedNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didFailRequestingCallTransaction:) name:CallKitManagerDidFailRequestingCallTransaction object:nil];
     }
     
     return self;
@@ -2168,6 +2169,18 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 - (void)didLeaveRoom:(NSNotification *)notification
 {
     [self disableRoomControls];
+}
+
+#pragma mark - CallKit Manager notifications
+
+- (void)didFailRequestingCallTransaction:(NSNotification *)notification
+{
+    NSString *roomToken = [notification.userInfo objectForKey:@"roomToken"];
+    if (![roomToken isEqualToString:_room.token]) {
+        return;
+    }
+    
+    [self configureActionItems];
 }
 
 #pragma mark - Chat Controller notifications


### PR DESCRIPTION
Starting a call from the chat view using the top right buttons fails some times (usually only on the first try after launching the app)
`The operation couldn’t be completed. (com.apple.CallKit.error.requesttransaction error 7.)`

This causes the call (or videocall) button keeps spinning forever.
This PR resets the call buttons if requesting the call transaction fails.