### PR TITLE
Fix scrollable message body

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -3083,7 +3083,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     CGRect bodyBounds = [message.parsedMessage boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX) options:(NSStringDrawingUsesLineFragmentOrigin|NSStringDrawingUsesFontLeading) context:NULL];
     
     CGFloat height = kChatCellAvatarHeight;
-    height += CGRectGetHeight(bodyBounds);
+    height += ceil(CGRectGetHeight(bodyBounds));
     height += 20.0; // right(10) + 2*left(5)
     
     if (height < kChatMessageCellMinimumHeight) {


### PR DESCRIPTION
Fix #701 

As mentioned in the `boundingRectWithSize` docs:

> In iOS 7 and later, this method returns fractional sizes (in the size component of the returned rectangle); to use a returned size to size views, you must use raise its value to the nearest higher integer using the ceil function.