### PR TITLE
Correctly dequeue cells and allow word-wrap

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		1F61C767285E35A6004D74D8 /* DiagnosticsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F61C766285E35A6004D74D8 /* DiagnosticsTableViewController.swift */; };
 		1F61C76B285F65E1004D74D8 /* SimpleTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F61C76A285F65E1004D74D8 /* SimpleTableViewController.swift */; };
 		1FA20C8A284001D80062B4F3 /* DebounceWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA20C89284001D80062B4F3 /* DebounceWebView.swift */; };
+		1FB6678F28CE381300D29F8D /* SubtitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB6678E28CE381300D29F8D /* SubtitleTableViewCell.swift */; };
 		1FD9182928C55A73009092AB /* BGTaskHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD9182828C55A73009092AB /* BGTaskHelper.swift */; };
 		1FEDE3C6257D439500853F79 /* NCChatFileController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FEDE3C4257D439500853F79 /* NCChatFileController.m */; };
 		1FEDE3CE257D43AB00853F79 /* NCMessageFileParameter.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FEDE3CC257D43AB00853F79 /* NCMessageFileParameter.m */; };
@@ -349,6 +350,7 @@
 		1F61C766285E35A6004D74D8 /* DiagnosticsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsTableViewController.swift; sourceTree = "<group>"; };
 		1F61C76A285F65E1004D74D8 /* SimpleTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTableViewController.swift; sourceTree = "<group>"; };
 		1FA20C89284001D80062B4F3 /* DebounceWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceWebView.swift; sourceTree = "<group>"; };
+		1FB6678E28CE381300D29F8D /* SubtitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleTableViewCell.swift; sourceTree = "<group>"; };
 		1FD9182828C55A73009092AB /* BGTaskHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BGTaskHelper.swift; sourceTree = "<group>"; };
 		1FEDE3C4257D439500853F79 /* NCChatFileController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NCChatFileController.m; sourceTree = "<group>"; };
 		1FEDE3C5257D439500853F79 /* NCChatFileController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCChatFileController.h; sourceTree = "<group>"; };
@@ -872,6 +874,7 @@
 				2C36A049261487BC0026F04A /* DetailedOptionsSelectorTableViewController.m */,
 				2CEDA88B26F492610044552B /* NSMutableAttributedString+Extensions.swift */,
 				1F61C76A285F65E1004D74D8 /* SimpleTableViewController.swift */,
+				1FB6678E28CE381300D29F8D /* SubtitleTableViewCell.swift */,
 			);
 			name = "User Interface";
 			sourceTree = "<group>";
@@ -1880,6 +1883,7 @@
 				2CA15541208E350300CE8EF0 /* NCChatMessage.m in Sources */,
 				2CB304192264775E0053078A /* SLKInputAccessoryView.m in Sources */,
 				2CA1CC911F014354002FE6A2 /* NCConnectionController.m in Sources */,
+				1FB6678F28CE381300D29F8D /* SubtitleTableViewCell.swift in Sources */,
 				2C92195C1F58530B008AC1A3 /* UIImageView+Letters.m in Sources */,
 				2C4D7D691F2F7DBC00FF4A0D /* ARDSettingsModel.m in Sources */,
 				2CB6ACBC26385A3800D3D641 /* ShareLocationViewController.m in Sources */,

