### PR TITLE
Implement communication notifications

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		1F4DD3EB2571C688007DC98E /* EmojiUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4DD3EA2571C688007DC98E /* EmojiUtils.swift */; };
 		1F4DD3EC2571C688007DC98E /* EmojiUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4DD3EA2571C688007DC98E /* EmojiUtils.swift */; };
 		1F4DD3ED2571C688007DC98E /* EmojiUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4DD3EA2571C688007DC98E /* EmojiUtils.swift */; };
+		1F53819129195FA4003DA6B7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2CA1CCAB1F067F35002FE6A2 /* Images.xcassets */; };
 		1F5813F828EB23EF00318FC3 /* NCSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5813F628EB23EF00318FC3 /* NCSplitViewController.swift */; };
 		1F5813F928EB23EF00318FC3 /* NCSplitViewPlaceholderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5813F728EB23EF00318FC3 /* NCSplitViewPlaceholderViewController.swift */; };
 		1F59446225B8EDF5002AD65F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2C7F47AC20289B9600081CC7 /* Localizable.strings */; };
@@ -34,6 +35,7 @@
 		1F7AE07829142CA1009F72AD /* NextcloudKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1F7AE07729142CA1009F72AD /* NextcloudKit */; };
 		1F7AE07A29142E62009F72AD /* NextcloudKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1F7AE07929142E62009F72AD /* NextcloudKit */; };
 		1F7AE07C29142E6A009F72AD /* NextcloudKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1F7AE07B29142E6A009F72AD /* NextcloudKit */; };
+		1F7AE07D29158878009F72AD /* IntentsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F90EFC225FE489B00F3FA55 /* IntentsUI.framework */; };
 		1F90EFBC25FE39F800F3FA55 /* NCIntentController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F90EFBB25FE39F800F3FA55 /* NCIntentController.m */; };
 		1F90EFBD25FE39F800F3FA55 /* NCIntentController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F90EFBB25FE39F800F3FA55 /* NCIntentController.m */; };
 		1F90EFBE25FE39F800F3FA55 /* NCIntentController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F90EFBB25FE39F800F3FA55 /* NCIntentController.m */; };
@@ -815,6 +817,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1F7AE07A29142E62009F72AD /* NextcloudKit in Frameworks */,
+				1F7AE07D29158878009F72AD /* IntentsUI.framework in Frameworks */,
 				3FCA62550CD1442D28E8A7C6 /* libPods-NotificationServiceExtension.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1705,6 +1708,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F53819129195FA4003DA6B7 /* Images.xcassets in Resources */,
 				1F59446225B8EDF5002AD65F /* Localizable.strings in Resources */,
 				2CB6ACED2641954700D3D641 /* MapViewController.xib in Resources */,
 			);

--- a/NextcloudTalk/NCIntentController.h
+++ b/NextcloudTalk/NCIntentController.h
@@ -22,17 +22,17 @@
 
 #import <Foundation/Foundation.h>
 #import <Intents/INSendMessageIntent.h>
+#import <Intents/INSendMessageIntent+UserNotifications.h>
 
 #import "NCRoom.h"
 
-NS_ASSUME_NONNULL_BEGIN
+typedef void (^GetInteractionForRoomCompletionBlock)(INSendMessageIntent *sendMessageIntent);
 
 @interface NCIntentController : NSObject
 
 + (instancetype)sharedInstance;
 
 - (void)donateSendMessageIntentForRoom:(NCRoom *)room;
+- (void)getInteractionForRoom:(NCRoom *)room withTitle:(NSString *)title withCompletionBlock:(GetInteractionForRoomCompletionBlock)block;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/NextcloudTalk/NCIntentController.m
+++ b/NextcloudTalk/NCIntentController.m
@@ -58,6 +58,7 @@ typedef void (^GetAvatarForRoomCompletionBlock)(UIImage *image);
                 if (image) {
                     block(image);
                 } else {
+                    NSLog(@"NCIntentController: Unable to get user avatar: %@", error.description);
                     block(nil);
                 }
             }];
