### PR TITLE
Background push subscription

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -216,7 +216,7 @@
     if (!isAppInBackground) {
         // Try to subscribe for push notifications in all accounts
         for (TalkAccount *account in [[NCDatabaseManager sharedInstance] allAccounts]) {
-            [[NCSettingsController sharedInstance] subscribeForPushNotificationsForAccountId:account.accountId];
+            [[NCSettingsController sharedInstance] subscribeForPushNotificationsForAccountId:account.accountId withCompletionBlock:nil];
         }
     }
 }

--- a/NextcloudTalk/NCSettingsController.h
+++ b/NextcloudTalk/NCSettingsController.h
@@ -49,6 +49,7 @@ typedef void (^UpdatedProfileCompletionBlock)(NSError *error);
 typedef void (^LogoutCompletionBlock)(NSError *error);
 typedef void (^GetCapabilitiesCompletionBlock)(NSError *error);
 typedef void (^GetSignalingConfigCompletionBlock)(NSError *error);
+typedef void (^SubscribeForPushNotificationsCompletionBlock)(BOOL success);
 
 typedef enum NCPreferredFileSorting {
     NCAlphabeticalSorting = 1,
@@ -73,7 +74,7 @@ typedef enum NCPreferredFileSorting {
 - (void)getSignalingConfigurationWithCompletionBlock:(GetSignalingConfigCompletionBlock)block;
 - (void)setSignalingConfigurationForAccountId:(NSString *)accountId;
 - (NCExternalSignalingController *)externalSignalingControllerForAccountId:(NSString *)accountId;
-- (void)subscribeForPushNotificationsForAccountId:(NSString *)accountId;
+- (void)subscribeForPushNotificationsForAccountId:(NSString *)accountId withCompletionBlock:(SubscribeForPushNotificationsCompletionBlock)block;
 - (NSInteger)chatMaxLengthConfigCapability;
 - (BOOL)canCreateGroupAndPublicRooms;
 - (BOOL)callsEnabledCapability;

--- a/NextcloudTalk/NCSettingsController.m
+++ b/NextcloudTalk/NCSettingsController.m
@@ -570,6 +570,10 @@ NSString * const kContactSyncEnabled  = @"contactSyncEnabled";
             [bgTask stopBackgroundTask];
         }
     }];
+#else
+    if (block) {
+        block(YES);
+    }
 #endif
 }
 


### PR DESCRIPTION
According to #691 push proxy subscription should be done roughly every 24h and on every app start. Currently only when the app is freshly started a subscription happens. If the app keeps running in the background, no subscription process is triggered. 
This PR checks when doing a background refresh if there's a need to refresh the push proxy subscription, therefore fulfilling the requirements of #691.