### PR TITLE
Add login via custom URL

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -47,6 +47,7 @@
 #import "NCRoomsManager.h"
 #import "NCSettingsController.h"
 #import "NCUserInterfaceController.h"
+#import "NCUtils.h"
 
 #import "NextcloudTalk-Swift.h"
 
@@ -144,6 +145,15 @@
         NSString *action = urlComponents.host;
         if ([action isEqualToString:@"open-conversation"]) {
             [[NCUserInterfaceController sharedInstance] presentChatForURL:urlComponents];
+            return YES;
+        } else if ([action isEqualToString:@"login"] && multiAccountEnabled) {
+            NSArray *queryItems = urlComponents.queryItems;
+            NSString *server = [NCUtils valueForKey:@"server" fromQueryItems:queryItems];
+            NSString *user = [NCUtils valueForKey:@"user" fromQueryItems:queryItems];
+            
+            if (server) {
+                [[NCUserInterfaceController sharedInstance] presentLoginViewControllerForServerURL:server withUser:user];
+            }
             return YES;
         }
     }

--- a/NextcloudTalk/AuthenticationViewController.h
+++ b/NextcloudTalk/AuthenticationViewController.h
@@ -34,8 +34,9 @@
 
 @property (nonatomic, weak) id<AuthenticationViewControllerDelegate> delegate;
 
-@property(strong,nonatomic) WKWebView *webView;
+@property(strong, nonatomic) WKWebView *webView;
 @property(strong, nonatomic) NSString *serverUrl;
+@property(strong, nonatomic) NSString *user;
 
 - (id)initWithServerUrl:(NSString *)serverUrl;
 

--- a/NextcloudTalk/AuthenticationViewController.m
+++ b/NextcloudTalk/AuthenticationViewController.m
@@ -60,7 +60,15 @@ NSString * const kNCAuthTokenFlowEndpoint               = @"/index.php/login/flo
     [super viewDidLoad];
     WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
     configuration.websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
-    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", _serverUrl, kNCAuthTokenFlowEndpoint]];
+    
+    NSString *urlString = [NSString stringWithFormat:@"%@%@", _serverUrl, kNCAuthTokenFlowEndpoint];
+    
+    if (_user) {
+        urlString = [NSString stringWithFormat:@"%@?user=%@", urlString, _user];
+    }
+    
+    NSURL *url = [NSURL URLWithString:urlString];
+    
     
     NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
     for (NSHTTPCookie *cookie in [storage cookies])

--- a/NextcloudTalk/LoginViewController.h
+++ b/NextcloudTalk/LoginViewController.h
@@ -40,4 +40,6 @@
 @property (nonatomic, weak) IBOutlet UIButton *cancel;
 @property (nonatomic, weak) IBOutlet UIActivityIndicatorView *activityIndicatorView;
 
+- (void)startLoginProcessWithServerURL:(NSString *)serverURL withUser:(NSString *)user;
+
 @end

--- a/NextcloudTalk/LoginViewController.m
+++ b/NextcloudTalk/LoginViewController.m
@@ -175,20 +175,9 @@
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [[CCCertificate sharedManager] presentViewControllerCertificateWithTitle:[error localizedDescription] viewController:self delegate:self];
                 });
-            } else if ([error code] == NSURLErrorAppTransportSecurityRequiresSecureConnection ||
-                       [error code] == NSURLErrorBadServerResponse ||
-                       [error code] == NSURLErrorCannotConnectToHost ||
-                       [error code] == NSURLErrorCannotFindHost ||
-                       [error code] == NSURLErrorClientCertificateRejected ||
-                       [error code] == NSURLErrorHTTPTooManyRedirects ||
-                       [error code] == NSURLErrorNetworkConnectionLost ||
-                       [error code] == NSURLErrorServerCertificateHasBadDate ||
-                       [error code] == NSURLErrorServerCertificateHasUnknownRoot ||
-                       [error code] == NSURLErrorTimedOut) {
+            } else {
                 NSString *errorMessage = [NSString stringWithFormat:@"%@\n%@", [error localizedDescription], NSLocalizedString(@"Please check that you entered the correct Nextcloud server address.", nil)];
                 [self showAlertWithTitle:NSLocalizedString(@"Nextcloud server not found", nil) andMessage:errorMessage];
-            } else {
-                [self showAlertWithTitle:NSLocalizedString(@"Nextcloud server not found", nil) andMessage:NSLocalizedString(@"Please check that you entered the correct Nextcloud server address.", nil)];
             }
         }
     }];

