### PR TITLE
Push notification subscription process fixes

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -175,7 +175,10 @@
 
 - (void)checkForPushNotificationSubscription
 {
-    if (normalPushToken && pushKitToken) {
+    BOOL isAppActive = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
+    // Subscribe only if both tokens have been generated and app is active (do not try to subscribe when
+    // the app is running in background e.g. when the app is launched due to a VoIP push notification)
+    if (normalPushToken && pushKitToken && isAppActive) {
         // Store new Normal Push & PushKit tokens in Keychain
         UICKeyChainStore *keychain = [UICKeyChainStore keyChainStoreWithService:bundleIdentifier accessGroup:groupIdentifier];
         [NCSettingsController sharedInstance].ncNormalPushToken = normalPushToken;

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -225,7 +225,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 - (NSURLSessionDataTask *)getServerNotification:(NSInteger)notificationId forAccount:(TalkAccount *)account withCompletionBlock:(GetServerNotificationCompletionBlock)block;
 
 // Push Notifications
-- (NSURLSessionDataTask *)subscribeAccount:(TalkAccount *)account toNextcloudServerWithCompletionBlock:(SubscribeToNextcloudServerCompletionBlock)block;
+- (NSURLSessionDataTask *)subscribeAccount:(TalkAccount *)account withPublicKey:(NSData *)publicKey toNextcloudServerWithCompletionBlock:(SubscribeToNextcloudServerCompletionBlock)block;
 - (NSURLSessionDataTask *)unsubscribeAccount:(TalkAccount *)account fromNextcloudServerWithCompletionBlock:(UnsubscribeToNextcloudServerCompletionBlock)block;
 - (NSURLSessionDataTask *)subscribeAccount:(TalkAccount *)account toPushServerWithCompletionBlock:(SubscribeToPushProxyCompletionBlock)block;
 - (NSURLSessionDataTask *)unsubscribeAccount:(TalkAccount *)account fromPushServerWithCompletionBlock:(UnsubscribeToPushProxyCompletionBlock)block;

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -2134,10 +2134,10 @@ NSInteger const kReceivedChatMessagesLimit = 100;
 
 #pragma mark - Push Notifications
 
-- (NSURLSessionDataTask *)subscribeAccount:(TalkAccount *)account toNextcloudServerWithCompletionBlock:(SubscribeToNextcloudServerCompletionBlock)block
+- (NSURLSessionDataTask *)subscribeAccount:(TalkAccount *)account withPublicKey:(NSData *)publicKey toNextcloudServerWithCompletionBlock:(SubscribeToNextcloudServerCompletionBlock)block
 {
     NSString *URLString = [NSString stringWithFormat:@"%@/ocs/v2.php/apps/notifications/api/v2/push", account.server];
-    NSString *devicePublicKey = [[NSString alloc] initWithData:account.pushNotificationPublicKey encoding:NSUTF8StringEncoding];
+    NSString *devicePublicKey = [[NSString alloc] initWithData:publicKey encoding:NSUTF8StringEncoding];
 
     NSDictionary *parameters = @{@"pushTokenHash" : [[NCKeyChainController sharedInstance] pushTokenSHA512],
                                  @"devicePublicKey" : devicePublicKey,

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -32,6 +32,12 @@ Please note that under rare circumstances apple will stop sending (call-)notific
     - If you're using Talk 13 or later, please note that notifications for chat messages and calls can be enabled/disabled independently for each conversation.
 - Also be aware that notifications are not generated when you have an active session for a conversation! This also applies for tabs that are open in the background, etc. You might want to check if there's still a browser open somewhere preventing notifications to be send to your device(s).
 
+## 🔒 Check app sessions
+
+- Using the web interface go to your Nextcloud "Settings" -> "Security"
+- Under "Devices & sessions" check if there are duplicate entries for the same device (e.g. iPhone (Nextcloud Talk))
+- Remove old duplicate entries and just leave the entry with the most recent "Last activity"
+
 ## 🖥 Check server settings
 
 Run the `notification:test-push` command for the user who is logged in at the device that should receive the notification:


### PR DESCRIPTION
- [x] Store push notifications key pair after subscription process is completed.
- [x] Do not try to subscribe for push notifications when the app is launched in the background due to a VoIP push notification.
- [x] Update "Debugging push notifications" document with information about app tokens.