### PR TITLE
Use reference provider to retrieve details of a shared deck card

### DIFF
--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -640,6 +640,19 @@ NSString * const kSharedItemTypeVoice       = @"voice";
         return ([_urlDetected length] != 0);
     }
 
+    // Check if the message is a shared deck card and a reference provider can be used to retrieve details
+    if (self.deckCard != nil && self.deckCard.link != nil && [self.deckCard.link length] > 0) {
+        // Check capabilities directly, otherwise NCSettingsController introduces new dependencies in NotificationServiceExtension
+        TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+        ServerCapabilities *serverCapabilities  = [[NCDatabaseManager sharedInstance] serverCapabilitiesForAccountId:activeAccount.accountId];
+
+        if (serverCapabilities && serverCapabilities.referenceApiSupported) {
+            _urlDetectionDone = YES;
+            _urlDetected = _deckCardParameter.link;
+            return true;
+        }
+    }
+
     NSDataDetector *dataDetector = [[NSDataDetector alloc] initWithTypes:NSTextCheckingTypeLink error:nil];
     NSArray *urlMatches = [dataDetector matchesInString:self.message options:0 range:NSMakeRange(0, [self.message length])];
 

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -31,7 +31,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 40;
+uint64_t const kTalkDatabaseSchemaVersion           = 41;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";
@@ -319,6 +319,7 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
 - (void)setServerCapabilities:(NSDictionary *)serverCapabilities forAccountId:(NSString *)accountId
 {
     NSDictionary *serverCaps = [serverCapabilities objectForKey:@"capabilities"];
+    NSDictionary *coreCaps = [serverCaps objectForKey:@"core"];
     NSDictionary *version = [serverCapabilities objectForKey:@"version"];
     NSDictionary *themingCaps = [serverCaps objectForKey:@"theming"];
     NSDictionary *talkCaps = [serverCaps objectForKey:@"spreed"];
@@ -366,6 +367,7 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
     }
     capabilities.talkVersion = [talkCaps objectForKey:@"version"];
     capabilities.guestsAppEnabled = [[guestsCaps objectForKey:@"enabled"] boolValue];
+    capabilities.referenceApiSupported = [[coreCaps objectForKey:@"reference-api"] boolValue];
     
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm transactionWithBlock:^{

--- a/NextcloudTalk/NCSettingsController.h
+++ b/NextcloudTalk/NCSettingsController.h
@@ -78,6 +78,7 @@ typedef enum NCPreferredFileSorting {
 - (BOOL)canCreateGroupAndPublicRooms;
 - (BOOL)callsEnabledCapability;
 - (BOOL)isGuestsAppEnabled;
+- (BOOL)isReferenceApiSupported;
 - (NCPreferredFileSorting)getPreferredFileSorting;
 - (void)setPreferredFileSorting:(NCPreferredFileSorting)sorting;
 - (BOOL)isContactSyncEnabled;

--- a/NextcloudTalk/NCSettingsController.m
+++ b/NextcloudTalk/NCSettingsController.m
@@ -475,6 +475,16 @@ NSString * const kContactSyncEnabled  = @"contactSyncEnabled";
     return NO;
 }
 
+- (BOOL)isReferenceApiSupported
+{
+    TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+    ServerCapabilities *serverCapabilities  = [[NCDatabaseManager sharedInstance] serverCapabilitiesForAccountId:activeAccount.accountId];
+    if (serverCapabilities) {
+        return serverCapabilities.referenceApiSupported;
+    }
+    return NO;
+}
+
 #pragma mark - Push Notifications
 
 - (void)subscribeForPushNotificationsForAccountId:(NSString *)accountId

--- a/NextcloudTalk/ServerCapabilities.h
+++ b/NextcloudTalk/ServerCapabilities.h
@@ -59,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSString *talkVersion;
 @property NSString *externalSignalingServerVersion;
 @property BOOL guestsAppEnabled;
+@property BOOL referenceApiSupported;
 
 @end
 


### PR DESCRIPTION
Before:
<img src="https://user-images.githubusercontent.com/1580193/195338655-94a0e49c-dd09-4eb9-ae17-fa685d614425.png" width="400">

After:
<img src="https://user-images.githubusercontent.com/1580193/195338685-eed0c0a9-a3b0-4b50-966c-c9c31813a7f0.png" width="400">

The changes in `NCSettingsController` are not really necessary at the moment (*), for completeness it makes sense, but could also be removed... I'm fine either way :-)

*) When we use `NCSettingsController` in `NCChatMessage` we need to introduce additional dependencies to notification service extension, which I would prefer not to do.