### PR TITLE
Fix saving of push tokens on new devices

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -175,17 +175,22 @@
 
 - (void)checkForPushNotificationSubscription
 {
-    BOOL isAppActive = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
-    // Subscribe only if both tokens have been generated and app is active (do not try to subscribe when
-    // the app is running in background e.g. when the app is launched due to a VoIP push notification)
-    if (normalPushToken && pushKitToken && isAppActive) {
-        // Store new Normal Push & PushKit tokens in Keychain
-        UICKeyChainStore *keychain = [UICKeyChainStore keyChainStoreWithService:bundleIdentifier accessGroup:groupIdentifier];
-        [NCSettingsController sharedInstance].ncNormalPushToken = normalPushToken;
-        [keychain setString:normalPushToken forKey:kNCNormalPushTokenKey];
-        [NCSettingsController sharedInstance].ncPushKitToken = pushKitToken;
-        [keychain setString:pushKitToken forKey:kNCPushKitTokenKey];
-        
+    if (!normalPushToken || !pushKitToken) {
+        return;
+    }
+
+    // Store new Normal Push & PushKit tokens in Keychain
+    UICKeyChainStore *keychain = [UICKeyChainStore keyChainStoreWithService:bundleIdentifier accessGroup:groupIdentifier];
+    [NCSettingsController sharedInstance].ncNormalPushToken = normalPushToken;
+    [keychain setString:normalPushToken forKey:kNCNormalPushTokenKey];
+    [NCSettingsController sharedInstance].ncPushKitToken = pushKitToken;
+    [keychain setString:pushKitToken forKey:kNCPushKitTokenKey];
+
+    BOOL isAppInBackground = [[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground;
+    // Subscribe only if both tokens have been generated and app is not running in the background (do not try to subscribe
+    // when the app is running in background e.g. when the app is launched due to a VoIP push notification)
+
+    if (!isAppInBackground) {
         // Remove subscribed flag for all accounts
         RLMRealm *realm = [RLMRealm defaultRealm];
         [realm beginWriteTransaction];
@@ -193,7 +198,7 @@
             account.pushNotificationSubscribed = NO;
         }
         [realm commitWriteTransaction];
-        
+
         // Try to subscribe for push notifications in all accounts
         for (TalkAccount *account in [[NCDatabaseManager sharedInstance] allAccounts]) {
             [[NCSettingsController sharedInstance] subscribeForPushNotificationsForAccountId:account.accountId];

--- a/NextcloudTalk/NCKeyChainController.m
+++ b/NextcloudTalk/NCKeyChainController.m
@@ -85,13 +85,24 @@ NSString * const kNCUserDefaultBrowser          = @"ncUserDefaultBrowser";
 
 - (NSString *)pushTokenSHA512
 {
-    return [self createSHA512:[self combinedPushToken]];
+    NSString *token = [self combinedPushToken];
+
+    if (!token) {
+        return nil;
+    }
+
+    return [self createSHA512:token];
 }
 
 - (NSString *)combinedPushToken
 {
     NSString *normalPushToken = [_keychain stringForKey:kNCNormalPushTokenKey];
     NSString *pushKitToken = [_keychain stringForKey:kNCPushKitTokenKey];
+
+    if (!normalPushToken || !pushKitToken) {
+        return nil;
+    }
+
     return [NSString stringWithFormat:@"%@ %@", normalPushToken, pushKitToken];
 }
 

--- a/NextcloudTalk/NCSettingsController.m
+++ b/NextcloudTalk/NCSettingsController.m
@@ -537,44 +537,56 @@ NSString * const kContactSyncEnabled  = @"contactSyncEnabled";
 {
 #if !TARGET_IPHONE_SIMULATOR
     NCPushNotificationKeyPair *keyPair = [self generatePushNotificationsKeyPairForAccountId:accountId];
-    if (keyPair) {
-        [[NCAPIController sharedInstance] subscribeAccount:[[NCDatabaseManager sharedInstance] talkAccountForAccountId:accountId] withPublicKey:keyPair.publicKey toNextcloudServerWithCompletionBlock:^(NSDictionary *responseDict, NSError *error) {
-            if (!error) {
-                NSLog(@"Subscribed to NC server successfully.");
-                
-                NSString *publicKey = [responseDict objectForKey:@"publicKey"];
-                NSString *deviceIdentifier = [responseDict objectForKey:@"deviceIdentifier"];
-                NSString *signature = [responseDict objectForKey:@"signature"];
-                
-                RLMRealm *realm = [RLMRealm defaultRealm];
-                [realm beginWriteTransaction];
-                NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@", accountId];
-                TalkAccount *managedAccount = [TalkAccount objectsWithPredicate:query].firstObject;
-                managedAccount.userPublicKey = publicKey;
-                managedAccount.deviceIdentifier = deviceIdentifier;
-                managedAccount.deviceSignature = signature;
-                [realm commitWriteTransaction];
-                
-                [[NCAPIController sharedInstance] subscribeAccount:[[NCDatabaseManager sharedInstance] talkAccountForAccountId:accountId] toPushServerWithCompletionBlock:^(NSError *error) {
-                    if (!error) {
-                        RLMRealm *realm = [RLMRealm defaultRealm];
-                        [realm beginWriteTransaction];
-                        NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@", accountId];
-                        TalkAccount *managedAccount = [TalkAccount objectsWithPredicate:query].firstObject;
-                        managedAccount.pushNotificationPublicKey = keyPair.publicKey;
-                        managedAccount.pushNotificationSubscribed = YES;
-                        [realm commitWriteTransaction];
-                        [[NCKeyChainController sharedInstance] setPushNotificationPrivateKey:keyPair.privateKey forAccountId:accountId];
-                        NSLog(@"Subscribed to Push Notification server successfully.");
-                    } else {
-                        NSLog(@"Error while subscribing to Push Notification server.");
-                    }
-                }];
-            } else {
-                NSLog(@"Error while subscribing to NC server.");
-            }
-        }];
+
+    if (!keyPair) {
+        NSLog(@"Error while subscribing: Unable to generate push notifications key pair.");
+        return;
     }
+
+    NSString *pushToken = [[NCKeyChainController sharedInstance] combinedPushToken];
+
+    if (!pushToken) {
+        NSLog(@"Error while subscribing: Push token is not available.");
+        return;
+    }
+
+
+    [[NCAPIController sharedInstance] subscribeAccount:[[NCDatabaseManager sharedInstance] talkAccountForAccountId:accountId] withPublicKey:keyPair.publicKey toNextcloudServerWithCompletionBlock:^(NSDictionary *responseDict, NSError *error) {
+        if (!error) {
+            NSLog(@"Subscribed to NC server successfully.");
+
+            NSString *publicKey = [responseDict objectForKey:@"publicKey"];
+            NSString *deviceIdentifier = [responseDict objectForKey:@"deviceIdentifier"];
+            NSString *signature = [responseDict objectForKey:@"signature"];
+
+            RLMRealm *realm = [RLMRealm defaultRealm];
+            [realm beginWriteTransaction];
+            NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@", accountId];
+            TalkAccount *managedAccount = [TalkAccount objectsWithPredicate:query].firstObject;
+            managedAccount.userPublicKey = publicKey;
+            managedAccount.deviceIdentifier = deviceIdentifier;
+            managedAccount.deviceSignature = signature;
+            [realm commitWriteTransaction];
+
+            [[NCAPIController sharedInstance] subscribeAccount:[[NCDatabaseManager sharedInstance] talkAccountForAccountId:accountId] toPushServerWithCompletionBlock:^(NSError *error) {
+                if (!error) {
+                    RLMRealm *realm = [RLMRealm defaultRealm];
+                    [realm beginWriteTransaction];
+                    NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@", accountId];
+                    TalkAccount *managedAccount = [TalkAccount objectsWithPredicate:query].firstObject;
+                    managedAccount.pushNotificationPublicKey = keyPair.publicKey;
+                    managedAccount.pushNotificationSubscribed = YES;
+                    [realm commitWriteTransaction];
+                    [[NCKeyChainController sharedInstance] setPushNotificationPrivateKey:keyPair.privateKey forAccountId:accountId];
+                    NSLog(@"Subscribed to Push Notification server successfully.");
+                } else {
+                    NSLog(@"Error while subscribing to Push Notification server.");
+                }
+            }];
+        } else {
+            NSLog(@"Error while subscribing to NC server.");
+        }
+    }];
 #endif
 }
 


### PR DESCRIPTION
On "new" devices (devices where talk-ios was not installed or restored from a backup) the push tokens won't be saved to the keychain, resulting in invalid registration at the push-proxy:
![image](https://user-images.githubusercontent.com/1580193/183376074-cf6fc6a1-a964-436a-9e70-aeb81c4640cd.png)

Since #806 (to be precise since https://github.com/nextcloud/talk-ios/pull/806/commits/e74adcf60396682b39a08e45368386c553d84add) push tokens and the registration at the server / push proxy only happens when the app is in state `UIApplicationStateActive`. Problem is, that when the app is launched it is first in state `UIApplicationStateInactive`:
> The app is inactive at launch, and then is generally in either an active or background state.
https://developer.apple.com/documentation/uikit/uiapplication/1623003-applicationstate?language=objc

When the tokens are retrieved fast enough, the app is still in state `UIApplicationStateInactive`, therefore the tokens will never get saved to the keychain.  When a new account is added to talk-ios, the subscription process is triggered at https://github.com/nextcloud/talk-ios/blob/eb2abab42bd9a23d9db7f08addae411bf80b99ab/NextcloudTalk/NCSettingsController.m#L173
and the NCKeyChainController will happily return the string `(null) (null)` as `combinedPushToken`, because at this point there's no check if there's actually a stored push token:
https://github.com/nextcloud/talk-ios/blob/eb2abab42bd9a23d9db7f08addae411bf80b99ab/NextcloudTalk/NCKeyChainController.m#L91-L96

This problem does not occur on devices which previously ran an older version of talk-ios and where the push token did not change since it was first started, because the correct push tokens were still in the keychain. Same probably happens when a backup to the same device was restored.

I'm not sure if there's a reason to use `UICKeyChainStore` directly in the `AppDelegate` vs. using `NCKeyChainController`. If there's no reason, we could think about changing this.

Fixes #851 
Related to #807 ?