### PR TITLE
Fix create new conversation issue

### DIFF
--- a/NextcloudTalk/NewRoomTableViewController.m
+++ b/NextcloudTalk/NewRoomTableViewController.m
@@ -429,7 +429,7 @@ NSString * const NCSelectedContactForChatNotification = @"NCSelectedContactForCh
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (!_searchController.active && indexPath.section == 0) {
+    if (!(_searchController.active && _resultTableViewController.contacts.count > 0) && indexPath.section == 0) {
         switch (indexPath.row) {
             case kHeaderSectionNewGroup:
                 [self startCreatingNewGroup];


### PR DESCRIPTION
When the search controller is active without any text in it, you could not select "Group" or "Public" converastion options.
This PR fixes the search controller check and allows to click on those options.