### PR TITLE
Report all calls to CallKit

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		1F61C767285E35A6004D74D8 /* DiagnosticsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F61C766285E35A6004D74D8 /* DiagnosticsTableViewController.swift */; };
 		1F61C76B285F65E1004D74D8 /* SimpleTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F61C76A285F65E1004D74D8 /* SimpleTableViewController.swift */; };
 		1F628CBA2842BAAF0083A425 /* QRCodeReader in Frameworks */ = {isa = PBXBuildFile; productRef = 1F628CB92842BAAF0083A425 /* QRCodeReader */; };
+		1F7625E52901B0DB00834869 /* CallsFromOldAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7625E42901B0DB00834869 /* CallsFromOldAccountViewController.swift */; };
+		1F7625E72901B0E800834869 /* CallsFromOldAccountViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1F7625E62901B0E800834869 /* CallsFromOldAccountViewController.xib */; };
 		1F90EFBC25FE39F800F3FA55 /* NCIntentController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F90EFBB25FE39F800F3FA55 /* NCIntentController.m */; };
 		1F90EFBD25FE39F800F3FA55 /* NCIntentController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F90EFBB25FE39F800F3FA55 /* NCIntentController.m */; };
 		1F90EFBE25FE39F800F3FA55 /* NCIntentController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F90EFBB25FE39F800F3FA55 /* NCIntentController.m */; };
@@ -376,6 +378,8 @@
 		1F5CDF632584E78900B0026E /* NCChatFileStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NCChatFileStatus.m; sourceTree = "<group>"; };
 		1F61C766285E35A6004D74D8 /* DiagnosticsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsTableViewController.swift; sourceTree = "<group>"; };
 		1F61C76A285F65E1004D74D8 /* SimpleTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleTableViewController.swift; sourceTree = "<group>"; };
+		1F7625E42901B0DB00834869 /* CallsFromOldAccountViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallsFromOldAccountViewController.swift; sourceTree = "<group>"; };
+		1F7625E62901B0E800834869 /* CallsFromOldAccountViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CallsFromOldAccountViewController.xib; sourceTree = "<group>"; };
 		1F90EFBA25FE39F800F3FA55 /* NCIntentController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NCIntentController.h; sourceTree = "<group>"; };
 		1F90EFBB25FE39F800F3FA55 /* NCIntentController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NCIntentController.m; sourceTree = "<group>"; };
 		1F90EFC225FE489B00F3FA55 /* IntentsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IntentsUI.framework; path = System/Library/Frameworks/IntentsUI.framework; sourceTree = SDKROOT; };
@@ -1150,6 +1154,8 @@
 				2C5E957B227097E0009CA9BE /* NCUtils.m */,
 				DA75580E278EEA1000A48A1B /* SettingsTableViewController.swift */,
 				1F61C766285E35A6004D74D8 /* DiagnosticsTableViewController.swift */,
+				1F7625E42901B0DB00834869 /* CallsFromOldAccountViewController.swift */,
+				1F7625E62901B0E800834869 /* CallsFromOldAccountViewController.xib */,
 				2C2026A32369F47400DFC89B /* AccountTableViewCell.xib */,
 				DA7558122790D65700A48A1B /* AccountTableViewCell.swift */,
 				2C7A1235200E0A5700864818 /* UserSettingsTableViewCell.xib */,
@@ -1646,6 +1652,7 @@
 				2C78EFA61F86FF4A008AFA74 /* CallParticipantViewCell.xib in Resources */,
 				2CC007CB20E125C20096D91F /* NewRoomTableViewController.xib in Resources */,
 				2C98F77D216231D3001A6A73 /* RoomTableViewCell.xib in Resources */,
+				1F7625E72901B0E800834869 /* CallsFromOldAccountViewController.xib in Resources */,
 				2CF9CBFF26025F65002246EF /* TextInputTableViewCell.xib in Resources */,
 				1F24B5A428E0649200654457 /* ReferenceGithubView.xib in Resources */,
 				2CC1FF4528147F11009F7288 /* RoomSharedItemsTableViewController.xib in Resources */,
