### PR TITLE
Fix reaction on mac

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1F3D3B22255F109E00230DAE /* BarButtonItemWithActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F3D3B20255F109E00230DAE /* BarButtonItemWithActivity.m */; };
+		1F468E7628DCC6C60099597B /* Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 1F468E7528DCC6C60099597B /* Dynamic */; };
+		1F468E7828DCC7310099597B /* EmojiTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F468E7728DCC7310099597B /* EmojiTextField.swift */; };
 		1F4DD3EB2571C688007DC98E /* EmojiUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4DD3EA2571C688007DC98E /* EmojiUtils.swift */; };
 		1F4DD3EC2571C688007DC98E /* EmojiUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4DD3EA2571C688007DC98E /* EmojiUtils.swift */; };
 		1F4DD3ED2571C688007DC98E /* EmojiUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4DD3EA2571C688007DC98E /* EmojiUtils.swift */; };
@@ -344,6 +346,7 @@
 /* Begin PBXFileReference section */
 		1F3D3B20255F109E00230DAE /* BarButtonItemWithActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BarButtonItemWithActivity.m; sourceTree = "<group>"; };
 		1F3D3B21255F109E00230DAE /* BarButtonItemWithActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BarButtonItemWithActivity.h; sourceTree = "<group>"; };
+		1F468E7728DCC7310099597B /* EmojiTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiTextField.swift; sourceTree = "<group>"; };
 		1F4DD3EA2571C688007DC98E /* EmojiUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiUtils.swift; sourceTree = "<group>"; };
 		1F5CDF622584E78900B0026E /* NCChatFileStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NCChatFileStatus.h; sourceTree = "<group>"; };
 		1F5CDF632584E78900B0026E /* NCChatFileStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NCChatFileStatus.m; sourceTree = "<group>"; };
@@ -747,6 +750,7 @@
 				2C90E5671EDDE1340093D85A /* CoreGraphics.framework in Frameworks */,
 				2C90E5641EDDE0FB0093D85A /* Foundation.framework in Frameworks */,
 				2CC5F0982716FF1900DE1775 /* NCCommunication in Frameworks */,
+				1F468E7628DCC6C60099597B /* Dynamic in Frameworks */,
 				2C38D4AC27BBAFCC00BAE015 /* WebRTC.xcframework in Frameworks */,
 				9993261EDAC77481FF4EF58A /* libPods-NextcloudTalk.a in Frameworks */,
 			);
@@ -876,6 +880,7 @@
 				2CEDA88B26F492610044552B /* NSMutableAttributedString+Extensions.swift */,
 				1F61C76A285F65E1004D74D8 /* SimpleTableViewController.swift */,
 				1FB6678E28CE381300D29F8D /* SubtitleTableViewCell.swift */,
+				1F468E7728DCC7310099597B /* EmojiTextField.swift */,
 			);
 			name = "User Interface";
 			sourceTree = "<group>";
@@ -1396,6 +1401,7 @@
 			packageProductDependencies = (
 				2CC5F0972716FF1900DE1775 /* NCCommunication */,
 				2CCCD21C2835088F00F076CE /* OpenSSL */,
+				1F468E7528DCC6C60099597B /* Dynamic */,
 			);
 			productName = NextcloudTalk;
 			productReference = 2C05747D1EDD9E8E00D9E7F2 /* NextcloudTalk.app */;
@@ -1519,6 +1525,7 @@
 			packageReferences = (
 				2CC5F0962716FF1900DE1775 /* XCRemoteSwiftPackageReference "ios-communication-library" */,
 				2CCCD21B2835088F00F076CE /* XCRemoteSwiftPackageReference "OpenSSL" */,
+				1F468E7428DCC6C60099597B /* XCRemoteSwiftPackageReference "Dynamic" */,
 			);
 			productRefGroup = 2C05747E1EDD9E8E00D9E7F2 /* Products */;
 			projectDirPath = "";