--- a/NextcloudTalk/DiagnosticsTableViewController.swift
+++ b/NextcloudTalk/DiagnosticsTableViewController.swift
@@ -98,6 +98,10 @@ class DiagnosticsTableViewController: UITableViewController {
     let notRequestedString = NSLocalizedString("Not requested", comment: "'{Microphone, Camera, ...} access was not requested'")
     let deniedFunctionalityString = NSLocalizedString("This will impact the functionality of this app. Please review your settings.", comment: "")
 
+    let cellIdentifierOpenAppSettings = "cellIdentifierOpenAppSettings"
+    let cellIdentifierSubtitle = "cellIdentifierSubtitle"
+    let cellIdentifierSubtitleAccessory = "cellIdentifierSubtitle"
+
     init(withAccount account: TalkAccount) {
         self.account = account
 
@@ -142,10 +146,9 @@ class DiagnosticsTableViewController: UITableViewController {
             self.navigationItem.scrollEdgeAppearance = appearance
         }
 
-        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "defaultCellIdentifier")
-        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "appOpenSettingsCellIdentifier")
-        self.tableView.register(SubtitleTableViewCell.self, forCellReuseIdentifier: "subtitleCellIdentifier")
-        self.tableView.register(SubtitleTableViewCell.self, forCellReuseIdentifier: "subtitleAccessoryCellIdentifier")
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifierOpenAppSettings)
+        self.tableView.register(SubtitleTableViewCell.self, forCellReuseIdentifier: cellIdentifierSubtitle)
+        self.tableView.register(SubtitleTableViewCell.self, forCellReuseIdentifier: cellIdentifierSubtitleAccessory)
 
         runChecks()
     }
@@ -317,7 +320,7 @@ class DiagnosticsTableViewController: UITableViewController {
             return appPhotoLibraryAccessCell(for: indexPath)
 
         case AppSections.kAppSectionOpenSettings.rawValue:
-            let cell = tableView.dequeueReusableCell(withIdentifier: "appOpenSettingsCellIdentifier", for: indexPath)
+            let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifierOpenAppSettings, for: indexPath)
 
             cell.textLabel?.text = NSLocalizedString("Open app settings", comment: "")
             cell.textLabel?.textAlignment = .center
@@ -329,7 +332,7 @@ class DiagnosticsTableViewController: UITableViewController {
             break
         }
 
