### PR TITLE
Always call completionHandler in didReceiveNotificationResponse

### DIFF
--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -260,16 +260,18 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
             UNTextInputNotificationResponse *textInputResponse = (UNTextInputNotificationResponse *)response;
             pushNotification.responseUserText = textInputResponse.userText;
             
-            [self handlePushNotificationResponseWithUserText:pushNotification withCompletionHandler:completionHandler];
+            [self handlePushNotificationResponseWithUserText:pushNotification];
         } else {
-            [self handlePushNotificationResponse:pushNotification withCompletionHandler:completionHandler];
+            [self handlePushNotificationResponse:pushNotification];
         }
     } else if (localNotificationType > 0) {
-        [self handleLocalNotificationResponse:notificationRequest.content.userInfo withCompletionHandler:completionHandler];
+        [self handleLocalNotificationResponse:notificationRequest.content.userInfo];
     }
+
+    completionHandler();
 }
 
-- (void)handlePushNotificationResponseWithUserText:(NCPushNotification *)pushNotification withCompletionHandler:(void (^)(void))completionHandler
+- (void)handlePushNotificationResponseWithUserText:(NCPushNotification *)pushNotification
 {
     NSLog(@"Recevied push-notification with user input -> sending chat message");
     
@@ -303,14 +305,10 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
             [application endBackgroundTask:sendTask];
             sendTask = UIBackgroundTaskInvalid;
         }];
-
-
     });
-    
-    completionHandler();
 }
 
-- (void)handlePushNotificationResponse:(NCPushNotification *)pushNotification withCompletionHandler:(void (^)(void))completionHandler
+- (void)handlePushNotificationResponse:(NCPushNotification *)pushNotification
 {
     if (pushNotification) {
         switch (pushNotification.type) {
@@ -329,11 +327,9 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
                 break;
         }
     }
-    
-    completionHandler();
 }
 
-- (void)handleLocalNotificationResponse:(NSDictionary *)notificationUserInfo withCompletionHandler:(void (^)(void))completionHandler
+- (void)handleLocalNotificationResponse:(NSDictionary *)notificationUserInfo
 {
     NCLocalNotificationType localNotificationType = (NCLocalNotificationType)[[notificationUserInfo objectForKey:@"localNotificationType"] integerValue];
     if (localNotificationType > 0) {
@@ -349,8 +345,6 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
                 break;
         }
     }
-    
-    completionHandler();
 }
 
 @end


### PR DESCRIPTION
iOS complains that we do not correctly call the completion handler in `didReceiveNotificationResponse`:

> Warning: UNUserNotificationCenter delegate received call to -userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler: but the completion handler was never called.

Currently the completion handler is called at the end of every called method, so essential it is not different from calling it at the end of `didReceiveNotificationResponse` and making sure it's called in every case. Therefore we can simplify our code and make iOS happy again.