@@ -1888,6 +1895,7 @@
 				2C92195C1F58530B008AC1A3 /* UIImageView+Letters.m in Sources */,
 				2C4D7D691F2F7DBC00FF4A0D /* ARDSettingsModel.m in Sources */,
 				2CB6ACBC26385A3800D3D641 /* ShareLocationViewController.m in Sources */,
+				1F468E7828DCC7310099597B /* EmojiTextField.swift in Sources */,
 				2C444708265E59BC00DF1DBC /* ShareItemController.m in Sources */,
 				2CA1CC951F014EF9002FE6A2 /* NCSettingsController.m in Sources */,
 				2C440D1120EA4A770005F9BB /* RoomInfoTableViewController.m in Sources */,
@@ -2670,6 +2678,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		1F468E7428DCC6C60099597B /* XCRemoteSwiftPackageReference "Dynamic" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mhdhejazi/Dynamic.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 		2CC5F0962716FF1900DE1775 /* XCRemoteSwiftPackageReference "ios-communication-library" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nextcloud/ios-communication-library";
@@ -2689,6 +2705,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		1F468E7528DCC6C60099597B /* Dynamic */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1F468E7428DCC6C60099597B /* XCRemoteSwiftPackageReference "Dynamic" */;
+			productName = Dynamic;
+		};
 		2CC5F0972716FF1900DE1775 /* NCCommunication */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2CC5F0962716FF1900DE1775 /* XCRemoteSwiftPackageReference "ios-communication-library" */;

--- a/NextcloudTalk/DebounceWebView.swift
+++ b/NextcloudTalk/DebounceWebView.swift
@@ -26,17 +26,16 @@ class DebounceWebView: WKWebView {
 
     // See: https://developer.apple.com/forums/thread/696525?answerId=708067022#708067022
     override func paste(_ sender: Any?) {
-        if #available(iOS 14.0, *) {
-            if ProcessInfo.processInfo.isiOSAppOnMac {
-                let currentPasteTimestamp: TimeInterval = Date().timeIntervalSinceReferenceDate
+        if NCUtils.isiOSAppOnMac() {
+            let currentPasteTimestamp: TimeInterval = Date().timeIntervalSinceReferenceDate
 
-                if currentPasteTimestamp - previousPasteTimestamp < 0.2 {
-                    return
-                }
-
-                previousPasteTimestamp = currentPasteTimestamp
+            if currentPasteTimestamp - previousPasteTimestamp < 0.2 {
+                return
             }
+
+            previousPasteTimestamp = currentPasteTimestamp
         }
+        
         super.paste(sender)
     }
 }

--- a/NextcloudTalk/EmojiTextField.swift
+++ b/NextcloudTalk/EmojiTextField.swift
@@ -57,8 +57,4 @@ import Dynamic
 
         return result
     }
-
-    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        return false
-    }
 }

--- a/NextcloudTalk/EmojiTextField.swift
+++ b/NextcloudTalk/EmojiTextField.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2020 Ivan Sein <ivan@nextcloud.com>
+//
+// Author Ivan Sein <ivan@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+@objc class EmojiTextField: UITextField {
+
+    // required for iOS 13
+    override var textInputContextIdentifier: String? { "" } // return non-nil to show the Emoji keyboard ¯\_(ツ)_/¯
+
+    override var textInputMode: UITextInputMode? {
+        for mode in UITextInputMode.activeInputModes where mode.primaryLanguage == "emoji" {
+            return mode
+        }
+        return nil
+    }
+}

--- a/NextcloudTalk/EmojiTextField.swift
+++ b/NextcloudTalk/EmojiTextField.swift
@@ -19,7 +19,21 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import Dynamic
+
 @objc class EmojiTextField: UITextField {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        tintColor = .clear
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+
+        tintColor = .clear
+    }
 
     // required for iOS 13
     override var textInputContextIdentifier: String? { "" } // return non-nil to show the Emoji keyboard ¯\_(ツ)_/¯
@@ -29,5 +43,22 @@
             return mode
         }
         return nil
