### PR TITLE
Add hint to translate 'Open conversations'

### DIFF
--- a/NextcloudTalk/RoomSearchTableViewController.m
+++ b/NextcloudTalk/RoomSearchTableViewController.m
@@ -134,7 +134,7 @@ typedef enum RoomSearchSection {
 {
     switch (section) {
         case RoomSearchSectionListable:
-            return NSLocalizedString(@"Open conversations", nil);
+            return NSLocalizedString(@"Open conversations", @"TRANSLATORS 'Open conversations' as a type of conversation. 'Open conversations' are conversations that can be found by other users");
         default:
             return nil;
     }

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -823,7 +823,7 @@
 /* No comment provided by engineer. */
 "Only visible to people on this instance and guests" = "Only visible to people on this instance and guests";
 
-/* No comment provided by engineer. */
+/* TRANSLATORS 'Open conversations' as a type of conversation. 'Open conversations' are conversations that can be found by other users */
 "Open conversations" = "Open conversations";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
It's currently not obvious how to translate "Open conversations", for example when translated to german:

![image](https://user-images.githubusercontent.com/1580193/173207067-05303a1b-ea0b-4fee-8689-80fe4466f539.png)

I suggest we add a hint to properly translate this.