### PR TITLE
Fix calls on M1 Macs

### DIFF
--- a/NextcloudTalk/CallKitManager.m
+++ b/NextcloudTalk/CallKitManager.m
@@ -32,6 +32,7 @@
 #import "NCRoomsManager.h"
 #import "NCSettingsController.h"
 #import "NCUserInterfaceController.h"
+#import "NCUtils.h"
 
 NSString * const CallKitManagerDidAnswerCallNotification        = @"CallKitManagerDidAnswerCallNotification";
 NSString * const CallKitManagerDidEndCallNotification           = @"CallKitManagerDidEndCallNotification";
@@ -82,6 +83,13 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
 
 + (BOOL)isCallKitAvailable
 {
+    if ([NCUtils isiOSAppOnMac]) {
+        // There's currently no support for CallKit when running on MacOS.
+        // If this is enabled on MacOS, there's no audio, because we fail to retrieve
+        // the streams from CallKit. Tested with MacOS 12 & 13.
+        return NO;
+    }
+
     // CallKit should be deactivated in China as requested by Apple
     return ![NSLocale.currentLocale.countryCode isEqual: @"CN"];
 }

--- a/NextcloudTalk/NCKeyChainController.m
+++ b/NextcloudTalk/NCKeyChainController.m
@@ -25,6 +25,7 @@
 #import <CommonCrypto/CommonDigest.h>
 
 #import "NCAppBranding.h"
+#import "NCUtils.h"
 
 @implementation NCKeyChainController
 
@@ -101,6 +102,12 @@ NSString * const kNCPNPrivateKey                = @"ncPNPrivateKey";
 
     if (!normalPushToken || !pushKitToken) {
         return nil;
+    }
+
+    if ([NCUtils isiOSAppOnMac]) {
+        // As CallKit is not supported on MacOS, we only supply the
+        // normal push token, to generate local notifications for calls
+        return normalPushToken;
     }
 
     return [NSString stringWithFormat:@"%@ %@", normalPushToken, pushKitToken];


### PR DESCRIPTION
Fixes #729 

When running on a Mac CallKit is not available (although the classes are). When CallKit is not disabled, we use the audio streams from CallKit, but without CallKit, this obviously fails. So we disable CallKit when running on MacOS for now.
Also VoIP push notifications don't really work the way they should - they just wake the app without any further notification. So we don't provider the voip token in that case.