### PR TITLE
Fix unread mention bottom button color

### DIFF
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -666,6 +666,10 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
     // Update unread mentions indicator visibility
     if (_lastRoomWithMentionIndexPath) {
         _unreadMentionsBottomButton.hidden = [visibleRows containsObject:_lastRoomWithMentionIndexPath] || lastVisibleRowIndexPath.row > _lastRoomWithMentionIndexPath.row;
+
+        // Make sure the style is adjusted to current accounts theme
+        _unreadMentionsBottomButton.backgroundColor = [NCAppBranding themeColor];
+        [_unreadMentionsBottomButton setTitleColor:[NCAppBranding themeTextColor] forState:UIControlStateNormal];
     }
 }
 


### PR DESCRIPTION
Steps to reproduce:
* Open the app starting with a account with custom theming colors
* Switch over to a account without / different theming colors which shows a unread mention bottom button

-> The button is still in the colors of the account the app was started with