-        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifierSubtitle, for: indexPath)
 
         switch indexPath.row {
         case AppSections.kAppSectionName.rawValue:
@@ -350,7 +353,7 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func appAVAccessCell(for mediaType: AVMediaType, for indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifierSubtitle, for: indexPath)
         let authStatusAV = AVCaptureDevice.authorizationStatus(for: mediaType)
 
         if mediaType == .audio {
@@ -374,7 +377,7 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func appContactsAccessCell(for indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifierSubtitle, for: indexPath)
         cell.textLabel?.text = NSLocalizedString("Contact access", comment: "")
 
         switch CNContactStore.authorizationStatus(for: .contacts) {
@@ -392,7 +395,7 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func appLocationAccessCell(for indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifierSubtitle, for: indexPath)
         cell.textLabel?.text = NSLocalizedString("Location access", comment: "")
 
         if CLLocationManager.locationServicesEnabled() {
@@ -415,7 +418,7 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func appPhotoLibraryAccessCell(for indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifierSubtitle, for: indexPath)
         cell.textLabel?.text = NSLocalizedString("Photo library access", comment: "")
 
         switch PHPhotoLibrary.authorizationStatus() {
@@ -433,7 +436,7 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func appNotificationsCell(for indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleAccessoryCellIdentifier", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifierSubtitleAccessory, for: indexPath)
         cell.textLabel?.text = NSLocalizedString("Notifications", comment: "")
         cell.accessoryType = .none
         cell.accessoryView = nil
@@ -458,7 +461,7 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func accountCell(for indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifierSubtitle, for: indexPath)
 
         switch indexPath.row {
         case AccountSections.kAccountSectionServer.rawValue:
@@ -481,7 +484,7 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func serverCell(for indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleAccessoryCellIdentifier", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifierSubtitleAccessory, for: indexPath)
         cell.accessoryType = .none
         cell.accessoryView = nil
 
@@ -516,7 +519,7 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func talkCell(for indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleAccessoryCellIdentifier", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifierSubtitleAccessory, for: indexPath)
         cell.accessoryType = .none
         cell.accessoryView = nil
 
@@ -552,7 +555,7 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func signalingCell(for indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifierSubtitle, for: indexPath)
 
         let allSectionsIndex = signalingSections[indexPath.row]
 

--- a/NextcloudTalk/DiagnosticsTableViewController.swift
+++ b/NextcloudTalk/DiagnosticsTableViewController.swift
@@ -100,7 +100,7 @@ class DiagnosticsTableViewController: UITableViewController {
 
     let cellIdentifierOpenAppSettings = "cellIdentifierOpenAppSettings"
     let cellIdentifierSubtitle = "cellIdentifierSubtitle"
-    let cellIdentifierSubtitleAccessory = "cellIdentifierSubtitle"
+    let cellIdentifierSubtitleAccessory = "cellIdentifierSubtitleAccessory"
 
     init(withAccount account: TalkAccount) {
         self.account = account

--- a/NextcloudTalk/DiagnosticsTableViewController.swift
+++ b/NextcloudTalk/DiagnosticsTableViewController.swift
@@ -142,6 +142,11 @@ class DiagnosticsTableViewController: UITableViewController {
             self.navigationItem.scrollEdgeAppearance = appearance
         }
 
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "defaultCellIdentifier")
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "appOpenSettingsCellIdentifier")
+        self.tableView.register(SubtitleTableViewCell.self, forCellReuseIdentifier: "subtitleCellIdentifier")
+        self.tableView.register(SubtitleTableViewCell.self, forCellReuseIdentifier: "subtitleAccessoryCellIdentifier")
+
         runChecks()
     }
 
@@ -294,25 +299,26 @@ class DiagnosticsTableViewController: UITableViewController {
     func appCell(for indexPath: IndexPath) -> UITableViewCell {
         switch indexPath.row {
         case AppSections.kAppSectionAllowNotifications.rawValue:
-            return appNotificationsCell()
+            return appNotificationsCell(for: indexPath)
 
         case AppSections.kAppSectionAllowMicrophoneAccess.rawValue:
-            return appAVAccessCell(for: .audio)
+            return appAVAccessCell(for: .audio, for: indexPath)
 
         case AppSections.kAppSectionAllowCameraAccess.rawValue:
-            return appAVAccessCell(for: .video)
+            return appAVAccessCell(for: .video, for: indexPath)
 
         case AppSections.kAppSectionAllowContactsAccess.rawValue:
-            return appContactsAccessCell()
+            return appContactsAccessCell(for: indexPath)
 
         case AppSections.kAppSectionAllowLocationAccess.rawValue:
-            return appLocationAccessCell()
+            return appLocationAccessCell(for: indexPath)
 
         case AppSections.kAppSectionAllowPhotoLibraryAccess.rawValue:
-            return appPhotoLibraryAccessCell()
+            return appPhotoLibraryAccessCell(for: indexPath)
 
         case AppSections.kAppSectionOpenSettings.rawValue:
-            let cell = UITableViewCell(style: .default, reuseIdentifier: "appOpenSettingsCellIdentifier")
+            let cell = tableView.dequeueReusableCell(withIdentifier: "appOpenSettingsCellIdentifier", for: indexPath)
+
             cell.textLabel?.text = NSLocalizedString("Open app settings", comment: "")
             cell.textLabel?.textAlignment = .center
             cell.textLabel?.textColor = UIColor.systemBlue
@@ -323,7 +329,7 @@ class DiagnosticsTableViewController: UITableViewController {
             break
         }
 
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "appCellIdentifier")
+        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
 
         switch indexPath.row {
         case AppSections.kAppSectionName.rawValue:
@@ -343,8 +349,8 @@ class DiagnosticsTableViewController: UITableViewController {
         return cell
     }
 
-    func appAVAccessCell(for mediaType: AVMediaType) -> UITableViewCell {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "appAVAccessCellIdentifier")
+    func appAVAccessCell(for mediaType: AVMediaType, for indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
         let authStatusAV = AVCaptureDevice.authorizationStatus(for: mediaType)
 
         if mediaType == .audio {
@@ -359,7 +365,6 @@ class DiagnosticsTableViewController: UITableViewController {
 
         case .denied:
             cell.detailTextLabel?.text = deniedString + "\n" + deniedFunctionalityString
-            cell.detailTextLabel?.numberOfLines = 2
 
         default:
             cell.detailTextLabel?.text = notRequestedString
@@ -368,10 +373,9 @@ class DiagnosticsTableViewController: UITableViewController {
         return cell
     }
 
-    func appContactsAccessCell() -> UITableViewCell {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "appContactsAccessCellIdentifier")
+    func appContactsAccessCell(for indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
         cell.textLabel?.text = NSLocalizedString("Contact access", comment: "")
-        cell.detailTextLabel?.numberOfLines = 1
 
         switch CNContactStore.authorizationStatus(for: .contacts) {
         case .authorized:
@@ -379,7 +383,6 @@ class DiagnosticsTableViewController: UITableViewController {
 
         case .denied:
             cell.detailTextLabel?.text = deniedString + "\n" + deniedFunctionalityString
-            cell.detailTextLabel?.numberOfLines = 2
 
         default:
             cell.detailTextLabel?.text = notRequestedString
@@ -388,10 +391,9 @@ class DiagnosticsTableViewController: UITableViewController {
         return cell
     }
 
-    func appLocationAccessCell() -> UITableViewCell {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "appLocationAccessCellIdentifier")
+    func appLocationAccessCell(for indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
         cell.textLabel?.text = NSLocalizedString("Location access", comment: "")
-        cell.detailTextLabel?.numberOfLines = 1
 
         if CLLocationManager.locationServicesEnabled() {
             switch CLLocationManager.authorizationStatus() {
@@ -400,7 +402,6 @@ class DiagnosticsTableViewController: UITableViewController {
 
             case .denied:
                 cell.detailTextLabel?.text = deniedString + "\n" + deniedFunctionalityString
-                cell.detailTextLabel?.numberOfLines = 2
 
             default:
                 cell.detailTextLabel?.text = notRequestedString
@@ -413,10 +414,9 @@ class DiagnosticsTableViewController: UITableViewController {
         return cell
     }
 
-    func appPhotoLibraryAccessCell() -> UITableViewCell {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "appPhotoLibraryAccessCellIdentifier")
+    func appPhotoLibraryAccessCell(for indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
         cell.textLabel?.text = NSLocalizedString("Photo library access", comment: "")
-        cell.detailTextLabel?.numberOfLines = 1
 
         switch PHPhotoLibrary.authorizationStatus() {
         case .authorized:
@@ -424,7 +424,6 @@ class DiagnosticsTableViewController: UITableViewController {
 
         case .denied:
             cell.detailTextLabel?.text = deniedString + "\n" + deniedFunctionalityString
-            cell.detailTextLabel?.numberOfLines = 2
 
         default:
             cell.detailTextLabel?.text = notRequestedString
@@ -433,10 +432,10 @@ class DiagnosticsTableViewController: UITableViewController {
         return cell
     }
 
-    func appNotificationsCell() -> UITableViewCell {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "appNotificationsCellIdentifier")
+    func appNotificationsCell(for indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleAccessoryCellIdentifier", for: indexPath)
         cell.textLabel?.text = NSLocalizedString("Notifications", comment: "")
-        cell.detailTextLabel?.numberOfLines = 1
+        cell.accessoryType = .none
         cell.accessoryView = nil
 
         if notificationSettingsIndicator.isAnimating {
@@ -449,7 +448,6 @@ class DiagnosticsTableViewController: UITableViewController {
 
             case .denied:
                 cell.detailTextLabel?.text = deniedString + "\n" + deniedFunctionalityString
-                cell.detailTextLabel?.numberOfLines = 2
 
             default:
                 cell.detailTextLabel?.text = notRequestedString
@@ -460,7 +458,7 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func accountCell(for indexPath: IndexPath) -> UITableViewCell {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "accountCellIdentifier")
+        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
 
         switch indexPath.row {
         case AccountSections.kAccountSectionServer.rawValue:
@@ -483,7 +481,8 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func serverCell(for indexPath: IndexPath) -> UITableViewCell {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "serverCellIdentifier")
+        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleAccessoryCellIdentifier", for: indexPath)
+        cell.accessoryType = .none
         cell.accessoryView = nil
 
         switch indexPath.row {
@@ -517,8 +516,9 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func talkCell(for indexPath: IndexPath) -> UITableViewCell {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "talkCellIdentifier")
+        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleAccessoryCellIdentifier", for: indexPath)
         cell.accessoryType = .none
+        cell.accessoryView = nil
 
         switch indexPath.row {
         case TalkSections.kTalkSectionVersion.rawValue:
@@ -552,9 +552,7 @@ class DiagnosticsTableViewController: UITableViewController {
     }
 
     func signalingCell(for indexPath: IndexPath) -> UITableViewCell {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "signalingCellIdentifier")
-        cell.accessoryType = .none
-        cell.detailTextLabel?.numberOfLines = 1
+        let cell = tableView.dequeueReusableCell(withIdentifier: "subtitleCellIdentifier", for: indexPath)
 
         let allSectionsIndex = signalingSections[indexPath.row]
 
@@ -604,7 +602,6 @@ class DiagnosticsTableViewController: UITableViewController {
                 }
 
                 cell.detailTextLabel?.text = stunServers.joined(separator: "\n")
-                cell.detailTextLabel?.numberOfLines = stunServers.count
             }
 
         case AllSignalingSections.kSignalingSectionTurnServers.rawValue:
@@ -632,7 +629,6 @@ class DiagnosticsTableViewController: UITableViewController {
                 }
 
                 cell.detailTextLabel?.text = turnServers.joined(separator: "\n")
-                cell.detailTextLabel?.numberOfLines = turnServers.count
             }
 
         default:

--- a/NextcloudTalk/DiagnosticsTableViewController.swift
+++ b/NextcloudTalk/DiagnosticsTableViewController.swift
@@ -604,7 +604,9 @@ class DiagnosticsTableViewController: UITableViewController {
                     }
                 }
 
-                cell.detailTextLabel?.text = stunServers.joined(separator: "\n")
+                if !stunServers.isEmpty {
+                    cell.detailTextLabel?.text = stunServers.joined(separator: "\n")
+                }
             }
 
         case AllSignalingSections.kSignalingSectionTurnServers.rawValue:
@@ -631,7 +633,9 @@ class DiagnosticsTableViewController: UITableViewController {
                     }
                 }
 
-                cell.detailTextLabel?.text = turnServers.joined(separator: "\n")
+                if !turnServers.isEmpty {
+                    cell.detailTextLabel?.text = turnServers.joined(separator: "\n")
+                }
             }
 
         default:

--- a/NextcloudTalk/SubtitleTableViewCell.swift
+++ b/NextcloudTalk/SubtitleTableViewCell.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2022 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+class SubtitleTableViewCell: UITableViewCell {
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+
+        detailTextLabel?.numberOfLines = 0
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}


### PR DESCRIPTION
Previously a new cell was always allocated, instead of correctly dequeuing a reusable one. Same issue exists in SettingsTableViewController.
Also this PR allows word wrapping for the cells:

Before:
![image](https://user-images.githubusercontent.com/1580193/189538599-fe9a2667-bf5d-471f-b352-63162b5cd683.png)

After:
![image](https://user-images.githubusercontent.com/1580193/189538633-e782d1b5-b893-472d-a98e-aea0d0927901.png)