--- a/NextcloudTalk/LoginViewController.m
+++ b/NextcloudTalk/LoginViewController.m
@@ -31,7 +31,6 @@
 @interface LoginViewController () <UITextFieldDelegate, CCCertificateDelegate, AuthenticationViewControllerDelegate>
 {
     AuthenticationViewController *_authenticationViewController;
-    NSString *_serverURL;
 }
 
 @end
@@ -102,32 +101,7 @@
         return;
     }
     
-    _serverURL = serverInputText;
-    
-    // Check whether baseUrl contain protocol. If not add https:// by default.
-    if(![_serverURL hasPrefix:@"https"] && ![_serverURL hasPrefix:@"http"]) {
-        _serverURL = [NSString stringWithFormat:@"https://%@",_serverURL];
-    }
-    
-    // Remove trailing slash
-    if([_serverURL hasSuffix:@"/"]) {
-        _serverURL = [_serverURL substringToIndex:[_serverURL length] - 1];
-    }
-    
-    // Remove stored cookies
-    NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    for (NSHTTPCookie *cookie in [storage cookies])
-    {
-        [storage deleteCookie:cookie];
-    }
-    
-    // Check if valid URL
-    NSURL *serverURL = [NSURL URLWithString:_serverURL];
-    if (serverURL) {
-        [self startLoginProcess];
-    } else {
-        [self showAlertWithTitle:NSLocalizedString(@"Invalid server address", nil) andMessage:NSLocalizedString(@"Please check that you entered a valid server address.", nil)];
-    }
+    [self startLoginProcessWithServerURL:serverInputText withUser:nil];
 }
 
 - (IBAction)cancel:(id)sender
@@ -148,18 +122,44 @@
 
 #pragma mark - Login
 
