### PR TITLE
Github color fix / race condition fix

### DIFF
--- a/NextcloudTalk/ChatMessageTableViewCell.m
+++ b/NextcloudTalk/ChatMessageTableViewCell.m
@@ -378,8 +378,10 @@
             _vConstraintReply[6].constant = 100;
         }
 
-        [message getReferenceDataWithCompletionBlock:^(NSDictionary *referenceData, NSString *url) {
-            [self.referenceView updateFor:referenceData and:url];
+        [message getReferenceDataWithCompletionBlock:^(NCChatMessage *message, NSDictionary *referenceData, NSString *url) {
+            if ([self.message isSameMessage:message]) {
+                [self.referenceView updateFor:referenceData and:url];
+            }
         }];
     }
 }

--- a/NextcloudTalk/GroupedChatMessageTableViewCell.m
+++ b/NextcloudTalk/GroupedChatMessageTableViewCell.m
@@ -133,8 +133,10 @@
         _vConstraint[2].constant = 5;
         _vConstraint[3].constant = 100;
 
-        [message getReferenceDataWithCompletionBlock:^(NSDictionary *referenceData, NSString *url) {
-            [self.referenceView updateFor:referenceData and:url];
+        [message getReferenceDataWithCompletionBlock:^(NCChatMessage *message, NSDictionary *referenceData, NSString *url) {
+            if ([self.message isSameMessage:message]) {
+                [self.referenceView updateFor:referenceData and:url];
+            }
         }];
     }
 }

--- a/NextcloudTalk/NCChatMessage.h
+++ b/NextcloudTalk/NCChatMessage.h
@@ -47,7 +47,9 @@ extern NSString * const kSharedItemTypeMedia;
 extern NSString * const kSharedItemTypeOther;
 extern NSString * const kSharedItemTypeVoice;
 
-typedef void (^GetReferenceDataCompletionBlock)(NSDictionary *referenceData, NSString *url);
+@class NCChatMessage;
+
+typedef void (^GetReferenceDataCompletionBlock)(NCChatMessage *message, NSDictionary *referenceData, NSString *url);
 
 @interface NCChatMessage : RLMObject <NSCopying>
 
@@ -103,5 +105,6 @@ typedef void (^GetReferenceDataCompletionBlock)(NSDictionary *referenceData, NSS
 - (void)removeReactionFromTemporayReactions:(NSString *)reaction;
 - (BOOL)containsURL;
 - (void)getReferenceDataWithCompletionBlock:(GetReferenceDataCompletionBlock)block;
+- (BOOL)isSameMessage:(NCChatMessage *)message;
 
 @end

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -663,20 +663,35 @@ NSString * const kSharedItemTypeVoice       = @"voice";
 {
     if (_referenceDataDone) {
         if (block) {
-            block(_referenceData, _urlDetected);
+            block(self, _referenceData, _urlDetected);
         }
     } else {
         TalkAccount *account = [[NCDatabaseManager sharedInstance] talkAccountForAccountId:_accountId];
 
         [[NCAPIController sharedInstance] getReferenceForUrlString:_urlDetected forAccount:account withCompletionBlock:^(NSDictionary *references, NSError *error) {
             if (block) {
-                block(references, self->_urlDetected);
+                block(self, references, self->_urlDetected);
             }
 
             self->_referenceData = references;
             self->_referenceDataDone = YES;
         }];
     }
+}
+
+- (BOOL)isSameMessage:(NCChatMessage *)message
+{
+    if (self.isTemporary) {
+        if ([self.referenceId isEqualToString:message.referenceId]) {
+            return YES;
+        }
+    } else {
+        if (self.messageId == message.messageId) {
+            return YES;
+        }
+    }
+
+    return NO;
 }
 
 @end

--- a/NextcloudTalk/ReferenceGithubView.swift
+++ b/NextcloudTalk/ReferenceGithubView.swift
@@ -81,7 +81,7 @@ import Foundation
                 if stateReason == "not_planned" {
                     image = UIImage(named: "github-issue-notplanned")?.withTintColor(UIColor.systemGray)
                 } else {
-                    image = UIImage(named: "github-issue-closed")?.withTintColor(UIColor.systemRed)
+                    image = UIImage(named: "github-issue-closed")?.withTintColor(UIColor.systemPurple)
                 }
             }
 


### PR DESCRIPTION
Change color of closed issues to purple (instead of red).

Fix a race condition which can occur if the cell is reused and the reference data wasn't retrieved before. As there was no check if the completionHandler is called for the correct message, the preview could show the wrong data.