### PR TITLE
Fix parsing of deck due dates

### DIFF
--- a/NextcloudTalk/ReferenceDeckView.swift
+++ b/NextcloudTalk/ReferenceDeckView.swift
@@ -86,9 +86,19 @@ import Foundation
 
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-            let date = dateFormatter.date(from: dueDateString)!
 
-            referenceDueDate.text = NCUtils.readableDateTime(from: date)
+            if let date = dateFormatter.date(from: dueDateString) {
+                referenceDueDate.text = NCUtils.readableDateTime(from: date)
+            }
+
+            // Date format was fixed in https://github.com/nextcloud/deck/pull/4115
+            dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+
+            if let date = dateFormatter.date(from: dueDateString) {
+                referenceDueDate.text = NCUtils.readableDateTime(from: date)
+            }
+
         } else {
             referenceDueDate.isHidden = true
             referenceDueDateIcon.isHidden = true


### PR DESCRIPTION
The format of deck due dates was changed in this PR https://github.com/nextcloud/deck/pull/4115. Make sure we correctly parse the old and new date format.