### PR TITLE
Fix date formatting when searching

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -789,7 +789,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         // Lobby timer
         if (_room.lobbyTimer > 0) {
             NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:_room.lobbyTimer];
-            NSString *meetingStart = [NCUtils readableDateFromDate:date];
+            NSString *meetingStart = [NCUtils readableDateTimeFromDate:date];
             placeHolderText = [placeHolderText stringByAppendingString:[NSString stringWithFormat:@"\n\n%@\n%@", NSLocalizedString(@"This meeting is scheduled for", @"The meeting start time will be displayed after this text e.g (This meeting is scheduled for tomorrow at 10:00)"), meetingStart]];
         }
         // Room description

--- a/NextcloudTalk/NCUtils.h
+++ b/NextcloudTalk/NCUtils.h
@@ -38,7 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 // https://www.php.net/manual/en/class.datetimeinterface.php#datetime.constants.atom
 + (NSDate *)dateFromDateAtomFormat:(NSString *)dateAtomFormatString;
 + (NSString *)dateAtomFormatFromDate:(NSDate *)date;
-+ (NSString *)readableDateFromDate:(NSDate *)date;
++ (NSString *)readableDateTimeFromDate:(NSDate *)date;
++ (NSString *)readableTimeOrDateFromDate:(NSDate *)date;
 + (NSString *)getTimeFromDate:(NSDate *)date;
 + (NSString *)relativeTimeFromDate:(NSDate *)date;
 

--- a/NextcloudTalk/NCUtils.m
+++ b/NextcloudTalk/NCUtils.m
@@ -29,6 +29,8 @@
 
 #import "NCDatabaseManager.h"
 #import "NCUserDefaults.h"
+#import "NSDate+DateTools.h"
+
 
 static NSString *const nextcloudScheme = @"nextcloud:";
 
@@ -143,13 +145,27 @@ static NSString *const nextcloudScheme = @"nextcloud:";
     
     return [dateFormatter stringFromDate:date];
 }
-+ (NSString *)readableDateFromDate:(NSDate *)date
++ (NSString *)readableDateTimeFromDate:(NSDate *)date
 {
     NSDateFormatter* dateFormatter = [[NSDateFormatter alloc] init];
     [dateFormatter setDateStyle:NSDateFormatterMediumStyle];
     [dateFormatter setTimeStyle:NSDateFormatterShortStyle];
     dateFormatter.doesRelativeDateFormatting = YES;
     return [dateFormatter stringFromDate:date];
+}
+
++ (NSString *)readableTimeOrDateFromDate:(NSDate *)date
+{
+    if ([date isToday]) {
+        return [self getTimeFromDate:date];
+    } else if ([date isYesterday]) {
+        return NSLocalizedString(@"Yesterday", nil);
+    }
+    
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    [formatter setTimeStyle:NSDateFormatterNoStyle];
+    [formatter setDateStyle:NSDateFormatterShortStyle];
+    return [formatter stringFromDate:date];
 }
 
 + (NSString *)getTimeFromDate:(NSDate *)date

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -978,7 +978,7 @@ typedef enum FileAction {
     NSInteger lobbyTimer = _lobbyDatePicker.date.timeIntervalSince1970;
     [self setLobbyState:NCRoomLobbyStateModeratorsOnly withTimer:lobbyTimer];
     
-    NSString *lobbyTimerReadable = [NCUtils readableDateFromDate:_lobbyDatePicker.date];
+    NSString *lobbyTimerReadable = [NCUtils readableDateTimeFromDate:_lobbyDatePicker.date];
     _lobbyDateTextField.text = [NSString stringWithFormat:@"%@",lobbyTimerReadable];
     [self dismissLobbyDatePicker];
 }
@@ -1756,7 +1756,7 @@ typedef enum FileAction {
                     cell.selectionStyle = UITableViewCellSelectionStyleNone;
                     cell.accessoryView = _lobbyDateTextField;
                     NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:_room.lobbyTimer];