@@ -1932,6 +1939,7 @@
 				2C78EF991F80F81E008AFA74 /* NCSignalingController.m in Sources */,
 				2CB304202264775E0053078A /* UIResponder+SLKAdditions.m in Sources */,
 				2C8E2A1B232174C20022BFC9 /* MessageSeparatorTableViewCell.m in Sources */,
+				1F7625E52901B0DB00834869 /* CallsFromOldAccountViewController.swift in Sources */,
 				2CB3041E2264775E0053078A /* SLKTextViewController.m in Sources */,
 				2CC007CE20E50B0A0096D91F /* MessageBodyTextView.m in Sources */,
 				2CBF82B21FCC7DBA00636459 /* CCCertificate.m in Sources */,

--- a/NextcloudTalk/CallKitManager.h
+++ b/NextcloudTalk/CallKitManager.h
@@ -53,6 +53,7 @@ extern NSString * const CallKitManagerDidFailRequestingCallTransaction;
 + (BOOL)isCallKitAvailable;
 - (void)reportIncomingCall:(NSString *)token withDisplayName:(NSString *)displayName forAccountId:(NSString *)accountId;
 - (void)reportIncomingCallForNonCallKitDevicesWithPushNotification:(NCPushNotification *)pushNotification;
+- (void)reportIncomingCallForOldAccount;
 - (void)startCall:(NSString *)token withVideoEnabled:(BOOL)videoEnabled andDisplayName:(NSString *)displayName silently:(BOOL)silently withAccountId:(NSString *)accountId;
 - (void)endCall:(NSString *)token;
 - (void)reportAudioMuted:(BOOL)muted forCall:(NSString *)token;

--- a/NextcloudTalk/CallsFromOldAccountViewController.swift
+++ b/NextcloudTalk/CallsFromOldAccountViewController.swift
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2022 Marcel Müller <marcel.mueller@nextcloud.com>
+//
+// Author Marcel Müller <marcel.mueller@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import UIKit
+
+class CallsFromOldAccountViewController: UIViewController {
+
+    @IBOutlet weak var warningTextLabel: UILabel!
+    @IBOutlet weak var acknowledgeWarningButton: NCButton!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: NCAppBranding.themeTextColor()]
+        self.navigationController?.navigationBar.tintColor = NCAppBranding.themeTextColor()
+        self.navigationController?.navigationBar.barTintColor = NCAppBranding.themeColor()
+        self.navigationController?.navigationBar.isTranslucent = false
+        self.navigationItem.title = NSLocalizedString("Calls from old account", comment: "")
+
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.titleTextAttributes = [.foregroundColor: NCAppBranding.themeTextColor()]
+        appearance.backgroundColor = NCAppBranding.themeColor()
+        self.navigationItem.standardAppearance = appearance
+        self.navigationItem.compactAppearance = appearance
+        self.navigationItem.scrollEdgeAppearance = appearance
+
+        acknowledgeWarningButton.setTitle(NSLocalizedString("Confirm and hide warning", comment: ""), for: .normal)
+        acknowledgeWarningButton.setButtonStyle(style: .primary)
+
+        let warning1 = NSLocalizedString("A call from an old account was received.", comment: "")
+        let warning2 = NSLocalizedString("This usually indicates that this device was previously used for an account, which was not properly removed from the server.", comment: "")
+        let warning3 = NSLocalizedString("To resolve this issue, use the web interface and go to 'Settings' -> 'Security'.", comment: "")
+        let warning4 = NSLocalizedString("Under 'Devices & sessions' check if there are duplicated entries for the same device.", comment: "")
+        let warning5 = NSLocalizedString("Remove old duplicate entries and leave just the most recent entries.", comment: "")
+        let warning6 = NSLocalizedString("If you're using multiple servers, you need to check all of them.", comment: "")
+
+        let warningTextComplete = warning1 + " " + warning2 + "\n\n" + warning3 + "\n\n" + warning4 + "\n\n" + warning5 + "\n\n" + warning6
+
+        warningTextLabel.text = warningTextComplete
+    }
+
+    @IBAction func acknowledgeWarningButtonPressed(_ sender: Any) {
+        NCSettingsController.sharedInstance().setDidReceiveCallsFromOldAccount(false)
+        self.navigationController?.popViewController(animated: true)
+    }
+
+}

