### PR TITLE
Do not update reactionsSelf from room's lastMessage

### DIFF
--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -129,14 +129,14 @@ NSString * const NCChatControllerDidReceiveCallEndedMessageNotification         
         
         NCChatMessage *managedMessage = [NCChatMessage objectsWhere:@"internalId = %@", message.internalId].firstObject;
         if (managedMessage) {
-            [NCChatMessage updateChatMessage:managedMessage withChatMessage:message];
+            [NCChatMessage updateChatMessage:managedMessage withChatMessage:message isRoomLastMessage:NO];
         } else if (message) {
             [realm addObject:message];
         }
         
         NCChatMessage *managedParentMessage = [NCChatMessage objectsWhere:@"internalId = %@", parent.internalId].firstObject;
         if (managedParentMessage) {
-            [NCChatMessage updateChatMessage:managedParentMessage withChatMessage:parent];
+            [NCChatMessage updateChatMessage:managedParentMessage withChatMessage:parent isRoomLastMessage:NO];
         } else if (parent) {
             [realm addObject:parent];
         }

--- a/NextcloudTalk/NCChatMessage.h
+++ b/NextcloudTalk/NCChatMessage.h
@@ -66,7 +66,7 @@ RLM_ARRAY_TYPE(NCChatReaction)
 
 + (instancetype)messageWithDictionary:(NSDictionary *)messageDict;
 + (instancetype)messageWithDictionary:(NSDictionary *)messageDict andAccountId:(NSString *)accountId;
-+ (void)updateChatMessage:(NCChatMessage *)managedChatMessage withChatMessage:(NCChatMessage *)chatMessage;
++ (void)updateChatMessage:(NCChatMessage *)managedChatMessage withChatMessage:(NCChatMessage *)chatMessage isRoomLastMessage:(BOOL)isRoomLastMessage;
 
 - (BOOL)isSystemMessage;
 - (BOOL)isEmojiMessage;

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -126,7 +126,7 @@ NSString * const kMessageTypeVoiceMessage   = @"voice-message";
     return message;
 }
 
-+ (void)updateChatMessage:(NCChatMessage *)managedChatMessage withChatMessage:(NCChatMessage *)chatMessage
++ (void)updateChatMessage:(NCChatMessage *)managedChatMessage withChatMessage:(NCChatMessage *)chatMessage isRoomLastMessage:(BOOL)isRoomLastMessage
 {
     managedChatMessage.actorDisplayName = chatMessage.actorDisplayName;
     managedChatMessage.actorId = chatMessage.actorId;
@@ -138,7 +138,10 @@ NSString * const kMessageTypeVoiceMessage   = @"voice-message";
     managedChatMessage.isReplyable = chatMessage.isReplyable;
     managedChatMessage.messageType = chatMessage.messageType;
     managedChatMessage.reactionsJSONString = chatMessage.reactionsJSONString;
-    managedChatMessage.reactionsSelfJSONString = chatMessage.reactionsSelfJSONString;
+    
+    if (!isRoomLastMessage) {
+        managedChatMessage.reactionsSelfJSONString = chatMessage.reactionsSelfJSONString;
+    }
     
     if (!managedChatMessage.parentId && chatMessage.parentId) {
         managedChatMessage.parentId = chatMessage.parentId;

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -441,7 +441,7 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
     
     NCChatMessage *managedLastMessage = [NCChatMessage objectsWhere:@"internalId = %@", lastMessage.internalId].firstObject;
     if (managedLastMessage) {
-        [NCChatMessage updateChatMessage:managedLastMessage withChatMessage:lastMessage];
+        [NCChatMessage updateChatMessage:managedLastMessage withChatMessage:lastMessage isRoomLastMessage:YES];
     } else if (lastMessage) {
         NCChatController *chatController = [[NCChatController alloc] initForRoom:room];
         [chatController storeMessages:@[messageDict] withRealm:realm];


### PR DESCRIPTION
There are some chat message's attributes (`parent` and `reactionsSelf`) that are not exposed in room's `lastMessage`.
https://nextcloud-talk.readthedocs.io/en/latest/conversation/#get-user-s-conversations

We should not update those attributes when updating a message with a room's `lastMessage`
