### PR TITLE
Workaround to fix xcode 14 build failed error about signing bundles.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,3 +47,13 @@ pre_install do |installer|
     puts 'end pre_install.'
 end
 
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    if target.respond_to?(:product_type) and target.product_type == "com.apple.product-type.bundle"
+      target.build_configurations.each do |config|
+          config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This PR allows to build the app using XCode 14.