--- a/NextcloudTalk/CallsFromOldAccountViewController.swift
+++ b/NextcloudTalk/CallsFromOldAccountViewController.swift
@@ -33,7 +33,7 @@ class CallsFromOldAccountViewController: UIViewController {
         self.navigationController?.navigationBar.tintColor = NCAppBranding.themeTextColor()
         self.navigationController?.navigationBar.barTintColor = NCAppBranding.themeColor()
         self.navigationController?.navigationBar.isTranslucent = false
-        self.navigationItem.title = NSLocalizedString("Calls from old account", comment: "")
+        self.navigationItem.title = NSLocalizedString("Calls from old accounts", comment: "")
 
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
@@ -46,7 +46,7 @@ class CallsFromOldAccountViewController: UIViewController {
         acknowledgeWarningButton.setTitle(NSLocalizedString("Confirm and hide warning", comment: ""), for: .normal)
         acknowledgeWarningButton.setButtonStyle(style: .primary)
 
-        let warning1 = NSLocalizedString("A call from an old account was received.", comment: "")
+        let warning1 = NSLocalizedString("Calls from an old account were received.", comment: "")
         let warning2 = NSLocalizedString("This usually indicates that this device was previously used for an account, which was not properly removed from the server.", comment: "")
         let warning3 = NSLocalizedString("To resolve this issue, use the web interface and go to 'Settings' -> 'Security'.", comment: "")
         let warning4 = NSLocalizedString("Under 'Devices & sessions' check if there are duplicated entries for the same device.", comment: "")

--- a/NextcloudTalk/CallsFromOldAccountViewController.xib
+++ b/NextcloudTalk/CallsFromOldAccountViewController.xib
@@ -27,7 +27,7 @@
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="otU-oy-cnr"/>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="wEz-so-ou3"/>
                     </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>

--- a/NextcloudTalk/CallsFromOldAccountViewController.xib
+++ b/NextcloudTalk/CallsFromOldAccountViewController.xib
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CallsFromOldAccountViewController" customModule="NextcloudTalk" customModuleProvider="target">
+            <connections>
+                <outlet property="acknowledgeWarningButton" destination="JBD-4r-MQ9" id="ghn-B9-JTK"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="warningTextLabel" destination="1Re-sk-ErK" id="cyq-ye-37V"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Re-sk-ErK">
+                    <rect key="frame" x="20" y="112" width="374" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="otU-oy-cnr"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="wEz-so-ou3"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JBD-4r-MQ9" customClass="NCButton" customModule="NextcloudTalk" customModuleProvider="target">
+                    <rect key="frame" x="158" y="163" width="98" height="40"/>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" id="J0b-me-Meq"/>
+                        <constraint firstAttribute="height" constant="40" id="pn7-f2-CaS"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                    <inset key="contentEdgeInsets" minX="24" minY="0.0" maxX="24" maxY="0.0"/>
+                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                    <state key="normal" title="Button">
+                        <color key="titleColor" systemColor="labelColor"/>
+                    </state>
+                    <connections>
+                        <action selector="acknowledgeWarningButtonPressed:" destination="-2" eventType="touchUpInside" id="ze0-sz-Jfl"/>
+                    </connections>
+                </button>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="1Re-sk-ErK" secondAttribute="trailing" constant="20" id="3BR-hb-od8"/>
+                <constraint firstItem="JBD-4r-MQ9" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="CUY-aC-JlA"/>
+                <constraint firstItem="JBD-4r-MQ9" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="ELA-6W-Vhe"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="JBD-4r-MQ9" secondAttribute="trailing" constant="20" id="YAf-Gp-ax1"/>
+                <constraint firstItem="JBD-4r-MQ9" firstAttribute="top" secondItem="1Re-sk-ErK" secondAttribute="bottom" constant="30" id="bpq-Kk-BgI"/>
+                <constraint firstItem="1Re-sk-ErK" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="20" id="lFh-YF-diq"/>
+                <constraint firstItem="1Re-sk-ErK" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="nHJ-ID-H47"/>
+            </constraints>
+            <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+            <point key="canvasLocation" x="82.608695652173921" y="91.741071428571431"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="labelColor">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/NextcloudTalk/NCNotificationController.h
+++ b/NextcloudTalk/NCNotificationController.h
@@ -30,7 +30,8 @@ extern NSString * const NCLocalNotificationJoinChatNotification;
 typedef enum {
     kNCLocalNotificationTypeMissedCall = 1,
     kNCLocalNotificationTypeCancelledCall,
-    kNCLocalNotificationTypeFailedSendChat
+    kNCLocalNotificationTypeFailedSendChat,
+    kNCLocalNotificationTypeCallFromOldAccount
 } NCLocalNotificationType;
 
 @interface NCNotificationController : NSObject
@@ -41,6 +42,7 @@ typedef enum {
 - (void)showLocalNotification:(NCLocalNotificationType)type withUserInfo:(NSDictionary *)userInfo;
 - (void)showLocalNotificationForIncomingCallWithPushNotificaion:(NCPushNotification *)pushNotification;
 - (void)showIncomingCallForPushNotification:(NCPushNotification *)pushNotification;
+- (void)showIncomingCallForOldAccount;
 - (void)removeAllNotificationsForAccountId:(NSString *)accountId;
 
 @end

--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -121,6 +121,14 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
             content.userInfo = userInfo;
         }
             break;
+
+        case kNCLocalNotificationTypeCallFromOldAccount:
+        {
+            NSString *receivedCallFromOldAccountString = NSLocalizedString(@"Received call from an old account", nil);
+            content.body = [NSString stringWithFormat:@"%@", receivedCallFromOldAccountString];
+            content.userInfo = userInfo;
+        }
+            break;
             
         default:
             break;
@@ -163,6 +171,11 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
     } else {
         [[CallKitManager sharedInstance] reportIncomingCallForNonCallKitDevicesWithPushNotification:pushNotification];
     }
+}
+
+- (void)showIncomingCallForOldAccount
+{
+    [[CallKitManager sharedInstance] reportIncomingCallForOldAccount];
 }
 
 - (void)updateAppIconBadgeNumber
