### PR TITLE
Fallback for notifications

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -401,6 +401,17 @@
     [NCUtils log:@"Start performBackgroundFetchWithCompletionHandler"];
 
     dispatch_group_enter(backgroundRefreshGroup);
+    [[NCNotificationController sharedInstance] checkForNewNotificationsWithCompletionBlock:^(NSError *error) {
+        [NCUtils log:@"CompletionHandler checkForNewNotificationsWithCompletionBlock"];
+
+        if (error) {
+            errorOccurred = YES;
+        }
+
+        dispatch_group_leave(backgroundRefreshGroup);
+    }];
+
+    dispatch_group_enter(backgroundRefreshGroup);
     [[NCRoomsManager sharedInstance] updateRoomsAndChatsUpdatingUserStatus:NO withCompletionBlock:^(NSError *error) {
         [NCUtils log:@"CompletionHandler updateRoomsAndChatsUpdatingUserStatus"];
 

--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -361,8 +361,8 @@
     [self scheduleAppRefresh];
 
     [self performBackgroundFetchWithCompletionHandler:^(BOOL errorOccurred) {
-         [task setTaskCompletedWithSuccess:!errorOccurred];
-     }];
+        [task setTaskCompletedWithSuccess:!errorOccurred];
+    }];
 }
 
 // This method is called when you simulate a background fetch from the debug menu in XCode

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -96,6 +96,7 @@ typedef void (^SetUserStatusCompletionBlock)(NSError *error);
 
 typedef void (^GetServerCapabilitiesCompletionBlock)(NSDictionary *serverCapabilities, NSError *error);
 typedef void (^GetServerNotificationCompletionBlock)(NSDictionary *notification, NSError *error, NSInteger statusCode);
+typedef void (^GetServerNotificationsCompletionBlock)(NSArray *notifications, NSString *ETag, NSError *error);
 
 typedef void (^SubscribeToNextcloudServerCompletionBlock)(NSDictionary *responseDict, NSError *error);
 typedef void (^UnsubscribeToNextcloudServerCompletionBlock)(NSError *error);
@@ -244,6 +245,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 
 // Server notifications
 - (NSURLSessionDataTask *)getServerNotification:(NSInteger)notificationId forAccount:(TalkAccount *)account withCompletionBlock:(GetServerNotificationCompletionBlock)block;
+- (NSURLSessionDataTask *)getServerNotificationsForAccount:(TalkAccount *)account withLastETag:(NSString *)lastETag withCompletionBlock:(GetServerNotificationsCompletionBlock)block;
 
 // Push Notifications
 - (NSURLSessionDataTask *)subscribeAccount:(TalkAccount *)account withPublicKey:(NSData *)publicKey toNextcloudServerWithCompletionBlock:(SubscribeToNextcloudServerCompletionBlock)block;

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -326,6 +326,7 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
     NSDictionary *userStatusCaps = [serverCaps objectForKey:@"user_status"];
     NSDictionary *provisioningAPICaps = [serverCaps objectForKey:@"provisioning_api"];
     NSDictionary *guestsCaps = [serverCaps objectForKey:@"guests"];
+    NSDictionary *notificationsCaps = [serverCaps objectForKey:@"notifications"];
     
     ServerCapabilities *capabilities = [[ServerCapabilities alloc] init];
     capabilities.accountId = accountId;
@@ -368,6 +369,7 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
     capabilities.talkVersion = [talkCaps objectForKey:@"version"];
     capabilities.guestsAppEnabled = [[guestsCaps objectForKey:@"enabled"] boolValue];
     capabilities.referenceApiSupported = [[coreCaps objectForKey:@"reference-api"] boolValue];
