### PR TITLE
Handle X-Nextcloud-Talk-Hash

### DIFF
--- a/NextcloudTalk/NCDatabaseManager.h
+++ b/NextcloudTalk/NCDatabaseManager.h
@@ -84,6 +84,7 @@ extern NSString * const kMinimumRequiredTalkCapability;
 - (NSInteger)numberOfUnreadNotifications;
 - (NSInteger)numberOfInactiveAccountsWithUnreadNotifications;
 - (void)removeUnreadNotificationForInactiveAccounts;
+- (void)updateTalkConfigurationHashForAccountId:(NSString *)accountId withHash:(NSString *)hash;
 
 - (ServerCapabilities *)serverCapabilitiesForAccountId:(NSString *)accountId;
 - (void)setServerCapabilities:(NSDictionary *)serverCapabilities forAccountId:(NSString *)accountId;

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -31,7 +31,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 32;
+uint64_t const kTalkDatabaseSchemaVersion           = 33;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";
@@ -283,6 +283,16 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
     for (TalkAccount *account in [TalkAccount allObjects]) {
         account.unreadNotification = NO;
     }
+    [realm commitWriteTransaction];
+}
+
+- (void)updateTalkConfigurationHashForAccountId:(NSString *)accountId withHash:(nonnull NSString *)hash
+{
+    RLMRealm *realm = [RLMRealm defaultRealm];
+    [realm beginWriteTransaction];
+    NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@", accountId];
+    TalkAccount *account = [TalkAccount objectsWithPredicate:query].firstObject;
+    account.lastReceivedConfigurationHash = hash;
     [realm commitWriteTransaction];
 }
 

--- a/NextcloudTalk/NotificationCenterNotifications.h
+++ b/NextcloudTalk/NotificationCenterNotifications.h
@@ -31,5 +31,6 @@ extern NSString * const NCUserProfileImageUpdatedNotification;
 extern NSString * const NCTokenRevokedResponseReceivedNotification;
 extern NSString * const NCURLWantsToOpenConversationNotification;
 extern NSString * const NCServerMaintenanceModeNotification;
+extern NSString * const NCTalkConfigurationHashChangedNotification;
 
 NS_ASSUME_NONNULL_END

--- a/NextcloudTalk/NotificationCenterNotifications.m
+++ b/NextcloudTalk/NotificationCenterNotifications.m
@@ -29,4 +29,5 @@ NSString * const NCUserProfileImageUpdatedNotification = @"NCUserProfileImageUpd
 NSString * const NCTokenRevokedResponseReceivedNotification = @"NCTokenRevokedResponseReceivedNotification";
 NSString * const NCURLWantsToOpenConversationNotification = @"NCURLWantsToOpenConversationNotification";
 NSString * const NCServerMaintenanceModeNotification = @"NCServerMaintenanceModeNotification";
+NSString * const NCTalkConfigurationHashChangedNotification = @"NCTalkConfigurationHashChangedNotification";
 

--- a/NextcloudTalk/TalkAccount.h
+++ b/NextcloudTalk/TalkAccount.h
@@ -55,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property BOOL hasCustomAvatar;
 @property BOOL hasContactSyncEnabled;
 @property BOOL active;
+@property NSString *lastReceivedConfigurationHash;
 
 @end
 


### PR DESCRIPTION
Fixes #318 

Current code contains a comment about `SetSignalingConfiguration`: 

> SetSignalingConfiguration should be called just once.

I'm not sure if it's enough (for all cases) to just disconnect a currently used external signaling server and create a new instance of `NCExternalSignalingController` ?

https://github.com/nextcloud/talk-ios/blob/ee9d38de75d877e55bd5b6287828b7c50658cecc/NextcloudTalk/NCSettingsController.m#L446-L454