### PR TITLE
Style cleanup

### DIFF
--- a/NextcloudTalk/AccountTableViewCell.swift
+++ b/NextcloudTalk/AccountTableViewCell.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @author Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// Author Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 

--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -262,7 +262,7 @@
     [self checkForPushNotificationSubscription];
 }
 
-- (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type
+- (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(PKPushType)type withCompletionHandler:(void (^)(void))completion
 {
     NSString *message = [payload.dictionaryPayload objectForKey:@"subject"];
     for (TalkAccount *talkAccount in [TalkAccount allObjects]) {
@@ -278,6 +278,8 @@
             }
         }
     }
+
+    completion();
 }
 
 - (NSString *)stringWithDeviceToken:(NSData *)deviceToken

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1355,7 +1355,7 @@ typedef NS_ENUM(NSInteger, CallState) {
         NSIndexPath *indexPath = [self indexPathForPeerId:peer.peerId];
         if (!indexPath) {
             [self->_peersInCall addObject:peer];
-            NSIndexPath *insertionIndexPath = [NSIndexPath indexPathForRow:_peersInCall.count - 1 inSection:0];
+            NSIndexPath *insertionIndexPath = [NSIndexPath indexPathForRow:self->_peersInCall.count - 1 inSection:0];
             [self.collectionView insertItemsAtIndexPaths:@[insertionIndexPath]];
         }
     });