+    capabilities.notificationsAppEnabled = ([notificationsCaps objectForKey:@"ocs-endpoints"] != nil);
     
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm transactionWithBlock:^{

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -31,7 +31,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 41;
+uint64_t const kTalkDatabaseSchemaVersion           = 42;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";

--- a/NextcloudTalk/NCNotification.h
+++ b/NextcloudTalk/NCNotification.h
@@ -31,6 +31,7 @@ typedef enum NCNotificationType {
 @interface NCNotification : NSObject
 
 @property (nonatomic, assign) NSInteger notificationId;
+@property (nonatomic, strong) NSString *app;
 @property (nonatomic, strong) NSString *objectId;
 @property (nonatomic, strong) NSString *objectType;
 @property (nonatomic, strong) NSString *subject;
@@ -45,5 +46,6 @@ typedef enum NCNotificationType {
 - (NSString *)chatMessageAuthor;
 - (NSString *)chatMessageTitle;
 - (NSString *)callDisplayName;
+- (NSString *)roomToken;
 
 @end

--- a/NextcloudTalk/NCNotification.m
+++ b/NextcloudTalk/NCNotification.m
@@ -32,6 +32,7 @@
     
     NCNotification *notification = [[NCNotification alloc] init];
     notification.notificationId = [[notificationDict objectForKey:@"notification_id"] integerValue];
+    notification.app = [notificationDict objectForKey:@"app"];
     notification.objectId = [notificationDict objectForKey:@"object_id"];
     notification.objectType = [notificationDict objectForKey:@"object_type"];
     notification.subject = [notificationDict objectForKey:@"subject"];
@@ -61,6 +62,17 @@
         type = kNCNotificationTypeCall;
     }
     return type;
+}
+
+- (NSString *)roomToken
+{
+    // Starting with NC 24 objectId additionally contains the messageId: "{roomToken}/{messageId}"
+    if ([_objectId containsString:@"/"]) {
+        NSArray *objectIdComponents = [_objectId componentsSeparatedByString:@"/"];
+        return objectIdComponents[0];
+    }
+
+    return _objectId;
 }
 
 - (NSString *)chatMessageAuthor

--- a/NextcloudTalk/NCNotificationController.h
+++ b/NextcloudTalk/NCNotificationController.h
@@ -27,7 +27,7 @@
 extern NSString * const NCNotificationControllerWillPresentNotification;
 extern NSString * const NCLocalNotificationJoinChatNotification;
 
-typedef void (^CheckForNewNotificationsWithCompletionBlock)(NSError *error);
+typedef void (^CheckForNewNotificationsCompletionBlock)(NSError *error);
 
 typedef enum {
     kNCLocalNotificationTypeMissedCall = 1,
@@ -47,6 +47,6 @@ typedef enum {
 - (void)showIncomingCallForPushNotification:(NCPushNotification *)pushNotification;
 - (void)showIncomingCallForOldAccount;
 - (void)removeAllNotificationsForAccountId:(NSString *)accountId;
-- (void)checkForNewNotificationsWithCompletionBlock:(CheckForNewNotificationsWithCompletionBlock)block;
+- (void)checkForNewNotificationsWithCompletionBlock:(CheckForNewNotificationsCompletionBlock)block;
 
 @end

--- a/NextcloudTalk/NCNotificationController.h
+++ b/NextcloudTalk/NCNotificationController.h
@@ -27,11 +27,14 @@
 extern NSString * const NCNotificationControllerWillPresentNotification;
 extern NSString * const NCLocalNotificationJoinChatNotification;
 
+typedef void (^CheckForNewNotificationsWithCompletionBlock)(NSError *error);
+
 typedef enum {
     kNCLocalNotificationTypeMissedCall = 1,
     kNCLocalNotificationTypeCancelledCall,
     kNCLocalNotificationTypeFailedSendChat,
-    kNCLocalNotificationTypeCallFromOldAccount
+    kNCLocalNotificationTypeCallFromOldAccount,
+    kNCLocalNotificationTypeChatNotification
 } NCLocalNotificationType;
 
 @interface NCNotificationController : NSObject
@@ -44,5 +47,6 @@ typedef enum {
 - (void)showIncomingCallForPushNotification:(NCPushNotification *)pushNotification;
 - (void)showIncomingCallForOldAccount;
 - (void)removeAllNotificationsForAccountId:(NSString *)accountId;
+- (void)checkForNewNotificationsWithCompletionBlock:(CheckForNewNotificationsWithCompletionBlock)block;
 
 @end

--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -281,7 +281,7 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
     [self updateAppIconBadgeNumber];
 }
 
-- (void)checkForNewNotificationsWithCompletionBlock:(CheckForNewNotificationsWithCompletionBlock)block
+- (void)checkForNewNotificationsWithCompletionBlock:(CheckForNewNotificationsCompletionBlock)block
 {
     dispatch_group_t notificationsGroup = dispatch_group_create();
 

--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -306,11 +306,15 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
             for (NSDictionary *notification in notifications) {
                 NCNotification *serverNotification = [NCNotification notificationWithDictionary:notification];
 
+                if (!serverNotification || ![serverNotification.app isEqualToString:kNCPNAppIdKey]) {
+                    continue;
+                }
+
                 // Add notificationId before filtering chat only ones
                 [newNotificationsIds addObject:@(serverNotification.notificationId)];
 
                 // Only process chat notifications from Talk
-                if (!serverNotification || ![serverNotification.app isEqualToString:kNCPNAppIdKey] || serverNotification.notificationType != kNCNotificationTypeChat) {
+                if (serverNotification.notificationType != kNCNotificationTypeChat) {
                     continue;
                 }
 

--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -155,6 +155,7 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
     NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
     [userInfo setObject:pushNotification.jsonString forKey:@"pushNotification"];
     [userInfo setObject:pushNotification.accountId forKey:@"accountId"];
+    [userInfo setObject:@(pushNotification.notificationId) forKey:@"notificationId"];
     content.userInfo = userInfo;
     
     NSString *identifier = [NSString stringWithFormat:@"Notification-%f", [[NSDate date] timeIntervalSince1970]];

--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -245,15 +245,14 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
     }
     
     void(^removeNotification)(UNNotificationRequest *, BOOL) = ^(UNNotificationRequest *notificationRequest, BOOL isPending) {
-        NSString *notificationString = [notificationRequest.content.userInfo objectForKey:@"pushNotification"];
         NSString *notificationAccountId = [notificationRequest.content.userInfo objectForKey:@"accountId"];
-        NCPushNotification *pushNotification = [NCPushNotification pushNotificationFromDecryptedString:notificationString withAccountId:notificationAccountId];
+        NSInteger notificationId = [[notificationRequest.content.userInfo objectForKey:@"notificationId"] integerValue];
 
-        if (!pushNotification || ![pushNotification.accountId isEqualToString:accountId]) {
+        if (![notificationAccountId isEqualToString:accountId]) {
             return;
         }
 
-        if ([notificationIds containsObject:@(pushNotification.notificationId)]) {
+        if ([notificationIds containsObject:@(notificationId)]) {
             if (isPending) {
                 [self->_notificationCenter removePendingNotificationRequestsWithIdentifiers:@[notificationRequest.identifier]];
             } else {

--- a/NextcloudTalk/NCPushNotification.h
+++ b/NextcloudTalk/NCPushNotification.h
@@ -34,6 +34,7 @@ typedef NS_ENUM(NSInteger, NCPushNotificationType) {
 };
 
 extern NSString * const kNCPNAppKey;
+extern NSString * const kNCPNAppIdKey;
 extern NSString * const kNCPNTypeKey;
 extern NSString * const kNCPNSubjectKey;
 extern NSString * const kNCPNIdKey;

--- a/NextcloudTalk/ServerCapabilities.h
+++ b/NextcloudTalk/ServerCapabilities.h
@@ -60,6 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSString *externalSignalingServerVersion;
 @property BOOL guestsAppEnabled;
 @property BOOL referenceApiSupported;
+@property BOOL notificationsAppEnabled;
 
 @end
 

--- a/NextcloudTalk/TalkAccount.h
+++ b/NextcloudTalk/TalkAccount.h
@@ -55,6 +55,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property BOOL hasContactSyncEnabled;
 @property BOOL active;
 @property NSString *lastReceivedConfigurationHash;
+@property NSInteger lastNotificationId;
+@property NSString *lastNotificationETag;
 
 @end
 

--- a/NotificationServiceExtension/NotificationService.m
+++ b/NotificationServiceExtension/NotificationService.m
@@ -145,6 +145,7 @@
                     NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
                     [userInfo setObject:pushNotification.jsonString forKey:@"pushNotification"];
                     [userInfo setObject:pushNotification.accountId forKey:@"accountId"];
+                    [userInfo setObject:@(pushNotification.notificationId) forKey:@"notificationId"];
                     self.bestAttemptContent.userInfo = userInfo;
                     // Create title and body structure if there is a new line in the subject
                     NSArray* components = [pushNotification.subject componentsSeparatedByString:@"\n"];


### PR DESCRIPTION
Background fetch is already implemented in `talk-ios` and periodically checks if there are updates to rooms available. This PR extends the functionality of background fetch and additionally queries the notifications v2 api (https://github.com/nextcloud/notifications/blob/master/docs/ocs-endpoint-v2.md). 
If talk-notifications are available, which were not previously shown by a push notification, we now show a local notification.

Some remarks:
* It's entirely up to iOS to decide when a background fetch is initiated
* This is no replacement for push notifications (especially since there's no guaranteed execution time)
* ETag/If-None-Match is used
* Directly replying to a local notification is not implemented (this can be done, but I don't think it's really worth the work)
* ~Needs to be adjusted after #858 is merged~

How to test:
* Make sure you don't receive push notifications (e.g. use a non-nextcloud bundle id)
* Send a chat message to the user
* Initiate a background-fetch: `Debug -> Simulate Background Fetch`
* Note: Doing a background fetch for the very first time for an account will only update the informations about notifications and not create local notifications on the device. Repeat the steps above to see a local notification appear on the device.