@@ -344,6 +357,11 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
             case kNCLocalNotificationTypeFailedSendChat:
             {
                 [[NCUserInterfaceController sharedInstance] presentChatForLocalNotification:notificationUserInfo];
+            }
+                break;
+            case kNCLocalNotificationTypeCallFromOldAccount:
+            {
+                [[NCUserInterfaceController sharedInstance] presentSettingsViewController];
             }
                 break;
             default:

--- a/NextcloudTalk/NCSettingsController.h
+++ b/NextcloudTalk/NCSettingsController.h
@@ -83,5 +83,7 @@ typedef enum NCPreferredFileSorting {
 - (void)setPreferredFileSorting:(NCPreferredFileSorting)sorting;
 - (BOOL)isContactSyncEnabled;
 - (void)setContactSync:(BOOL)enabled;
+- (BOOL)didReceiveCallsFromOldAccount;
+- (void)setDidReceiveCallsFromOldAccount:(BOOL)receivedOldCalls;
 
 @end

--- a/NextcloudTalk/NCSettingsController.m
+++ b/NextcloudTalk/NCSettingsController.m
@@ -83,8 +83,10 @@ NSString * const kUserProfileScopePublished     = @"v2-published";
 
 NSInteger const kDefaultChatMaxLength           = 1000;
 
-NSString * const kPreferredFileSorting  = @"preferredFileSorting";
-NSString * const kContactSyncEnabled  = @"contactSyncEnabled";
+NSString * const kPreferredFileSorting          = @"preferredFileSorting";
+NSString * const kContactSyncEnabled            = @"contactSyncEnabled";
+
+NSString * const kDidReceiveCallsFromOldAccount = @"receivedCallsFromOldAccount";
 
 + (NCSettingsController *)sharedInstance
 {
@@ -244,6 +246,18 @@ NSString * const kContactSyncEnabled  = @"contactSyncEnabled";
     TalkAccount *account = [TalkAccount objectsWhere:(@"active = true")].firstObject;
     account.hasContactSyncEnabled = enabled;
     [realm commitWriteTransaction];
+}
+
+- (BOOL)didReceiveCallsFromOldAccount
+{
+    BOOL didReceiveCallsFromOldAccount = [[[NSUserDefaults standardUserDefaults] objectForKey:kDidReceiveCallsFromOldAccount] boolValue];
+
+    return didReceiveCallsFromOldAccount;
+}
+
+- (void)setDidReceiveCallsFromOldAccount:(BOOL)receivedOldCalls
+{
+    [[NSUserDefaults standardUserDefaults] setObject:@(receivedOldCalls) forKey:kDidReceiveCallsFromOldAccount];
 }
 
 #pragma mark - User Profile

--- a/NextcloudTalk/NCUserInterfaceController.h
+++ b/NextcloudTalk/NCUserInterfaceController.h
@@ -55,5 +55,6 @@
 - (void)presentCallKitCallInRoom:(NSString *)token withVideoEnabled:(BOOL)video;
 - (void)presentChatForURL:(NSURLComponents *)urlComponents;
 - (void)presentLoginViewControllerForServerURL:(NSString *)serverURL withUser:(NSString *)user;
+- (void)presentSettingsViewController;
 
 @end

--- a/NextcloudTalk/NCUserInterfaceController.m
+++ b/NextcloudTalk/NCUserInterfaceController.m
@@ -417,6 +417,14 @@
                                                       userInfo:userInfo];
 }
 