@@ -1420,7 +1420,7 @@ typedef NS_ENUM(NSInteger, CallState) {
             NSIndexPath *indexPath = [self indexPathForPeerId:remotePeer.peerId];
             if (!indexPath) {
                 [self->_peersInCall addObject:remotePeer];
-                NSIndexPath *insertionIndexPath = [NSIndexPath indexPathForRow:_peersInCall.count - 1 inSection:0];
+                NSIndexPath *insertionIndexPath = [NSIndexPath indexPathForRow:self->_peersInCall.count - 1 inSection:0];
                 [self.collectionView insertItemsAtIndexPaths:@[insertionIndexPath]];
             } else {
                 [self.collectionView reloadItemsAtIndexPaths:@[indexPath]];
@@ -1603,7 +1603,7 @@ typedef NS_ENUM(NSInteger, CallState) {
         for (RTCEAGLVideoView *rendererView in [self->_videoRenderersDict allValues]) {
             if ([videoView isEqual:rendererView]) {
                 rendererView.frame = CGRectMake(0, 0, size.width, size.height);
-                NSArray *keys = [_videoRenderersDict allKeysForObject:videoView];
+                NSArray *keys = [self->_videoRenderersDict allKeysForObject:videoView];
                 if (keys.count) {
                     NSIndexPath *indexPath = [self indexPathForPeerId:keys[0]];
                     if (indexPath) {

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -428,7 +428,7 @@ typedef NS_ENUM(NSInteger, CallState) {
 
 - (void)setLocalVideoRect
 {
-    CGSize localVideoSize = CGSizeMake(0, 0);
+    CGSize localVideoSize;
     
     CGFloat width = [UIScreen mainScreen].bounds.size.width / 6;
     CGFloat height = [UIScreen mainScreen].bounds.size.height / 6;

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -263,6 +263,8 @@ typedef NS_ENUM(NSInteger, CallState) {
 
 - (void)viewWillAppear:(BOOL)animated
 {
+    [super viewWillAppear:animated];
+
     [self setLocalVideoRect];
     
     // Fix missing hallo after the view controller disappears
@@ -281,6 +283,8 @@ typedef NS_ENUM(NSInteger, CallState) {
 
 - (void)viewDidAppear:(BOOL)animated
 {
+    [super viewDidAppear:animated];
+
     [[UIDevice currentDevice] setProximityMonitoringEnabled:YES];
     [UIApplication sharedApplication].idleTimerDisabled = YES;
 }

--- a/NextcloudTalk/DateLabelCustom.swift
+++ b/NextcloudTalk/DateLabelCustom.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2021 Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @author Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2021 Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// Author Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 

--- a/NextcloudTalk/DebounceWebView.swift
+++ b/NextcloudTalk/DebounceWebView.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Marcel Müller <marcel-mueller@gmx.de>
- *
- * @author Marcel Müller <marcel-mueller@gmx.de>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import WebKit
 

--- a/NextcloudTalk/DebounceWebView.swift
+++ b/NextcloudTalk/DebounceWebView.swift
@@ -27,13 +27,13 @@ class DebounceWebView: WKWebView {
     // See: https://developer.apple.com/forums/thread/696525?answerId=708067022#708067022
     override func paste(_ sender: Any?) {
         if #available(iOS 14.0, *) {
-            if ProcessInfo.processInfo.isiOSAppOnMac  {
+            if ProcessInfo.processInfo.isiOSAppOnMac {
                 let currentPasteTimestamp: TimeInterval = Date().timeIntervalSinceReferenceDate
-                
+
                 if currentPasteTimestamp - previousPasteTimestamp < 0.2 {
                     return
                 }
-                
+
                 previousPasteTimestamp = currentPasteTimestamp
             }
         }

--- a/NextcloudTalk/DiagnosticsTableViewController.swift
+++ b/NextcloudTalk/DiagnosticsTableViewController.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Marcel Müller <marcel-mueller@gmx.de>
- *
- * @author Marcel Müller <marcel-mueller@gmx.de>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 import Contacts

--- a/NextcloudTalk/DirectoryTableViewController.m
+++ b/NextcloudTalk/DirectoryTableViewController.m
@@ -143,16 +143,11 @@
     [optionsActionSheet addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil) style:UIAlertActionStyleCancel handler:nil]];
     
     UIAlertAction *selectedAction = modificationDate;
-    switch ([[NCSettingsController sharedInstance] getPreferredFileSorting]) {
-        case NCAlphabeticalSorting:
-            selectedAction = alphabetical;
-            break;
-        case NCModificationDateSorting:
-            selectedAction = modificationDate;
-            break;
-        default:
-            break;
+
+    if ([[NCSettingsController sharedInstance] getPreferredFileSorting] == NCAlphabeticalSorting) {
+        selectedAction = alphabetical;
     }
+
     [selectedAction setValue:[[UIImage imageNamed:@"checkmark"] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal] forKey:@"image"];
     
     // Presentation on iPads
@@ -188,16 +183,11 @@
 - (void)sortItemsInDirectory
 {
     NSSortDescriptor *valueDescriptor = [[NSSortDescriptor alloc] initWithKey:@"date" ascending:NO];
-    switch ([[NCSettingsController sharedInstance] getPreferredFileSorting]) {
-        case NCAlphabeticalSorting:
-            valueDescriptor = [[NSSortDescriptor alloc] initWithKey:@"fileName" ascending:YES selector:@selector(localizedCaseInsensitiveCompare:)];
-            break;
-        case NCModificationDateSorting:
-            valueDescriptor = [[NSSortDescriptor alloc] initWithKey:@"date" ascending:NO];
-            break;
-        default:
-            break;
+
+    if ([[NCSettingsController sharedInstance] getPreferredFileSorting] == NCAlphabeticalSorting) {
+        valueDescriptor = [[NSSortDescriptor alloc] initWithKey:@"fileName" ascending:YES selector:@selector(localizedCaseInsensitiveCompare:)];
     }
+
     NSArray *descriptors = [NSArray arrayWithObjects:valueDescriptor, nil];
     [_itemsInDirectory sortUsingDescriptors:descriptors];
     [self.tableView reloadData];

--- a/NextcloudTalk/EmojiUtils.swift
+++ b/NextcloudTalk/EmojiUtils.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2020 Marcel Müller <marcel-mueller@gmx.de>
- *
- * @author Marcel Müller <marcel-mueller@gmx.de>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2020 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import Foundation
 

--- a/NextcloudTalk/GeoLocationRichObject.m
+++ b/NextcloudTalk/GeoLocationRichObject.m
@@ -62,7 +62,7 @@ NSString * const GeoLocationRichObjectType = @"geo-location";
 - (NSDictionary *)richObjectDictionary
 {
     NSError *error;
-    NSString *jsonString = nil;
+    NSString *jsonString = @"";
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:[self metaData]
                                                        options:0
                                                          error:&error];

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1594,11 +1594,6 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 
 #pragma mark - UIDocumentPickerViewController Delegate
 
-- (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentAtURL:(NSURL *)url
-{
-    [self shareDocumentsWithURLs:@[url] fromController:controller];
-}
-
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls
 {
     [self shareDocumentsWithURLs:urls fromController:controller];

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1693,8 +1693,6 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         vcString = [vcString stringByReplacingOccurrencesOfString:@"END:VCARD" withString:[vcardImageString stringByAppendingString:@"END:VCARD"]];
     }
     
-    vCardData = [vcString dataUsingEncoding:NSUTF8StringEncoding];
-    
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *folderPath = [paths objectAtIndex:0];
     NSString *filePath = [folderPath stringByAppendingPathComponent:@"contact.vcf"];
@@ -3366,7 +3364,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 
 - (UITableViewCell *)getCellForMessage:(NCChatMessage *) message
 {
-    UITableViewCell *cell = [UITableViewCell new];
+    UITableViewCell *cell;
     if (message.messageId == kUnreadMessagesSeparatorIdentifier) {
         MessageSeparatorTableViewCell *separatorCell = (MessageSeparatorTableViewCell *)[self.tableView dequeueReusableCellWithIdentifier:MessageSeparatorCellIdentifier];
         separatorCell.messageId = message.messageId;

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -200,7 +200,7 @@ static NSTimeInterval kMaxReconnectInterval     = 16;
     }
     
     NSLog(@"Sending: %@", jsonString);
-    [_webSocket send:jsonString];
+    [_webSocket sendString:jsonString error:nil];
 }
 
 - (void)sendHello

--- a/NextcloudTalk/NCSettingsController.h
+++ b/NextcloudTalk/NCSettingsController.h
@@ -73,10 +73,10 @@ typedef enum NCPreferredFileSorting {
 @property (nonatomic, copy) NSString *ncDeviceIdentifier;
 @property (nonatomic, copy) NSString *ncDeviceSignature;
 @property (nonatomic, copy) NSString *ncUserPublicKey;
-@property (nonatomic, copy) NSMutableArray *supportedBrowsers;
+@property (nonatomic, strong) NSMutableArray *supportedBrowsers;
 @property (nonatomic, copy) ARDSettingsModel *videoSettingsModel;
-@property (nonatomic, copy) NSMutableDictionary *signalingConfigutations; // accountId -> signalingConfigutation
-@property (nonatomic, copy) NSMutableDictionary *externalSignalingControllers; // accountId -> externalSignalingController
+@property (nonatomic, strong) NSMutableDictionary *signalingConfigutations; // accountId -> signalingConfigutation
+@property (nonatomic, strong) NSMutableDictionary *externalSignalingControllers; // accountId -> externalSignalingController
 
 + (instancetype)sharedInstance;
 - (void)addNewAccountForUser:(NSString *)user withToken:(NSString *)token inServer:(NSString *)server;

--- a/NextcloudTalk/NCSignalingMessage.m
+++ b/NextcloudTalk/NCSignalingMessage.m
@@ -382,7 +382,7 @@ NSString *const kRoomTypeScreen = @"screen";
                                       nick:(NSString *)nick
 {
     RTCSdpType sdpType = sessionDescription.type;
-    NSString *type = nil;
+    NSString *type = @"";
     switch (sdpType) {
         case RTCSdpTypeOffer:
             type = kNCSignalingMessageTypeOfferKey;

--- a/NextcloudTalk/ReactionsSummaryView.swift
+++ b/NextcloudTalk/ReactionsSummaryView.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Ivan Sein <ivan@nextcloud.com>
- *
- * @author Ivan Sein <ivan@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Ivan Sein <ivan@nextcloud.com>
+//
+// Author Ivan Sein <ivan@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 

--- a/NextcloudTalk/ReactionsView.swift
+++ b/NextcloudTalk/ReactionsView.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Ivan Sein <ivan@nextcloud.com>
- *
- * @author Ivan Sein <ivan@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Ivan Sein <ivan@nextcloud.com>
+//
+// Author Ivan Sein <ivan@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 

--- a/NextcloudTalk/ReactionsViewCell.swift
+++ b/NextcloudTalk/ReactionsViewCell.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Ivan Sein <ivan@nextcloud.com>
- *
- * @author Ivan Sein <ivan@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Ivan Sein <ivan@nextcloud.com>
+//
+// Author Ivan Sein <ivan@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -251,6 +251,8 @@ typedef enum FileAction {
 
 - (void)viewDidAppear:(BOOL)animated
 {
+    [super viewDidAppear:animated];
+    
     [[NCRoomsManager sharedInstance] updateRoom:_room.token];
     [self getRoomParticipants];
 }

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -696,7 +696,7 @@ typedef enum FileAction {
                                        message:NSLocalizedString(@"Conversation name cannot be empty", nil)
                                        preferredStyle:UIAlertControllerStyleAlert];
 
-        UIAlertAction* defaultAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault
+        UIAlertAction* defaultAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault
            handler:^(UIAlertAction * action) {}];
 
         [alert addAction:defaultAction];

--- a/NextcloudTalk/RoomSharedItemsTableViewController.swift
+++ b/NextcloudTalk/RoomSharedItemsTableViewController.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Ivan Sein <ivan@nextcloud.com>
- *
- * @author Ivan Sein <ivan@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Ivan Sein <ivan@nextcloud.com>
+//
+// Author Ivan Sein <ivan@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 import QuickLook

--- a/NextcloudTalk/SettingsTableViewController.swift
+++ b/NextcloudTalk/SettingsTableViewController.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @author Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// Author Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 import NCCommunication

--- a/NextcloudTalk/ShareLocationViewController.m
+++ b/NextcloudTalk/ShareLocationViewController.m
@@ -208,7 +208,7 @@ typedef enum ShareLocationSection {
     [geocoder reverseGeocodeLocation:location completionHandler:^(NSArray *placemarks, NSError *error) {
         if (!error) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                _dropPinPlacemark = placemarks[0];
+                self->_dropPinPlacemark = placemarks[0];
                 [self.tableView reloadSections:[[NSIndexSet alloc] initWithIndex:kShareLocationSectionDropPin] withRowAnimation:UITableViewRowAnimationNone];
             });
         }

--- a/NextcloudTalk/SimpleTableViewController.swift
+++ b/NextcloudTalk/SimpleTableViewController.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Marcel Müller <marcel-mueller@gmx.de>
- *
- * @author Marcel Müller <marcel-mueller@gmx.de>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 class SimpleTableViewController: UITableViewController {
     let options: [String]

--- a/NextcloudTalk/TextInputTableViewCell.swift
+++ b/NextcloudTalk/TextInputTableViewCell.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @author Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// Author Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 

--- a/NextcloudTalk/UserProfileTableViewController+Actions.swift
+++ b/NextcloudTalk/UserProfileTableViewController+Actions.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @author Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// Author Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import Foundation
 

--- a/NextcloudTalk/UserProfileTableViewController+AvatarSetup.swift
+++ b/NextcloudTalk/UserProfileTableViewController+AvatarSetup.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @author Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// Author Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import Foundation
 

--- a/NextcloudTalk/UserProfileTableViewController+DelegateMethods.swift
+++ b/NextcloudTalk/UserProfileTableViewController+DelegateMethods.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @author Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// Author Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import Foundation
 

--- a/NextcloudTalk/UserProfileTableViewController+Utils.swift
+++ b/NextcloudTalk/UserProfileTableViewController+Utils.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @author Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// Author Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import Foundation
 

--- a/NextcloudTalk/UserProfileTableViewController.swift
+++ b/NextcloudTalk/UserProfileTableViewController.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @author Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// Author Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 

--- a/NextcloudTalk/UserSettingsTableViewCell.swift
+++ b/NextcloudTalk/UserSettingsTableViewCell.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @author Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// Author Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 import NCCommunication

--- a/NextcloudTalk/UserStatusMessageViewController.swift
+++ b/NextcloudTalk/UserStatusMessageViewController.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2020 Ivan Sein <ivan@nextcloud.com>
- *
- * @author Ivan Sein <ivan@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2020 Ivan Sein <ivan@nextcloud.com>
+//
+// Author Ivan Sein <ivan@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 

--- a/NextcloudTalk/UserStatusMessageViewController.swift
+++ b/NextcloudTalk/UserStatusMessageViewController.swift
@@ -409,10 +409,8 @@ extension UserStatusMessageViewController: UITableViewDataSource {
     override var textInputContextIdentifier: String? { "" } // return non-nil to show the Emoji keyboard ¯\_(ツ)_/¯
 
     override var textInputMode: UITextInputMode? {
-        for mode in UITextInputMode.activeInputModes {
-            if mode.primaryLanguage == "emoji" {
-                return mode
-            }
+        for mode in UITextInputMode.activeInputModes where mode.primaryLanguage == "emoji" {
+            return mode
         }
         return nil
     }

--- a/NextcloudTalk/UserStatusTableViewController.swift
+++ b/NextcloudTalk/UserStatusTableViewController.swift
@@ -1,24 +1,23 @@
-/**
- * @copyright Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @author Aleksandra Lazarevic <aleksandra@nextcloud.com>
- *
- * @license GNU GPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+//
+// Copyright (c) 2022 Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// Author Aleksandra Lazarevic <aleksandra@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 
 import UIKit
 

--- a/ShareExtension/ShareConfirmationViewController.m
+++ b/ShareExtension/ShareConfirmationViewController.m
@@ -579,11 +579,6 @@
 
 #pragma mark - UIDocumentPickerViewController Delegate
 
-- (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentAtURL:(NSURL *)url
-{
-    [self shareDocumentsWithURLs:@[url] fromController:controller];
-}
-
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls
 {
     [self shareDocumentsWithURLs:urls fromController:controller];

--- a/ShareExtension/ShareConfirmationViewController.m
+++ b/ShareExtension/ShareConfirmationViewController.m
@@ -153,6 +153,8 @@
 
 - (void)viewDidAppear:(BOOL)animated
 {
+    [super viewDidAppear:animated];
+
     if (_type == ShareConfirmationTypeText) {
         [self.itemToolbar setHidden:YES];
         [self.shareTextView becomeFirstResponder];

--- a/ShareExtension/ShareViewController.m
+++ b/ShareExtension/ShareViewController.m
@@ -554,10 +554,9 @@
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     NCRoom *room = [_rooms objectAtIndex:indexPath.row];
-    BOOL isFilteredTable = NO;
+
     if (tableView == _resultTableViewController.tableView) {
         room = [_filteredRooms objectAtIndex:indexPath.row];
-        isFilteredTable = YES;
     }
 
     BOOL hasChatPermission = ![[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityChatPermission] || (room.permissions & NCPermissionChat) != 0;


### PR DESCRIPTION
This PR fixes some issues found by swiftlint and XCode analyze. It's best reviewed [commit-wise](https://github.com/nextcloud/talk-ios/pull/841/commits).

Unable to test the push changes in this commit: https://github.com/nextcloud/talk-ios/pull/841/commits/9a7bcadca337f4ed4c85a77a5963e0914088b868
Old function: https://developer.apple.com/documentation/pushkit/pkpushregistrydelegate/1614492-pushregistry
New function: https://developer.apple.com/documentation/pushkit/pkpushregistrydelegate/2875784-pushregistry
(There're no major changes, just a different signature and a call to completion, so I don't think there will be an issue)

I didn't notice an issue with this commit: https://github.com/nextcloud/talk-ios/pull/841/commits/f402140daa785ff58a53b51f93c706beaef69cd8 But still wonder if this was just an oversight or if there was a reasoning behind it...

This one is not needed anymore, because we're targeting iOS 12 now:
Old function: https://developer.apple.com/documentation/uikit/uidocumentpickerdelegate/1618680-documentpicker
New function: https://developer.apple.com/documentation/uikit/uidocumentpickerdelegate/2902364-documentpicker