### PR TITLE
Fix unread mentions position / disable gestures

### DIFF
--- a/NextcloudTalk/NCSplitViewController.swift
+++ b/NextcloudTalk/NCSplitViewController.swift
@@ -29,6 +29,9 @@
         self.delegate = self
         self.preferredDisplayMode = .allVisible
 
+        // As we always show the columns on iPads, we don't need gesture support
+        self.presentsWithGesture = false
+
         for viewController in self.viewControllers {
             if let navController = viewController as? UINavigationController {
                 navController.delegate = self

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -152,10 +152,11 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
 
     NSDictionary *views = @{@"unreadMentionsButton": _unreadMentionsBottomButton};
     NSDictionary *metrics = @{@"buttonWidth": @(buttonWidth)};
+    UILayoutGuide *margins = self.view.layoutMarginsGuide;
+    
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[unreadMentionsButton(28)]-30-|" options:0 metrics:nil views:views]];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(>=0)-[unreadMentionsButton(buttonWidth)]-(>=0)-|" options:0 metrics:metrics views:views]];
-    [self.view addConstraint:[NSLayoutConstraint constraintWithItem:self.view attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual
-                                                             toItem:_unreadMentionsBottomButton attribute:NSLayoutAttributeCenterX multiplier:1.f constant:0.f]];
+    [NSLayoutConstraint activateConstraints:@[[_unreadMentionsBottomButton.centerXAnchor constraintEqualToAnchor:margins.centerXAnchor]]];
     [self.view addConstraint:[_unreadMentionsBottomButton.bottomAnchor constraintEqualToAnchor:self.tableView.safeAreaLayoutGuide.bottomAnchor constant:-20]];
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appStateHasChanged:) name:NCAppStateHasChangedNotification object:nil];


### PR DESCRIPTION
Currently the unread mentions button is centered to the views centerXAnchor. The splitViewController slightly extends the view of the primary column to allow gestures, therefore the mentions button is not centered visually anymore. As this even happens after disabling gesture support, we now center to the layoutMarginsGuides centerXAnchor, which works fine on iPads (expanded and collapsed) and iPhones.