+    }
+
+    @discardableResult override func becomeFirstResponder() -> Bool {
+        let result = super.becomeFirstResponder()
+
+        if result && NCUtils.isiOSAppOnMac() {
+            // Open the emoji picker when running on Mac OS
+
+            let app = Dynamic.NSApplication.sharedApplication()
+            app.orderFrontCharacterPalette(nil)
+        }
+
+        return result
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+        return false
     }
 }

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1478,8 +1478,13 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
             CGRect rowRect = [self.tableView rectForRowAtIndexPath:indexPath];
             CGRect convertedRowRect = [self.tableView convertRect:rowRect toView:self.view];
 
+            // Show the emoji picker at the textView location of the cell
+            convertedRowRect.origin.y += convertedRowRect.size.height - 16;
+            convertedRowRect.origin.x += 54;
+
             // We don't want to have a clickable textField floating around
             convertedRowRect.size.width = 0;
+            convertedRowRect.size.height = 0;
 
             // Remove and add the emojiTextField to the view, so the Mac OS emoji picker is always at the right location
             [self.emojiTextField removeFromSuperview];

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1467,10 +1467,26 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.textView resignFirstResponder];
     });
+
     // Present emoji keyboard
     dispatch_async(dispatch_get_main_queue(), ^{
         self.reactingMessage = message;
         self.lastMessageBeforeReaction = [[self.tableView indexPathsForVisibleRows] lastObject];
+
+        if ([NCUtils isiOSAppOnMac]) {
+            // Move the emojiTextField to the position of the cell
+            CGRect rowRect = [self.tableView rectForRowAtIndexPath:indexPath];
+            CGRect convertedRowRect = [self.tableView convertRect:rowRect toView:self.view];
+
+            // We don't want to have a clickable textField floating around
+            convertedRowRect.size.width = 0;
+
+            // Remove and add the emojiTextField to the view, so the Mac OS emoji picker is always at the right location
+            [self.emojiTextField removeFromSuperview];
+            [self.emojiTextField setFrame:convertedRowRect];
+            [self.view addSubview:self.emojiTextField];
+        }
+
         [self.emojiTextField becomeFirstResponder];
     });
 }

--- a/NextcloudTalk/NCUtils.h
+++ b/NextcloudTalk/NCUtils.h
@@ -58,6 +58,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)log:(NSString *)message;
 
++ (BOOL)isiOSAppOnMac;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/NextcloudTalk/NCUtils.m
+++ b/NextcloudTalk/NCUtils.m
@@ -404,4 +404,13 @@ static NSString *const nextcloudScheme = @"nextcloud:";
     }
 }
 
++ (BOOL)isiOSAppOnMac
+{
+    if (@available(iOS 14.0, *)) {
+        return [NSProcessInfo processInfo].isiOSAppOnMac;
+    }
+
+    return false;
+}
+
 @end

--- a/NextcloudTalk/UserStatusMessageViewController.swift
+++ b/NextcloudTalk/UserStatusMessageViewController.swift
@@ -402,16 +402,3 @@ extension UserStatusMessageViewController: UITableViewDataSource {
         return cell
     }
 }
-
-@objc class EmojiTextField: UITextField {
-
-    // required for iOS 13
-    override var textInputContextIdentifier: String? { "" } // return non-nil to show the Emoji keyboard ¯\_(ツ)_/¯
-
-    override var textInputMode: UITextInputMode? {
-        for mode in UITextInputMode.activeInputModes where mode.primaryLanguage == "emoji" {
-            return mode
-        }
-        return nil
-    }
-}


### PR DESCRIPTION
Fixes #837 

The way we invoke the emoji keyboard in iOS does not work when running on a Mac. In this case we need to open the emoji picker built into Mac OS. This can be done by accessing `NSApplication` which by default is not accessible in an iOS application. Therefore the `Dynamic` library was added to access the needed methods. 
To show the emoji picker always at the correct location, we need to remove and then re-add the `emojiTextField`. Otherwise the location will be correct for the first time we open the picker, but depending on how the second row was selected, it might stay at the old location (although still targeting the new row).

There's still a small issue left (probably not happening a lot in real world usage): 
* Choose "Add reaction" on row 1
* Leave emoji picker open
* Do a right click on row 2 and select "Add reaction"
* The picker will not be visible anymore, but shows, after another click 