-                    _lobbyDateTextField.text = _room.lobbyTimer > 0 ? [NCUtils readableDateFromDate:date] : nil;
+                    _lobbyDateTextField.text = _room.lobbyTimer > 0 ? [NCUtils readableDateTimeFromDate:date] : nil;
                     [cell.imageView setImage:[UIImage imageNamed:@"timer"]];
                     
                     return cell;

--- a/NextcloudTalk/RoomSearchTableViewController.m
+++ b/NextcloudTalk/RoomSearchTableViewController.m
@@ -22,7 +22,6 @@
 
 #import "RoomSearchTableViewController.h"
 
-#import "NSDate+DateTools.h"
 #import "UIImageView+AFNetworking.h"
 
 #import "NCAPIController.h"
@@ -30,6 +29,7 @@
 #import "NCDatabaseManager.h"
 #import "NCRoom.h"
 #import "NCSettingsController.h"
+#import "NCUtils.h"
 #import "PlaceholderView.h"
 #import "RoomTableViewCell.h"
 
@@ -76,19 +76,6 @@ typedef enum RoomSearchSection {
 }
 
 #pragma mark - Utils
-
-- (NSString *)getDateLabelStringForDate:(NSDate *)date
-{
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    if ([date isToday]) {
-        [formatter setDateFormat:@"HH:mm"];
-    } else if ([date isYesterday]) {
-        return NSLocalizedString(@"Yesterday", nil);
-    } else {
-        [formatter setDateFormat:@"dd/MM/yy"];
-    }
-    return [formatter stringFromDate:date];
-}
 
 - (NCRoom *)roomForIndexPath:(NSIndexPath *)indexPath
 {
@@ -160,7 +147,7 @@ typedef enum RoomSearchSection {
         cell.titleOnly = YES;
     }
     NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:room.lastActivity];
-    cell.dateLabel.text = [self getDateLabelStringForDate:date];
+    cell.dateLabel.text = [NCUtils readableTimeOrDateFromDate:date];
     
     // Set unread messages
     if ([[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityDirectMentionFlag]) {

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -26,7 +26,6 @@
 
 #import "AFNetworking.h"
 #import "AFImageDownloader.h"
-#import "NSDate+DateTools.h"
 #import "UIButton+AFNetworking.h"
 #import "UIImageView+AFNetworking.h"
 
@@ -971,20 +970,6 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
 
 #pragma mark - Utils
 
-- (NSString *)getDateLabelStringForDate:(NSDate *)date
-{
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    if ([date isToday]) {
-        [formatter setDateFormat:@"HH:mm"];
-    } else if ([date isYesterday]) {
-        return NSLocalizedString(@"Yesterday", nil);
-    } else {
-        [formatter setTimeStyle:NSDateFormatterNoStyle];
-        [formatter setDateStyle:NSDateFormatterShortStyle];
-    }
-    return [formatter stringFromDate:date];
-}
-
 - (NCRoom *)roomForIndexPath:(NSIndexPath *)indexPath
 {
     if (_searchController.active && !_resultTableViewController.view.isHidden) {
@@ -1100,7 +1085,7 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
         cell.titleOnly = YES;
     }
     NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:room.lastActivity];
-    cell.dateLabel.text = [self getDateLabelStringForDate:date];
+    cell.dateLabel.text = [NCUtils readableTimeOrDateFromDate:date];
     
     // Set unread messages
     if ([[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityDirectMentionFlag]) {


### PR DESCRIPTION
When searching for rooms the date formatting is always `dd/MM/yy` instead of the localized version.

Before:
![image](https://user-images.githubusercontent.com/1580193/173207665-67d2c502-ff71-4948-b1e6-90f9cd47e690.png)

After:
![image](https://user-images.githubusercontent.com/1580193/173207681-371a726a-c348-4083-8b7f-254dd7e881a5.png)

