### PR TITLE
Reduce load on the server when checking call state

### DIFF
--- a/NextcloudTalk/CallKitManager.m
+++ b/NextcloudTalk/CallKitManager.m
@@ -41,7 +41,7 @@ NSString * const CallKitManagerWantsToUpgradeToVideoCall        = @"CallKitManag
 NSString * const CallKitManagerDidFailRequestingCallTransaction = @"CallKitManagerDidFailRequestingCallTransaction";
 
 NSTimeInterval const kCallKitManagerMaxRingingTimeSeconds       = 45.0;
-NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 3.0;
+NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
 
 @interface CallKitManager () <CXProviderDelegate>
 

--- a/NextcloudTalk/CallKitManager.m
+++ b/NextcloudTalk/CallKitManager.m
@@ -347,10 +347,12 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
         NSInteger callAPIVersion = [[NCAPIController sharedInstance] callAPIVersionForAccount:account];
         for (NSMutableDictionary *user in peers) {
             NSString *userId = [user objectForKey:@"userId"];
+            BOOL isUserActorType = YES;
             if (callAPIVersion >= APIv3) {
                 userId = [user objectForKey:@"actorId"];
+                isUserActorType = [[user objectForKey:@"actorType"] isEqualToString:@"users"];
             }
-            if ([account.userId isEqualToString:userId]) {
+            if ([account.userId isEqualToString:userId] && isUserActorType) {
                 // Account is already in a call (answered the call on a different device) -> no need to keep ringing
                 [self endCallWithUUID:call.uuid];
                 return;


### PR DESCRIPTION
- [x] Use getPeersForCall instead of getParticipantsFromRoom to check call state (it is a lighter request for the server).
- [x] Increased the timer of the request to 5 secs (before 3 secs).