### PR TITLE
Enable/Disable call buttons when receiving call started/ended system messages

### DIFF
--- a/NextcloudTalk/NCChatController.h
+++ b/NextcloudTalk/NCChatController.h
@@ -36,6 +36,8 @@ extern NSString * const NCChatControllerDidReceiveChatBlockedNotification;
 extern NSString * const NCChatControllerDidReceiveNewerCommonReadMessageNotification;
 extern NSString * const NCChatControllerDidReceiveDeletedMessageNotification;
 extern NSString * const NCChatControllerDidReceiveHistoryClearedNotification;
+extern NSString * const NCChatControllerDidReceiveCallStartedMessageNotification;
+extern NSString * const NCChatControllerDidReceiveCallEndedMessageNotification;
 
 @interface NCChatController : NSObject
 

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -36,6 +36,8 @@ NSString * const NCChatControllerDidReceiveChatBlockedNotification              
 NSString * const NCChatControllerDidReceiveNewerCommonReadMessageNotification       = @"NCChatControllerDidReceiveNewerCommonReadMessageNotification";
 NSString * const NCChatControllerDidReceiveDeletedMessageNotification               = @"NCChatControllerDidReceiveDeletedMessageNotification";
 NSString * const NCChatControllerDidReceiveHistoryClearedNotification               = @"NCChatControllerDidReceiveHistoryClearedNotification";
+NSString * const NCChatControllerDidReceiveCallStartedMessageNotification           = @"NCChatControllerDidReceiveCallStartedMessageNotification";
+NSString * const NCChatControllerDidReceiveCallEndedMessageNotification             = @"NCChatControllerDidReceiveCallEndedMessageNotification";
 
 @interface NCChatController ()
 
@@ -359,6 +361,20 @@ NSString * const NCChatControllerDidReceiveHistoryClearedNotification           
         NSMutableDictionary *userInfo = [NSMutableDictionary new];
         
         for (NCChatMessage *message in storedMessages) {
+            // Notify if "call started" have been received
+            if ([message.systemMessage isEqualToString:@"call_started"]) {
+                [[NSNotificationCenter defaultCenter] postNotificationName:NCChatControllerDidReceiveCallStartedMessageNotification
+                                                                    object:self
+                                                                  userInfo:userInfo];
+            }
+            // Notify if "call eneded" have been received
+            if ([message.systemMessage isEqualToString:@"call_ended"] ||
+                [message.systemMessage isEqualToString:@"call_ended_everyone"] ||
+                [message.systemMessage isEqualToString:@"call_missed"]) {
+                [[NSNotificationCenter defaultCenter] postNotificationName:NCChatControllerDidReceiveCallEndedMessageNotification
+                                                                    object:self
+                                                                  userInfo:userInfo];
+            }
             // Notify if "deleted messages" have been received
             if ([message.systemMessage isEqualToString:@"message_deleted"]) {
                 [userInfo setObject:message forKey:@"deleteMessage"];
@@ -594,6 +610,20 @@ NSString * const NCChatControllerDidReceiveHistoryClearedNotification           
                         [[NCRoomsManager sharedInstance] updateLastMessage:message withNoUnreadMessages:YES forRoom:self->_room];
                     }
                     
+                    // Notify if "call started" have been received
+                    if ([message.systemMessage isEqualToString:@"call_started"]) {
+                        [[NSNotificationCenter defaultCenter] postNotificationName:NCChatControllerDidReceiveCallStartedMessageNotification
+                                                                            object:self
+                                                                          userInfo:userInfo];
+                    }
+                    // Notify if "call eneded" have been received
+                    if ([message.systemMessage isEqualToString:@"call_ended"] ||
+                        [message.systemMessage isEqualToString:@"call_ended_everyone"] ||
+                        [message.systemMessage isEqualToString:@"call_missed"]) {
+                        [[NSNotificationCenter defaultCenter] postNotificationName:NCChatControllerDidReceiveCallEndedMessageNotification
+                                                                            object:self
+                                                                          userInfo:userInfo];
+                    }
                     // Notify if "deleted messages" have been received
                     if ([message.systemMessage isEqualToString:@"message_deleted"]) {
                         [userInfo setObject:message forKey:@"deleteMessage"];

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -174,6 +174,8 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didSendChatMessage:) name:NCChatControllerDidSendChatMessageNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveChatBlocked:) name:NCChatControllerDidReceiveChatBlockedNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveNewerCommonReadMessage:) name:NCChatControllerDidReceiveNewerCommonReadMessageNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveCallStartedMessage:) name:NCChatControllerDidReceiveCallStartedMessageNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveCallEndedMessage:) name:NCChatControllerDidReceiveCallEndedMessageNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveDeletedMessage:) name:NCChatControllerDidReceiveDeletedMessageNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveHistoryCleared:) name:NCChatControllerDidReceiveHistoryClearedNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
@@ -2444,6 +2446,24 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     }
     
     [self checkLastCommonReadMessage];
+}
+
+- (void)didReceiveCallStartedMessage:(NSNotification *)notification
+{
+    if (notification.object != _chatController) {
+        return;
+    }
+    _room.hasCall = YES;
+    [self checkRoomControlsAvailability];
+}
+
+- (void)didReceiveCallEndedMessage:(NSNotification *)notification
+{
+    if (notification.object != _chatController) {
+        return;
+    }
+    _room.hasCall = NO;
+    [self checkRoomControlsAvailability];
 }
 
 - (void)didReceiveDeletedMessage:(NSNotification *)notification


### PR DESCRIPTION
Overwrite room.hasCall property when receiving call started/ended system messages.
After that we check if call buttons can be enabled or disabled.