### PR TITLE
Link preview fixes

### DIFF
--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -649,7 +649,7 @@ NSString * const kSharedItemTypeVoice       = @"voice";
         NSURL *url = [match URL];
         NSString *scheme = [url scheme];
 
-        if ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]) {
+        if ([[scheme lowercaseString] isEqualToString:@"http"] || [[scheme lowercaseString] isEqualToString:@"https"]) {
             _urlDetected = [url absoluteString];
             return true;
         }

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -649,6 +649,7 @@ NSString * const kSharedItemTypeVoice       = @"voice";
         NSURL *url = [match URL];
         NSString *scheme = [url scheme];
 
+        // Check that the scheme is either https or http, because other schemes (like mailto) would be recognized as well
         if ([[scheme lowercaseString] isEqualToString:@"http"] || [[scheme lowercaseString] isEqualToString:@"https"]) {
             _urlDetected = [url absoluteString];
             return true;

--- a/NextcloudTalk/ReferenceGithubView.swift
+++ b/NextcloudTalk/ReferenceGithubView.swift
@@ -55,6 +55,7 @@ import Foundation
         referenceBody.textContainerInset = .zero
         referenceBody.textContainer.lineFragmentPadding = .zero
         referenceBody.textContainer.lineBreakMode = .byTruncatingTail
+        referenceBody.textContainer.maximumNumberOfLines = 3
 
         let tap = UITapGestureRecognizer(target: self, action: #selector(self.handleTap))
         contentView.addGestureRecognizer(tap)


### PR DESCRIPTION
Two small fixes:

1. The scheme is actually case sensitive, so if a url like "Https://github.com" is posted, it won't match and won't show a link preview (although perfectly fine in terms of a url).

2. Noticed that sometimes the textview gets truncated correctly, but still shows part of the next line, therefore limit it to 3 lines for now explicitly:
<img width="264" alt="image" src="https://user-images.githubusercontent.com/1580193/194043221-2d966bf2-5729-4f46-b674-dca0ed4af84c.png">