-- (void)startLoginProcess
+- (void)startLoginProcessWithServerURL:(NSString *)serverURL withUser:(NSString *)user
 {
+    // Check whether baseUrl contain protocol. If not add https:// by default.
+    if(![serverURL hasPrefix:@"https"] && ![serverURL hasPrefix:@"http"]) {
+        serverURL = [NSString stringWithFormat:@"https://%@",serverURL];
+    }
+    
+    // Remove trailing slash
+    if([serverURL hasSuffix:@"/"]) {
+        serverURL = [serverURL substringToIndex:[serverURL length] - 1];
+    }
+        
+    // Check if valid URL
+    NSURL *validServerURL = [NSURL URLWithString:serverURL];
+    if (!validServerURL) {
+        [self showAlertWithTitle:NSLocalizedString(@"Invalid server address", nil) andMessage:NSLocalizedString(@"Please check that you entered a valid server address.", nil)];
+        return;
+    }
+    
+    [self.serverUrl setText:serverURL];
+    
+    // Remove stored cookies
+    NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+    for (NSHTTPCookie *cookie in [storage cookies])
+    {
+        [storage deleteCookie:cookie];
+    }
+    
     [self.activityIndicatorView startAnimating];
     self.activityIndicatorView.hidden = NO;
-    [[NCAPIController sharedInstance] getServerCapabilitiesForServer:_serverURL withCompletionBlock:^(NSDictionary *serverCapabilities, NSError *error) {
+    [[NCAPIController sharedInstance] getServerCapabilitiesForServer:serverURL withCompletionBlock:^(NSDictionary *serverCapabilities, NSError *error) {
         [self.activityIndicatorView stopAnimating];
         self.activityIndicatorView.hidden = YES;
         if (!error) {
             NSArray *talkFeatures = [[[serverCapabilities objectForKey:@"capabilities"] objectForKey:@"spreed"] objectForKey:@"features"];
             // Check minimum required version
             if ([talkFeatures containsObject:kMinimumRequiredTalkCapability]) {
-                [self presentAuthenticationView];
+                [self presentAuthenticationViewWithServerURL:serverURL withUser:user];
             } else if (talkFeatures.count == 0) {
                 NSString *title = [NSString stringWithFormat:NSLocalizedString(@"%@ not installed", @"{app name} is not installed"), talkAppName];
                 NSString *message = [NSString stringWithFormat:NSLocalizedString(@"It seems that %@ is not installed in your server.", @"It seems that {app name} is not installed in your server."), talkAppName];
@@ -183,10 +183,15 @@
     }];
 }
 
-- (void)presentAuthenticationView
+- (void)presentAuthenticationViewWithServerURL:(NSString *)serverURL withUser:(NSString *)user
 {
-    _authenticationViewController = [[AuthenticationViewController alloc] initWithServerUrl:_serverURL];
+    _authenticationViewController = [[AuthenticationViewController alloc] initWithServerUrl:serverURL];
     _authenticationViewController.delegate = self;
+    
+    if (user) {
+        _authenticationViewController.user = user;
+    }
+    
     [self presentViewController:_authenticationViewController animated:YES completion:nil];
 }
 

--- a/NextcloudTalk/NCUserInterfaceController.h
+++ b/NextcloudTalk/NCUserInterfaceController.h
@@ -45,5 +45,6 @@
 - (void)presentCallViewController:(CallViewController *)callViewController;
 - (void)presentCallKitCallInRoom:(NSString *)token withVideoEnabled:(BOOL)video;
 - (void)presentChatForURL:(NSURLComponents *)urlComponents;
+- (void)presentLoginViewControllerForServerURL:(NSString *)serverURL withUser:(NSString *)user;
 
 @end

--- a/NextcloudTalk/NCUserInterfaceController.m
+++ b/NextcloudTalk/NCUserInterfaceController.m
@@ -98,16 +98,38 @@
 
 - (void)presentLoginViewController
 {
+    [self presentLoginViewControllerForServerURL:nil withUser:nil];
+}
+
+- (void)presentLoginViewControllerForServerURL:(NSString *)serverURL withUser:(NSString *)user
+{
     if (forceDomain && domain) {
         _authViewController = [[AuthenticationViewController alloc] initWithServerUrl:domain];
         _authViewController.delegate = self;
         _authViewController.modalPresentationStyle = ([[NCDatabaseManager sharedInstance] numberOfAccounts] == 0) ? UIModalPresentationFullScreen : UIModalPresentationAutomatic;
         [_mainNavigationController presentViewController:_authViewController animated:YES completion:nil];
     } else {
-        _loginViewController = [[LoginViewController alloc] init];
-        _loginViewController.delegate = self;
-        _loginViewController.modalPresentationStyle = ([[NCDatabaseManager sharedInstance] numberOfAccounts] == 0) ? UIModalPresentationFullScreen : UIModalPresentationAutomatic;
-        [_mainNavigationController presentViewController:_loginViewController animated:YES completion:nil];
+        // Don't open a login if we're in a call
+        if ([[NCRoomsManager sharedInstance] callViewController]) {
+            return;
+        }
+        
+        // Leave chat if we're currently in one
+        if ([[NCRoomsManager sharedInstance] chatViewController]) {
+            [self presentConversationsList];
+        }
+        
+        if (!_loginViewController || [_mainNavigationController presentedViewController] != _loginViewController) {
+            _loginViewController = [[LoginViewController alloc] init];
+            _loginViewController.delegate = self;
+            _loginViewController.modalPresentationStyle = ([[NCDatabaseManager sharedInstance] numberOfAccounts] == 0) ? UIModalPresentationFullScreen : UIModalPresentationAutomatic;
+            
+            [_mainNavigationController presentViewController:_loginViewController animated:YES completion:nil];
+        }
+        
+        if (serverURL) {
+            [_loginViewController startLoginProcessWithServerURL:serverURL withUser:user];
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to start the login process with a custom URL:
```
nextcloudtalk://login?server={serverURL}
nextcloudtalk://login?server={serverURL}&user={user}
```

The optional user parameter only works on NC >= 24

Fixes #234 (although already closed)