### PR TITLE
Support 'delete-multiple' notification type

### DIFF
--- a/NextcloudTalk/NCPushNotification.h
+++ b/NextcloudTalk/NCPushNotification.h
@@ -29,6 +29,7 @@ typedef NS_ENUM(NSInteger, NCPushNotificationType) {
     NCPushNotificationTypeChat,
     NCPushNotificationTypeDelete,
     NCPushNotificationTypeDeleteAll,
+    NCPushNotificationTypeDeleteMultiple,
     NCPushNotificationTypeAdminNotification
 };
 
@@ -53,6 +54,7 @@ extern NSString * const NCPushNotificationJoinVideoCallAcceptedNotification;
 @property (nonatomic, copy) NSString *roomToken;
 @property (nonatomic, assign) NSInteger roomId;
 @property (nonatomic, assign) NSInteger notificationId;
+@property (nonatomic, strong) NSArray *notificationIds;
 @property (nonatomic, copy) NSString *accountId;
 @property (nonatomic, copy) NSString *jsonString;
 @property (nonatomic, copy) NSString *responseUserText;

--- a/NextcloudTalk/NCPushNotification.m
+++ b/NextcloudTalk/NCPushNotification.m
@@ -30,11 +30,13 @@ NSString * const kNCPNTypeKey                   = @"type";
 NSString * const kNCPNSubjectKey                = @"subject";
 NSString * const kNCPNIdKey                     = @"id";
 NSString * const kNCPNNotifIdKey                = @"nid";
+NSString * const kNCPNNotifIdsKey               = @"nids";
 NSString * const kNCPNTypeCallKey               = @"call";
 NSString * const kNCPNTypeRoomKey               = @"room";
 NSString * const kNCPNTypeChatKey               = @"chat";
 NSString * const kNCPNTypeDeleteKey             = @"delete";
 NSString * const kNCPNTypeDeleteAllKey          = @"delete-all";
+NSString * const kNCPNTypeDeleteMultipleKey     = @"delete-multiple";
 NSString * const kNCPNAppIdAdminNotificationKey = @"admin_notification_talk";
 
 NSString * const NCPushNotificationJoinChatNotification                 = @"NCPushNotificationJoinChatNotification";
@@ -87,6 +89,9 @@ NSString * const NCPushNotificationJoinVideoCallAcceptedNotification    = @"NCPu
         pushNotification.type = NCPushNotificationTypeDelete;
     } else if ([jsonNotification objectForKey:kNCPNTypeDeleteAllKey]) {
         pushNotification.type = NCPushNotificationTypeDeleteAll;
+    } else if ([jsonNotification objectForKey:kNCPNTypeDeleteMultipleKey]) {
+        pushNotification.notificationIds = [jsonNotification objectForKey:kNCPNNotifIdsKey];
+        pushNotification.type = NCPushNotificationTypeDeleteMultiple;
     } else {
         NSString *app = [jsonNotification objectForKey:kNCPNAppKey];
         


### PR DESCRIPTION
Ref Issue https://github.com/nextcloud/notifications/issues/936
Ref PR https://github.com/nextcloud/notifications/pull/939

This PR implements support for 'delete-multiple' notification type, allowing us to delete multiple notifications with a single background notification.