+- (void)presentSettingsViewController
+{
+    [self presentConversationsList];
+    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:nil];
+    NCNavigationController *settingsNC = [storyboard instantiateViewControllerWithIdentifier:@"settingsNC"];
+    [self.mainViewController presentViewController:settingsNC animated:YES completion:nil];
+}
+
 #pragma mark - Notifications
 
 - (void)appStateHasChanged:(NSNotification *)notification

--- a/NextcloudTalk/SettingsTableViewController.swift
+++ b/NextcloudTalk/SettingsTableViewController.swift
@@ -28,7 +28,7 @@ enum SettingsSection: Int {
     case kSettingsSectionUserStatus
     case kSettingsSectionAccounts
     case kSettingsSectionConfiguration
-    case kSettingsSectionDiagnostics
+    case kSettingsSectionAdvanced
     case kSettingsSectionAbout
 }
 
@@ -130,8 +130,8 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
         // Configuration section
         sections.append(SettingsSection.kSettingsSectionConfiguration.rawValue)
 
-        // Diagnostics section
-        sections.append(SettingsSection.kSettingsSectionDiagnostics.rawValue)
+        // Advanced section
+        sections.append(SettingsSection.kSettingsSectionAdvanced.rawValue)
 
         // About section
         sections.append(SettingsSection.kSettingsSectionAbout.rawValue)
@@ -461,7 +461,7 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
             return 1
         case SettingsSection.kSettingsSectionConfiguration.rawValue:
             return getConfigurationSectionOptions().count
-        case SettingsSection.kSettingsSectionDiagnostics.rawValue:
+        case SettingsSection.kSettingsSectionAdvanced.rawValue:
             return 1
         case SettingsSection.kSettingsSectionAbout.rawValue:
             return AboutSection.kAboutSectionNumber.rawValue
@@ -493,7 +493,7 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
             return NSLocalizedString("Accounts", comment: "")
         case SettingsSection.kSettingsSectionConfiguration.rawValue:
             return NSLocalizedString("Configuration", comment: "")
-        case SettingsSection.kSettingsSectionDiagnostics.rawValue:
+        case SettingsSection.kSettingsSectionAdvanced.rawValue:
             return NSLocalizedString("Advanced", comment: "")
         case SettingsSection.kSettingsSectionAbout.rawValue:
             return NSLocalizedString("About", comment: "")
