### PR TITLE
Fix connected state in case of reconnecting/disconnecting

### DIFF
--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -47,7 +47,6 @@ static NSTimeInterval kMaxReconnectInterval     = 16;
 @property (nonatomic, strong) NSMutableArray* pendingMessages;
 @property (nonatomic, assign) NSInteger reconnectInterval;
 @property (nonatomic, strong) NSTimer *reconnectTimer;
-@property (nonatomic, assign) BOOL reconnecting;
 @property (nonatomic, assign) BOOL sessionChanged;
 
 @end
@@ -145,7 +144,7 @@ static NSTimeInterval kMaxReconnectInterval     = 16;
     
     [_webSocket cancel];
     _webSocket = nil;
-    _reconnecting = YES;
+    _connected = NO;
     
     [self setReconnectionTimer];
 }
@@ -161,6 +160,7 @@ static NSTimeInterval kMaxReconnectInterval     = 16;
     [self invalidateReconnectionTimer];
     [_webSocket cancel];
     _webSocket = nil;
+    _connected = NO;
 }
 
 - (void)setReconnectionTimer
@@ -297,6 +297,8 @@ static NSTimeInterval kMaxReconnectInterval     = 16;
     if ([_currentRoom isEqualToString:roomId]) {
         _currentRoom = nil;
         [self joinRoom:@"" withSessionId:@""];
+    } else {
+        NSLog(@"External signaling: Not leaving because it's not room we joined");
     }
 }
 


### PR DESCRIPTION
### Before this PR
* Enter a conversation
  * See that a join message is sent to HPB
* Move app to background
  * See that a leave message is sent to HPB
* Move app to foreground and then again to background
  * Notice that `_currentRoom` is empty and there's no leave message sent

Because we didn't reset the connected state, we try to send the join message on an invalid web socket. As the join is never sent, we never get a room message back, resulting in `_currentRoom` being empty and therefore canceling the leave.
Also the `_reconnecting` property was never used, so removed it in this PR.

### After this PR
* Enter a conversation
  * See that a join message is sent to HPB
* Move app to background
  * See that a leave message is sent to HPB
* Move app to foreground and then again to background
  * Join and leave message are correctly sent to HPB