### PR TITLE
Use better name for "Send silently" option.

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1153,7 +1153,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
                                                                                 message:nil
                                                                          preferredStyle:UIAlertControllerStyleActionSheet];
     
-    UIAlertAction *silentSendAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Send silently", nil)
+    UIAlertAction *silentSendAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Send without notification", nil)
                                                                style:UIAlertActionStyleDefault
                                                              handler:^void (UIAlertAction *action) {
         [self sendCurrentMessageSilently:YES];

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -983,7 +983,7 @@
 "Send options" = "Send options";
 
 /* No comment provided by engineer. */
-"Send silently" = "Send silently";
+"Send without notification" = "Send without notification";
 
 /* No comment provided by engineer. */
 "Send/Accept" = "Send/Accept";


### PR DESCRIPTION
As discussed, we will use "Send without notification" for silent-sent option.