### PR TITLE
Fix joining calls under certain circumstances 

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -540,6 +540,11 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         return;
     }
 
+    // If we stopped the chat, we don't want to resume it here
+    if (_hasStopped) {
+        return;
+    }
+
     // Check if new messages were added while the app was inactive (eg. via background-refresh)
     NCChatMessage *lastMessage = [[self->_messages objectForKey:[self->_dateSections lastObject]] lastObject];
     
@@ -557,6 +562,11 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 
 -(void)appWillResignActive:(NSNotification*)notification
 {
+    // If we stopped the chat, we don't want to change anything here
+    if (_hasStopped) {
+        return;
+    }
+
     _hasReceiveNewMessages = NO;
     _startReceivingMessagesAfterJoin = YES;
     [self removeUnreadMessagesSeparator];

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -597,22 +597,34 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
         _callViewController.silentCall = silently;
         [_callViewController setModalTransitionStyle:UIModalTransitionStyleCrossDissolve];
         _callViewController.delegate = self;
+
+        NSString *chatViewControllerRoomToken = _chatViewController.room.token;
+        NSString *joiningRoomToken = room.token;
+
         // Workaround until external signaling supports multi-room
         NCExternalSignalingController *extSignalingController = [[NCSettingsController sharedInstance] externalSignalingControllerForAccountId:activeAccount.accountId];
         if ([extSignalingController isEnabled]) {
-            NSString *currentRoom = extSignalingController.currentRoom;
-            if (![currentRoom isEqualToString:room.token] && [_chatViewController.room.token isEqualToString:currentRoom]) {
+            NSString *extSignalingRoomToken = extSignalingController.currentRoom;
+
+            if (![extSignalingRoomToken isEqualToString:joiningRoomToken] && [extSignalingRoomToken isEqualToString:chatViewControllerRoomToken]) {
                 // Since we are going to join another conversation, we don't need to leaveRoom() in extSignalingController.
                 // That's why we set currentRoom = nil, so when leaveRoom() is called in extSignalingController the currentRoom
                 // is no longer the room we want to leave (so no message is sent to the external signaling server).
                 extSignalingController.currentRoom = nil;
+            }
+        }
+
+        if (_chatViewController) {
+            if ([chatViewControllerRoomToken isEqualToString:joiningRoomToken]) {
+                // We're in the chat of the room we want to start a call, so stop chat for now
+                [_chatViewController stopChat];
+            } else {
+                // We're in a different chat, so make sure we leave the chat and go back to the conversation list
                 [_chatViewController leaveChat];
                 [[NCUserInterfaceController sharedInstance] presentConversationsList];
             }
         }
-        if ([_chatViewController.room.token isEqualToString:room.token]) {
-            [_chatViewController stopChat];
-        }
+
         [[NCUserInterfaceController sharedInstance] presentCallViewController:_callViewController];
         [self joinRoom:room.token forCall:YES];
     } else {

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -606,7 +606,7 @@ NSString * const NCRoomsManagerDidReceiveChatMessagesNotification   = @"ChatMess
         if ([extSignalingController isEnabled]) {
             NSString *extSignalingRoomToken = extSignalingController.currentRoom;
 
-            if (![extSignalingRoomToken isEqualToString:joiningRoomToken] && [extSignalingRoomToken isEqualToString:chatViewControllerRoomToken]) {
+            if (![extSignalingRoomToken isEqualToString:joiningRoomToken]) {
                 // Since we are going to join another conversation, we don't need to leaveRoom() in extSignalingController.
                 // That's why we set currentRoom = nil, so when leaveRoom() is called in extSignalingController the currentRoom
                 // is no longer the room we want to leave (so no message is sent to the external signaling server).


### PR DESCRIPTION
After adding some log output for joining a call, I noticed the following:

```
2022-10-24 21:25:59.895711: Joining room 5divmvxs with sessionId YOJyD...
2022-10-24 21:25:59.908808: CallController room 5divmvxs (test@https://host) with account test@https://host
2022-10-24 21:26:00.321478: Joining room nzj3mfnu with sessionId aBWwH...
```

In fact I did try to join a call in room 5divmvxs from CallKit, so the additional joining of room nzj3mfnu was unexpected. After a few tries I noticed that it makes a difference if a call is joined from a CallKit banner or CallKit fullscreen. In the fullscreen case the app is actually sent to the background, eg. the lifecycle events "appWillResignActive" and "appDidBecomeActive" were actually called. This did not happen if the call was accepted through a CallKit banner. 

So after accepting a call from the fullscreen CallKit we correctly join the room and init the CallController. At the same time (when a chat from another conversation was open) the ChatViewController of the "old" conversation did receive the lifecycle event "appDidBecomeActive", therefore joining that conversation and effectively preventing a successful connection to the correct room.

In NCChatViewController we just prevent the lifecycle events to run if the chat was stopped before.

In NCRoomsManager I made sure that we leave a chat in every case when there's a different chat active at the time of starting/joining a call. I did rename a few variables to make it more clear, but we can change that back ;).

One thing I did not fully understand is this condition:

```objc
            if (![extSignalingRoomToken isEqualToString:joiningRoomToken] && [extSignalingRoomToken isEqualToString:chatViewControllerRoomToken]) {
                // Since we are going to join another conversation, we don't need to leaveRoom() in extSignalingController.
                // That's why we set currentRoom = nil, so when leaveRoom() is called in extSignalingController the currentRoom
                // is no longer the room we want to leave (so no message is sent to the external signaling server).
                extSignalingController.currentRoom = nil;
            }
```
The first part is clear, if the external signaling controller is currently joined to another room, we want don't want to send a leaveRoom() message, because we join another conversation soon.
What I don't get why the second condition is necessary. Why is this only done, when the external signaling controller is joined to the same room as a potential active chatViewController? It should not matter, should it? (Maybe it's not needed anymore because of the way I changed the code, not sure, in this case the condition should be removed). 

The changes were introduced at https://github.com/nextcloud/talk-ios/pull/399

How to test?
* Join room A
* Don't move to the background
* Get a call from room B
* Make the banner fullscreen
* Accept via CallKit