@@ -120,6 +121,7 @@ typedef void (^GetAvatarForRoomCompletionBlock)(UIImage *image);
         [interaction donateInteractionWithCompletion:^(NSError * _Nullable error) {
             if (block) {
                 if (error) {
+                    NSLog(@"Interaction donation failed: %@", error.description);
                     block(nil);
                 } else {
                     block(sendMessageIntent);

--- a/NextcloudTalk/NCIntentController.m
+++ b/NextcloudTalk/NCIntentController.m
@@ -22,15 +22,19 @@
 
 #import <Intents/INInteraction.h>
 #import <Intents/INSendMessageIntent.h>
-#import <Intents/INSendMessageIntent_Deprecated.h>
+#import <Intents/INSendMessageIntent+UserNotifications.h>
 #import <Intents/INSpeakableString.h>
 #import <Intents/INOutgoingMessageType.h>
 #import <Intents/INImage.h>
+#import <Intents/INPerson.h>
+#import <Intents/INPersonHandle.h>
 #import <IntentsUI/INImage+IntentsUI.h>
 
 #import "NCIntentController.h"
 #import "NCAPIController.h"
 #import "NCDatabaseManager.h"
+
+typedef void (^GetAvatarForRoomCompletionBlock)(UIImage *image);
 
 @implementation NCIntentController
 
@@ -44,46 +48,105 @@
     return sharedInstance;
 }
 
-- (void)donateSendMessageIntentForRoom:(NCRoom *)room
+- (void)getAvatarForRoom:(NCRoom *)room withCompletionBlock:(GetAvatarForRoomCompletionBlock)block
 {
-    INSpeakableString *groupName = [[INSpeakableString alloc] initWithSpokenPhrase:room.displayName];
-    INSendMessageIntent *sendMessageIntent = [[INSendMessageIntent alloc] initWithRecipients:nil
-                                                                        outgoingMessageType:INOutgoingMessageTypeOutgoingMessageText
-                                                                                    content:nil
-                                                                         speakableGroupName:groupName
-                                                                     conversationIdentifier:room.internalId
-                                                                                serviceName:nil
-                                                                                     sender:nil
-                                                                                attachments:nil];
     switch (room.type) {
         case kNCRoomTypeOneToOne:
         {
             TalkAccount *account = [[NCDatabaseManager sharedInstance] talkAccountForAccountId:room.accountId];
             [[NCAPIController sharedInstance] getUserAvatarForUser:room.name andSize:512 usingAccount:account withCompletionBlock:^(UIImage *image, NSError *error) {
                 if (image) {
-                    [sendMessageIntent setImage:[INImage imageWithUIImage:image] forParameterNamed:@"speakableGroupName"];
-                    [self donateMessageSentIntent:sendMessageIntent];
+                    block(image);
+                } else {
+                    block(nil);
                 }
             }];
             break;
         }
         case kNCRoomTypeGroup:
         {
-            [sendMessageIntent setImage:[INImage imageWithUIImage:[UIImage imageNamed:@"group-avatar"]] forParameterNamed:@"speakableGroupName"];
-            [self donateMessageSentIntent:sendMessageIntent];
+            block([UIImage imageNamed:@"group-avatar"]);
             break;
         }
 
         case kNCRoomTypePublic:
         {
-            [sendMessageIntent setImage:[INImage imageWithUIImage:[UIImage imageNamed:@"public-avatar"]] forParameterNamed:@"speakableGroupName"];
-            [self donateMessageSentIntent:sendMessageIntent];
+            block([UIImage imageNamed:@"public-avatar"]);
             break;
         }
 
         default:
+        {
+            block(nil);
             break;
+        }
     }
+}
+
+- (void)getInteractionForRoom:(NCRoom *)room withTitle:(NSString *)title withCompletionBlock:(GetInteractionForRoomCompletionBlock)block
+{
+    [self getAvatarForRoom:room withCompletionBlock:^(UIImage *avatarImage) {
+        if (!avatarImage) {
+            if (block) {
+                block(nil);
+            }
+            return;
+        }
+
+        INSpeakableString *groupName = [[INSpeakableString alloc] initWithSpokenPhrase:title];
+        INPersonHandle *handle = [[INPersonHandle alloc] initWithValue:nil type:INPersonHandleTypeUnknown];
+        INImage *image = [INImage imageWithUIImage:avatarImage];
+
+        INPerson *person = [[INPerson alloc]
+                            initWithPersonHandle:handle
+                            nameComponents:nil
+                            displayName:title
+                            image:image
+                            contactIdentifier:nil
+                            customIdentifier:nil];
+
+        INSendMessageIntent *sendMessageIntent = [[INSendMessageIntent alloc] initWithRecipients:nil
+                                                                             outgoingMessageType:INOutgoingMessageTypeOutgoingMessageText
+                                                                                         content:nil
+                                                                              speakableGroupName:groupName
+                                                                          conversationIdentifier:room.internalId
+                                                                                     serviceName:nil
+                                                                                          sender:person
+                                                                                     attachments:nil];
+
+        INInteraction *interaction = [[INInteraction alloc] initWithIntent:sendMessageIntent response:nil];
+        interaction.direction = INInteractionDirectionIncoming;
+
+        [interaction donateInteractionWithCompletion:^(NSError * _Nullable error) {
+            if (block) {
+                if (error) {
+                    block(nil);
+                } else {
+                    block(sendMessageIntent);
+                }
+            }
+        }];
+    }];
+}
+
+- (void)donateSendMessageIntentForRoom:(NCRoom *)room
+{
+    INSpeakableString *groupName = [[INSpeakableString alloc] initWithSpokenPhrase:room.displayName];
+    INSendMessageIntent *sendMessageIntent = [[INSendMessageIntent alloc] initWithRecipients:nil
+                                                                         outgoingMessageType:INOutgoingMessageTypeOutgoingMessageText
+                                                                                     content:nil
+                                                                          speakableGroupName:groupName
+                                                                      conversationIdentifier:room.internalId
+                                                                                 serviceName:nil
+                                                                                      sender:nil
+                                                                                 attachments:nil];
+
+    [self getAvatarForRoom:room withCompletionBlock:^(UIImage *image) {
+        if (image) {
+            [sendMessageIntent setImage:[INImage imageWithUIImage:image] forParameterNamed:@"speakableGroupName"];
+            [self donateMessageSentIntent:sendMessageIntent];
+        }
+    }];
 }
 
 - (void)donateMessageSentIntent:(INSendMessageIntent *)sendMessageIntent

--- a/NextcloudTalk/NextcloudTalk.entitlements
+++ b/NextcloudTalk/NextcloudTalk.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.usernotifications.communication</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.nextcloud.Talk</string>

--- a/NotificationServiceExtension/NotificationService.m
+++ b/NotificationServiceExtension/NotificationService.m
@@ -191,6 +191,7 @@
                                     if (sendMessageIntent) {
                                         self.contentHandler([self.bestAttemptContent contentByUpdatingWithProvider:sendMessageIntent error:&error]);
                                     } else {
+                                        NSLog(@"Did not receive sendMessageIntent -> showing non-communication notification");
                                         self.contentHandler(self.bestAttemptContent);
                                     }
                                 }];

--- a/NotificationServiceExtension/NotificationService.m
+++ b/NotificationServiceExtension/NotificationService.m
@@ -25,6 +25,8 @@
 #import "NCAPISessionManager.h"
 #import "NCAppBranding.h"
 #import "NCDatabaseManager.h"
+#import "NCIntentController.h"
+#import "NCRoom.h"
 #import "NCKeyChainController.h"
 #import "NCNotification.h"
 #import "NCPushNotification.h"
@@ -81,18 +83,17 @@
     RLMRealmConfiguration *configuration = [RLMRealmConfiguration defaultConfiguration];
     configuration.fileURL = databaseURL;
     configuration.schemaVersion= kTalkDatabaseSchemaVersion;
-    configuration.objectClasses = @[TalkAccount.class];
+    configuration.objectClasses = @[TalkAccount.class, NCRoom.class, ServerCapabilities.class];
     configuration.migrationBlock = ^(RLMMigration *migration, uint64_t oldSchemaVersion) {
         // At the very minimum we need to update the version with an empty block to indicate that the schema has been upgraded (automatically) by Realm
     };
-    NSError *error = nil;
-    RLMRealm *realm = [RLMRealm realmWithConfiguration:configuration error:&error];
+    [RLMRealmConfiguration setDefaultConfiguration:configuration];
     
     BOOL foundDecryptableMessage = NO;
     
     // Decrypt message
     NSString *message = [self.bestAttemptContent.userInfo objectForKey:@"subject"];
-    for (TalkAccount *talkAccount in [TalkAccount allObjectsInRealm:realm]) {
+    for (TalkAccount *talkAccount in [TalkAccount allObjects]) {
         TalkAccount *account = [[TalkAccount alloc] initWithValue:talkAccount];
         NSData *pushNotificationPrivateKey = [[NCKeyChainController sharedInstance] pushNotificationPrivateKeyForAccountId:account.accountId];
         if (message && pushNotificationPrivateKey) {
@@ -112,9 +113,9 @@
                     
                     foundDecryptableMessage = YES;
 
-                    [realm transactionWithBlock:^{
+                    [[RLMRealm defaultRealm] transactionWithBlock:^{
                         NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@", account.accountId];
-                        TalkAccount *managedAccount = [TalkAccount objectsInRealm:realm withPredicate:query].firstObject;
+                        TalkAccount *managedAccount = [TalkAccount objectsWithPredicate:query].firstObject;
 
                         // Update unread notifications counter for push notification account
                         managedAccount.unreadBadgeNumber += 1;
@@ -128,7 +129,7 @@
                     
                     // Get the total number of unread notifications
                     NSInteger unreadNotifications = 0;
-                    for (TalkAccount *user in [TalkAccount allObjectsInRealm:realm]) {
+                    for (TalkAccount *user in [TalkAccount allObjects]) {
                         unreadNotifications += user.unreadBadgeNumber;
                     }
                     
@@ -147,6 +148,7 @@
                     [userInfo setObject:pushNotification.accountId forKey:@"accountId"];
                     [userInfo setObject:@(pushNotification.notificationId) forKey:@"notificationId"];
                     self.bestAttemptContent.userInfo = userInfo;
+
                     // Create title and body structure if there is a new line in the subject
                     NSArray* components = [pushNotification.subject componentsSeparatedByString:@"\n"];
                     if (components.count > 1) {
@@ -157,6 +159,7 @@
                         self.bestAttemptContent.title = title;
                         self.bestAttemptContent.body = body;
                     }
+
                     // Try to get the notification from the server
                     NSString *URLString = [NSString stringWithFormat:@"%@/ocs/v2.php/apps/notifications/api/v2/notifications/%ld", account.server, (long)pushNotification.notificationId];
                     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
@@ -177,6 +180,25 @@
                             self.bestAttemptContent.body = serverNotification.message;
                             self.bestAttemptContent.summaryArgument = serverNotification.chatMessageAuthor;
                         }
+
+                        if (@available(iOS 15.0, *)) {
+                            NCRoom *room = [self roomWithToken:pushNotification.roomToken forAccountId:pushNotification.accountId];
+
+                            if (room) {
+                                [[NCIntentController sharedInstance] getInteractionForRoom:room withTitle:serverNotification.chatMessageTitle withCompletionBlock:^(INSendMessageIntent *sendMessageIntent) {
+                                    __block NSError *error;
+
+                                    if (sendMessageIntent) {
+                                        self.contentHandler([self.bestAttemptContent contentByUpdatingWithProvider:sendMessageIntent error:&error]);
+                                    } else {
+                                        self.contentHandler(self.bestAttemptContent);
+                                    }
+                                }];
+
+                                return;
+                            }
+                        }
+
                         self.contentHandler(self.bestAttemptContent);
                     } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
                         self.contentHandler(self.bestAttemptContent);
@@ -194,6 +216,19 @@
         // No need to wait for the extension timeout, nothing is happening anymore
         self.contentHandler(self.bestAttemptContent);
     }
+}
+
+- (NCRoom *)roomWithToken:(NSString *)token forAccountId:(NSString *)accountId
+{
+    NCRoom *unmanagedRoom = nil;
+    NSPredicate *query = [NSPredicate predicateWithFormat:@"token = %@ AND accountId = %@", token, accountId];
+    NCRoom *managedRoom = [NCRoom objectsWithPredicate:query].firstObject;
+
+    if (managedRoom) {
+        unmanagedRoom = [[NCRoom alloc] initWithValue:managedRoom];
+    }
+
+    return unmanagedRoom;
 }
 
 - (void)serviceExtensionTimeWillExpire {


### PR DESCRIPTION
Fixes #780 

<img width="365" alt="image" src="https://user-images.githubusercontent.com/1580193/200354780-006737ec-a312-4491-8bb7-89f6a83e754b.png">

Usually Apple wants us to provide even more information to the intent, like recipients of a group message. We don't have that information in the push notification, nor in the server notification. At this point I don't think it is worth it to do another API call to retrieve those informations as this PR does what we want it to do.