### PR TITLE
Adjust space between title and comment icon

### DIFF
--- a/NextcloudTalk/ReferenceGithubView.xib
+++ b/NextcloudTalk/ReferenceGithubView.xib
@@ -28,7 +28,7 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iby-r5-06p">
-                    <rect key="frame" x="40" y="10" width="457.5" height="18"/>
+                    <rect key="frame" x="40" y="10" width="492.5" height="18"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -57,7 +57,7 @@
             </subviews>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstItem="0Ho-aZ-xOH" firstAttribute="leading" secondItem="Iby-r5-06p" secondAttribute="trailing" constant="40" id="11S-43-a43"/>
+                <constraint firstItem="0Ho-aZ-xOH" firstAttribute="leading" secondItem="Iby-r5-06p" secondAttribute="trailing" constant="5" id="11S-43-a43"/>
                 <constraint firstAttribute="trailing" secondItem="0Ho-aZ-xOH" secondAttribute="trailing" priority="750" constant="29" id="2t1-6s-XbH"/>
                 <constraint firstItem="Iby-r5-06p" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="10" id="BrA-8P-nYn"/>
                 <constraint firstAttribute="trailing" secondItem="WRq-4l-Gy5" secondAttribute="trailing" constant="10" id="Mov-JW-ht7"/>


### PR DESCRIPTION
Small adjustment:

<img width="343" alt="Bildschirmfoto 2022-10-06 um 21 48 56" src="https://user-images.githubusercontent.com/1580193/194405729-33f07544-e9e3-4e25-8eec-50a59a10565d.png">


<img width="355" alt="Bildschirmfoto 2022-10-06 um 21 49 40" src="https://user-images.githubusercontent.com/1580193/194405723-8379780b-e4ec-4d37-bd8b-dbe655f0827d.png">