@@ -556,8 +556,8 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
             cell = userAccountsCell(for: indexPath)
         case SettingsSection.kSettingsSectionConfiguration.rawValue:
             cell = sectionConfigurationCell(for: indexPath)
-        case SettingsSection.kSettingsSectionDiagnostics.rawValue:
-            cell = diagnosticsCell(for: indexPath)
+        case SettingsSection.kSettingsSectionAdvanced.rawValue:
+            cell = advancedCell(for: indexPath)
         case SettingsSection.kSettingsSectionAbout.rawValue:
             cell = sectionAboutCell(for: indexPath)
         default:
@@ -590,7 +590,7 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
             default:
                 break
             }
-        case SettingsSection.kSettingsSectionDiagnostics.rawValue:
+        case SettingsSection.kSettingsSectionAdvanced.rawValue:
             self.diagnosticsPressed()
         case SettingsSection.kSettingsSectionAbout.rawValue:
             switch indexPath.row {
@@ -709,8 +709,8 @@ extension SettingsTableViewController {
         return cell
     }
 
-    func diagnosticsCell(for indexPath: IndexPath) -> UITableViewCell {
-        let userStatusCellIdentifier = "DiagnosticsCellIdentifier"
+    func advancedCell(for indexPath: IndexPath) -> UITableViewCell {
+        let userStatusCellIdentifier = "AdvancedCellIdentifier"
         let cell = UITableViewCell(style: .default, reuseIdentifier: userStatusCellIdentifier)
 
         cell.textLabel?.text = NSLocalizedString("Diagnostics", comment: "")

--- a/NextcloudTalk/SettingsTableViewController.swift
+++ b/NextcloudTalk/SettingsTableViewController.swift
@@ -755,7 +755,7 @@ extension SettingsTableViewController {
             cell.accessoryType = .disclosureIndicator
 
         case AdvancedSectionOption.kAdvancedSectionOptionCallFromOldAccount.rawValue:
-            cell.textLabel?.text = NSLocalizedString("Calls from old account", comment: "")
+            cell.textLabel?.text = NSLocalizedString("Calls from old accounts", comment: "")
             cell.imageView?.image = UIImage(systemName: "exclamationmark.triangle.fill")?.withRenderingMode(.alwaysTemplate)
             cell.imageView?.tintColor = UIColor.systemOrange
             cell.accessoryType = .disclosureIndicator

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -59,6 +59,9 @@
 "[Unknown username]" = "[Unknown username]";
 
 /* No comment provided by engineer. */
+"A call from an old account was received." = "A call from an old account was received.";
+
+/* No comment provided by engineer. */
 "About" = "About";
 
 /* No comment provided by engineer. */
@@ -248,6 +251,9 @@
 "Calls enabled?" = "Calls enabled?";
 
 /* No comment provided by engineer. */
+"Calls from old account" = "Calls from old account";
+
+/* No comment provided by engineer. */
 "Camera" = "Camera";
 
 /* No comment provided by engineer. */
@@ -300,6 +306,9 @@
 
 /* No comment provided by engineer. */
 "Configuration" = "Configuration";
+
+/* No comment provided by engineer. */
+"Confirm and hide warning" = "Confirm and hide warning";
 
 /* No comment provided by engineer. */
 "Connecting to %@ …" = "Connecting to %@ …";
@@ -692,6 +701,9 @@
 "If you enable your camera, this call will be interrupted for a few seconds." = "If you enable your camera, this call will be interrupted for a few seconds.";
 
 /* No comment provided by engineer. */
+"If you're using multiple servers, you need to check all of them." = "If you're using multiple servers, you need to check all of them.";
+
+/* No comment provided by engineer. */
 "Images, files, voice messages…" = "Images, files, voice messages…";
 
 /* No comment provided by engineer. */
@@ -967,6 +979,9 @@
 /* No comment provided by engineer. */
 "OK" = "OK";
 
+/* Will be used as the caller name when a voip notification can't be decrypted */
+"Old account" = "Old account";
+
 /* No comment provided by engineer. */
 "Once a conversation is left, to rejoin a closed conversation, an invite is needed. An open conversation can be rejoined at any time." = "Once a conversation is left, to rejoin a closed conversation, an invite is needed. An open conversation can be rejoined at any time.";
 
@@ -1088,6 +1103,9 @@
 "Read status" = "Read status";
 
 /* No comment provided by engineer. */
+"Received call from an old account" = "Received call from an old account";
+
+/* No comment provided by engineer. */
 "Record voice message" = "Record voice message";
 
 /* No comment provided by engineer. */
@@ -1107,6 +1125,9 @@
 
 /* No comment provided by engineer. */
 "Remove group and members" = "Remove group and members";
+
+/* No comment provided by engineer. */
+"Remove old duplicate entries and leave just the most recent entries." = "Remove old duplicate entries and leave just the most recent entries.";
 
 /* No comment provided by engineer. */
 "Remove participant" = "Remove participant";
@@ -1295,10 +1316,16 @@
 "This meeting is scheduled for" = "This meeting is scheduled for";
 
 /* No comment provided by engineer. */
+"This usually indicates that this device was previously used for an account, which was not properly removed from the server." = "This usually indicates that this device was previously used for an account, which was not properly removed from the server.";
+
+/* No comment provided by engineer. */
 "This week" = "This week";
 
 /* No comment provided by engineer. */
 "This will impact the functionality of this app. Please review your settings." = "This will impact the functionality of this app. Please review your settings.";
+
+/* No comment provided by engineer. */
+"To resolve this issue, use the web interface and go to 'Settings' -> 'Security'." = "To resolve this issue, use the web interface and go to 'Settings' -> 'Security'.";
 
 /* TRANSLATORS this is for sending something 'to' a user. Eg. 'To: John Doe' */
 "To:" = "To:";
@@ -1323,6 +1350,9 @@
 
 /* No comment provided by engineer. */
 "Unavailable" = "Unavailable";
+
+/* No comment provided by engineer. */
+"Under 'Devices & sessions' check if there are duplicated entries for the same device." = "Under 'Devices & sessions' check if there are duplicated entries for the same device.";
 
 /* No comment provided by engineer. */
 "Undo" = "Undo";

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -59,9 +59,6 @@
 "[Unknown username]" = "[Unknown username]";
 
 /* No comment provided by engineer. */
-"A call from an old account was received." = "A call from an old account was received.";
-
-/* No comment provided by engineer. */
 "About" = "About";
 
 /* No comment provided by engineer. */
@@ -251,7 +248,10 @@
 "Calls enabled?" = "Calls enabled?";
 
 /* No comment provided by engineer. */
-"Calls from old account" = "Calls from old account";
+"Calls from an old account were received." = "Calls from an old account were received.";
+
+/* No comment provided by engineer. */
+"Calls from old accounts" = "Calls from old accounts";
 
 /* No comment provided by engineer. */
 "Camera" = "Camera";


### PR DESCRIPTION
Since iOS 13 we're forced to report all received VoIP push notifications to CallKit. Failing in doing so multiple times restricts the app to only receive VoIP push notification when the app is running, but not in the background anymore.
Under normal circumstances this is not a problem, because we want to show calls. A problem arises if the device was previously used with talk-ios, but the account was not properly removed (talk-ios was removed, but not the account). This results in the server sending push notifications to the device with an unknown encryption key. In that case we can't decrypt the message and are unable to properly show the call notification.

This PR reports all calls to CallKit, even those which we are unable to properly decrypt. In that case "Old account" will be displayed as caller id and a local notification will be posted. Additionally we remember that we received such a problematic notification and show information in the settings controller.

<img width="320" alt="image" src="https://user-images.githubusercontent.com/1580193/197020016-f7bf2c37-77da-44bc-8e95-a54144891f23.png">

<img width="245" alt="image" src="https://user-images.githubusercontent.com/1580193/197020081-08db0fa4-2ac2-494d-97d3-0e673c929df9.png">
