### PR TITLE
Check if the guests app is enabled

### DIFF
--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -31,7 +31,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 34;
+uint64_t const kTalkDatabaseSchemaVersion           = 35;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";
@@ -321,6 +321,7 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
     NSDictionary *talkCaps = [serverCaps objectForKey:@"spreed"];
     NSDictionary *userStatusCaps = [serverCaps objectForKey:@"user_status"];
     NSDictionary *provisioningAPICaps = [serverCaps objectForKey:@"provisioning_api"];
+    NSDictionary *guestsCaps = [serverCaps objectForKey:@"guests"];
     
     ServerCapabilities *capabilities = [[ServerCapabilities alloc] init];
     capabilities.accountId = accountId;
@@ -362,6 +363,7 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
         capabilities.callEnabled = YES;
     }
     capabilities.talkVersion = [talkCaps objectForKey:@"version"];
+    capabilities.guestsAppEnabled = [[guestsCaps objectForKey:@"enabled"] boolValue];
     
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm transactionWithBlock:^{

--- a/NextcloudTalk/NCSettingsController.h
+++ b/NextcloudTalk/NCSettingsController.h
@@ -92,6 +92,7 @@ typedef enum NCPreferredFileSorting {
 - (NSInteger)chatMaxLengthConfigCapability;
 - (BOOL)canCreateGroupAndPublicRooms;
 - (BOOL)callsEnabledCapability;
+- (BOOL)isGuestsAppEnabled;
 - (NCPreferredFileSorting)getPreferredFileSorting;
 - (void)setPreferredFileSorting:(NCPreferredFileSorting)sorting;
 - (BOOL)isContactSyncEnabled;

--- a/NextcloudTalk/NCSettingsController.m
+++ b/NextcloudTalk/NCSettingsController.m
@@ -531,6 +531,16 @@ NSString * const kContactSyncEnabled  = @"contactSyncEnabled";
     return YES;
 }
 
+- (BOOL)isGuestsAppEnabled
+{
+    TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+    ServerCapabilities *serverCapabilities  = [[NCDatabaseManager sharedInstance] serverCapabilitiesForAccountId:activeAccount.accountId];
+    if (serverCapabilities) {
+        return serverCapabilities.guestsAppEnabled;
+    }
+    return NO;
+}
+
 #pragma mark - Push Notifications
 
 - (void)subscribeForPushNotificationsForAccountId:(NSString *)accountId

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -422,10 +422,11 @@ typedef enum FileAction {
     if ([[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityListableRooms]) {
         [actions addObject:[NSNumber numberWithInt:kConversationActionListable]];
         
-        if (_room.listable == NCRoomListableScopeRegularUsersOnly || _room.listable == NCRoomListableScopeEveryone) {
+        if (_room.listable != NCRoomListableScopeParticipantsOnly && [[NCSettingsController sharedInstance] isGuestsAppEnabled]) {
             [actions addObject:[NSNumber numberWithInt:kConversationActionListableForEveryone]];
         }
     }
+
     // Read only room action
     if ([[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityReadOnlyRooms]) {
         [actions addObject:[NSNumber numberWithInt:kConversationActionReadOnly]];

--- a/NextcloudTalk/ServerCapabilities.h
+++ b/NextcloudTalk/ServerCapabilities.h
@@ -59,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property BOOL callEnabled;
 @property NSString *talkVersion;
 @property NSString *externalSignalingServerVersion;
+@property BOOL guestsAppEnabled;
 
 @end
 


### PR DESCRIPTION
Follow-Up to https://github.com/nextcloud/talk-ios/pull/817

Decision was made that the guests-app should expose it's availability on its own capabilities (https://github.com/nextcloud/guests/pull/901). We can now correctly check if the guests-app is available or not and adjust the room options accordingly.

This will be available starting with NC25, earlier versions will only allow to open a conversation to registered users, but not guests. As there was no release with this functionality of talk-ios, I'd argue it's fine to merge as it doesn't break existing functionality. 