### PR TITLE
Prepend emoji to body text of messages containing files

### DIFF
--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -24,6 +24,7 @@
 
 #import "NCAPIController.h"
 #import "NCAppBranding.h"
+#import "NCUtils.h"
 #import "NextcloudTalk-Swift.h"
 
 NSInteger const kChatMessageGroupTimeDifference = 30;
@@ -419,6 +420,40 @@ NSString * const kSharedItemTypeVoice       = @"voice";
     NSString *originalMessage = self.file.contactName ? self.file.contactName : self.message;
     NSString *parsedMessage = originalMessage;
     NSError *error = nil;
+    BOOL shouldPrependEmoji = self.isVoiceMessage || self.file || self.geoLocation || self.deckCard || self.poll;
+    
+    // prepend an appropriate emoji based on file type before formatting the string
+    if (shouldPrependEmoji) {
+        NSString *emojiToPrepend;
+        
+        if (self.isVoiceMessage) {
+            emojiToPrepend = @"🎙️";
+        }
+        else if (self.geoLocation) {
+            emojiToPrepend = @"📍";
+        }
+        else if (self.deckCard) {
+            emojiToPrepend = @"🗂️";
+        }
+        else if (self.poll) {
+            emojiToPrepend = @"📊";
+        }
+        else if (self.file) {
+            if ([[NCUtils previewImageForFileMIMEType:self.file.mimetype] isEqual:@"file-video"]) {
+                emojiToPrepend = @"📼";
+            }
+            else if ([[NCUtils previewImageForFileMIMEType:self.file.mimetype] isEqual:@"file-image"]) {
+                emojiToPrepend = @"🖼️";
+            }
+            else if ([[NCUtils previewImageForFileMIMEType:self.file.mimetype] isEqual:@"file-vcard"]) {
+                emojiToPrepend = @"👤";
+            }
+            else {
+                emojiToPrepend = @"📂";
+            }
+        }
+        parsedMessage = [NSString stringWithFormat:@"%@ %@", emojiToPrepend, parsedMessage];
+    }
     
     NSRegularExpression *parameterRegex = [NSRegularExpression regularExpressionWithPattern:@"\\{([^}]+)\\}" options:NSRegularExpressionCaseInsensitive error:&error];
     NSArray *matches = [parameterRegex matchesInString:originalMessage


### PR DESCRIPTION
this should apply to:
- message previews in the chat list view ✅
- messages inside a chat ✅
- notifications (I can't check since I can't receive notifications with my developer certificate)

This should help identify the nature of a message in lieu of a media preview.

![Simulator Screen Shot - iPhone 14 Pro - 2022-10-29 at 12 27 19](https://user-images.githubusercontent.com/48513706/198827617-656b4b3b-6207-42b7-a096-268f40deea92.png)

![Simulator Screen Shot - iPhone 14 Pro - 2022-10-29 at 13 03 47](https://user-images.githubusercontent.com/48513706/198827896-0ba568cf-2207-4775-80d1-0957a21d9b77.png)
