### PR TITLE
Fix crash when opening a conversation from a push notification

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -530,6 +530,13 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 
 -(void)appDidBecomeActive:(NSNotification*)notification
 {
+    // Don't handle this event if the view is not loaded yet.
+    // Otherwise we try to join the room and receive new messages while
+    // viewDidLoad wasn't called, resulting in uninitialized dictionaries and crashes
+    if (!self.isViewLoaded) {
+        return;
+    }
+
     // Check if new messages were added while the app was inactive (eg. via background-refresh)
     NCChatMessage *lastMessage = [[self->_messages objectForKey:[self->_dateSections lastObject]] lastObject];
     

--- a/NextcloudTalk/NCSplitViewController.swift
+++ b/NextcloudTalk/NCSplitViewController.swift
@@ -79,7 +79,12 @@
                 if let navController = self.viewController(for: .secondary) as? UINavigationController,
                    vc is NCChatViewController {
 
-                    navController.setViewControllers([vc], animated: false)
+                    // Only set the viewController if there's actually an active one shown by showDetailViewController
+                    // Otherwise UI might break or crash (view not loaded correctly)
+                    // This might happen if a chatViewController is shown by a push notification
+                    if self.hasActiveChatViewController() {
+                        navController.setViewControllers([vc], animated: false)
+                    }
                 }
             }
         }

--- a/NextcloudTalk/NCUserInterfaceController.m
+++ b/NextcloudTalk/NCUserInterfaceController.m
@@ -337,12 +337,27 @@
     [self presentConversationsList];
 
     if (@available(iOS 14.0, *)) {
-        [_mainSplitViewController showDetailViewController:chatViewController sender:self];
+        if (_mainSplitViewController.transitionCoordinator == nil) {
+            // No ongoing animations -> show chatViewController directly
+            [_mainSplitViewController showDetailViewController:chatViewController sender:self];
+        } else {
+            // Wait until the splitViewController finished all it's animations.
+            // Otherwise the chatViewController might end up in the wrong column.
+            // This mainly happens when being in a conversation and tapping a push notification
+            // of another conversation.
+            [_mainSplitViewController.transitionCoordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+                // Nothing to do here, we are only interested in the completion block
+            } completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self->_mainSplitViewController showDetailViewController:chatViewController sender:self];
+                });
+            }];
+        }
     } else {
         [(UINavigationController *)_mainViewController pushViewController:chatViewController animated:YES];
     }
 
-    [_roomsTableViewController highlightSelectedRoom];
+    [_roomsTableViewController setSelectedRoomToken:chatViewController.room.token];
 }
 
 - (void)presentCallViewController:(CallViewController *)callViewController

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1246,7 +1246,6 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
     
     // Present room chat
     [self presentChatForRoomAtIndexPath:indexPath];
-    [self setSelectedRoomToken:[self roomForIndexPath:indexPath].token];
 }
 
 - (void)setSelectedRoomToken:(NSString *)selectedRoomToken


### PR DESCRIPTION
When you receive a push notification, the app might crash trying to open the corresponding conversation.
Also this PR fixes the room highlight after showing a conversation of a push notification.

### Crash when the app is running and a notification is tapped

* Be in conversation 1
* Receive a push notification of conversation 2 and tap on it

Conversation 1 is now left, the `RoomTableViewController` is briefly shown and then conversation 2 should be entered. When we try to show the `ChatViewController` of conversation 2 the animations of `SplitViewController` are not finished and calling `showDetailViewController` results in the `ChatViewController` being added to the wrong column (I suspect that we actually transition from primary column to secondary or vice versa at that moment). We now force the `ChatViewController` on the second column, although it's not actually there. This results in an invalid state and a crash.

The first solution here was to check if there's an active `ChatViewController` before forcing it to the second column. This solution might lead to problems further down the road, so I decided to check for a `transitionCoordinator` being available and additionally wait for all animations to complete.

### Crash when the app is in the background and a notification is tapped

This one is a bit tricky. The app gets activated after a push notification is tapped. As in the case above, an active conversation is left and the new conversation should be shown. 
The `ChatViewController` is allocated and initialized by a call to `initForRoom`. In this method we register all observers for notifications. It takes a moment for the `SplitViewController` to actually load the view and show it, but the controller already handles notifications. It happens pretty reliable that the controller receives the `UIApplicationDidBecomeActiveNotification` notification. This results in joining the room and retrieving the initial history before the view is loaded. After that, the view is loaded -> this resets some already filled dictionaries (messages and dateSections). When now a new message is received, the app crashes, because the we try to append it to a non-existing dateSection.

Correct order of events:
- `initForRoom`
- `viewDidLoad`
- `viewWillAppear`
- `[[NCRoomsManager sharedInstance] joinRoom:_room.token];`

Wrong order of events when in background and a push notification is tapped:
- `initForRoom`
- `appDidBecomeActive`
- `[[NCRoomsManager sharedInstance] joinRoom:_room.token];`
- `viewDidLoad`
- `viewWillAppear`


Tested on iPhone (iOS 16) and iPad (iOS 15).