### PR TITLE
Make sure the current room is always highlighted

### DIFF
--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -555,6 +555,9 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
         [[NCUserInterfaceController sharedInstance] presentChatViewController:_chatViewController];
     } else {
         NSLog(@"Not creating new chat room: chatViewController for room %@ does already exist.", room.token);
+
+        // Still make sure the current room is highlighted
+        [[NCUserInterfaceController sharedInstance].roomsTableViewController setSelectedRoomToken:_chatViewController.room.token];
     }
 }
 


### PR DESCRIPTION
After one of the last split view refactorings a bug was introduced which allows to deselect the current room in the room table view controller while still being in the room.