### PR TITLE
SwiftLint M1 / Comment

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -1585,7 +1585,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		2C8035721F950BA800501B5C /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ $ git submodule update --init
 $ open NextcloudTalk.xcworkspace
 ```
 
+Pull Requests will be checked with [SwiftLint](https://github.com/realm/SwiftLint). We strongly encourage the installation of SwiftLint to detect issues as early as possible.
+
 ## WebRTC library
 
 We are using our own builds of the WebRTC library. They can be found in this [repository](https://github.com/nextcloud-releases/talk-clients-webrtc)


### PR DESCRIPTION
https://github.com/realm/SwiftLint#xcode

When SwiftLint is installed via Homebrew on M1 Macs it won't be detected by default, because it's installed in `/opt/homebrew/bin` instead of `/usr/local/bin/`. This can be solved either by creating a symbolic link or by adding `/opt/homebrew/bin` to the path env before invoking SwiftLint (see link above).
This PR adds `/opt/homebrew/bin` to path env and also adds a comment about SwiftLint to the README.