### PR TITLE
Add check for share overview

### DIFF
--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -1419,7 +1419,10 @@ NSInteger const kReceivedChatMessagesLimit = 100;
             NSMutableArray *messages = [NSMutableArray new];
             for (NSDictionary *messageDict in responseMessages) {
                 NCChatMessage *message = [NCChatMessage messageWithDictionary:messageDict];
-                [messages addObject:message];
+
+                if (message) {
+                    [messages addObject:message];
+                }
             }
             [sharedItems setObject:messages forKey:key];
         }


### PR DESCRIPTION
Crash reported at the App Store. We should make sure that we really are able to construct a message before trying to add it (crash on nil). Although I wasn't able to reproduce this, we should add the check.