### PR TITLE
Don't deliver local notifications when user status is DND

### DIFF
--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -96,7 +96,7 @@ typedef void (^SetUserStatusCompletionBlock)(NSError *error);
 
 typedef void (^GetServerCapabilitiesCompletionBlock)(NSDictionary *serverCapabilities, NSError *error);
 typedef void (^GetServerNotificationCompletionBlock)(NSDictionary *notification, NSError *error, NSInteger statusCode);
-typedef void (^GetServerNotificationsCompletionBlock)(NSArray *notifications, NSString *ETag, NSError *error);
+typedef void (^GetServerNotificationsCompletionBlock)(NSArray *notifications, NSString *ETag, NSString *userStatus, NSError *error);
 
 typedef void (^SubscribeToNextcloudServerCompletionBlock)(NSDictionary *responseDict, NSError *error);
 typedef void (^UnsubscribeToNextcloudServerCompletionBlock)(NSError *error);

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -2417,11 +2417,11 @@ NSInteger const kReceivedChatMessagesLimit = 100;
             NSDictionary *headers = [self getResponseHeaders:response];
 
             if (block) {
-                block(notifications, [headers objectForKey:@"ETag"], nil);
+                block(notifications, [headers objectForKey:@"ETag"], [headers objectForKey:@"x-nextcloud-user-status"], nil);
             }
         } else {
             if (block) {
-                block(nil, nil, error);
+                block(nil, nil, nil, error);
             }
         }
     }];


### PR DESCRIPTION
Fixes #962 
Ref https://github.com/nextcloud/notifications/pull/724

When using local notifications as a fallback, we still need to respect the users DND status.