### PR TITLE
Separate the parsed message for chat

### DIFF
--- a/NextcloudTalk/ChatMessageTableViewCell.m
+++ b/NextcloudTalk/ChatMessageTableViewCell.m
@@ -301,7 +301,7 @@
 - (void)setupForMessage:(NCChatMessage *)message withLastCommonReadMessage:(NSInteger)lastCommonRead
 {
     self.titleLabel.text = message.actorDisplayName;
-    self.bodyTextView.attributedText = message.parsedMessage;
+    self.bodyTextView.attributedText = message.parsedMessageForChat;
     self.messageId = message.messageId;
     self.message = message;
     NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:message.timestamp];
@@ -334,7 +334,7 @@
     NCChatMessage *parent = message.parent;
     if (parent.message) {
         self.quotedMessageView.actorLabel.text = ([parent.actorDisplayName isEqualToString:@""]) ? NSLocalizedString(@"Guest", nil) : parent.actorDisplayName;
-        self.quotedMessageView.messageLabel.text = parent.parsedMessage.string;
+        self.quotedMessageView.messageLabel.text = parent.parsedMessageForChat.string;
         self.quotedMessageView.highlighted = [parent isMessageFromUser:activeAccount.userId];
     }
     

--- a/NextcloudTalk/FileMessageTableViewCell.m
+++ b/NextcloudTalk/FileMessageTableViewCell.m
@@ -182,7 +182,7 @@
 - (void)setupForMessage:(NCChatMessage *)message withLastCommonReadMessage:(NSInteger)lastCommonRead
 {
     self.titleLabel.text = message.actorDisplayName;
-    self.bodyTextView.attributedText = message.parsedMessage;
+    self.bodyTextView.attributedText = message.parsedMessageForChat;
     self.messageId = message.messageId;
     self.message = message;
     

--- a/NextcloudTalk/GroupedChatMessageTableViewCell.m
+++ b/NextcloudTalk/GroupedChatMessageTableViewCell.m
@@ -97,7 +97,7 @@
 
 - (void)setupForMessage:(NCChatMessage *)message withLastCommonReadMessage:(NSInteger)lastCommonRead
 {
-    self.bodyTextView.attributedText = message.parsedMessage;
+    self.bodyTextView.attributedText = message.parsedMessageForChat;
     self.messageId = message.messageId;
     self.message = message;
     

--- a/NextcloudTalk/LocationMessageTableViewCell.m
+++ b/NextcloudTalk/LocationMessageTableViewCell.m
@@ -161,7 +161,7 @@
 - (void)setupForMessage:(NCChatMessage *)message withLastCommonReadMessage:(NSInteger)lastCommonRead
 {
     self.titleLabel.text = message.actorDisplayName;
-    self.bodyTextView.attributedText = message.parsedMessage;
+    self.bodyTextView.attributedText = message.parsedMessageForChat;
     self.messageId = message.messageId;
     self.message = message;
     

--- a/NextcloudTalk/NCChatMessage.h
+++ b/NextcloudTalk/NCChatMessage.h
@@ -98,6 +98,7 @@ typedef void (^GetReferenceDataCompletionBlock)(NCChatMessage *message, NSDictio
 - (NSString *)objectShareLink;
 - (NSDictionary *)messageParameters;
 - (NSMutableAttributedString *)parsedMessage;
+- (NSMutableAttributedString *)parsedMessageForChat;
 - (NSMutableAttributedString *)systemMessageFormat;
 - (NCChatMessage *)parent;
 - (NSMutableArray *)reactionsArray;

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -397,22 +397,9 @@ NSString * const kSharedItemTypeVoice       = @"voice";
     return messageParametersDict;
 }
 
-- (BOOL)shouldHideParsedMessage
-{
-    if (!self.message) {
-        return YES;
-    }
-
-    if ([self getDeckCardUrlForReferenceProvider]) {
-        return YES;
-    }
-
-    return NO;
-}
-
 - (NSMutableAttributedString *)parsedMessage
 {
-    if ([self shouldHideParsedMessage]) {
+    if (!self.message) {
         return nil;
     }
     
@@ -483,6 +470,16 @@ NSString * const kSharedItemTypeVoice       = @"voice";
     }
     
     return attributedMessage;
+}
+
+- (NSMutableAttributedString *)parsedMessageForChat
+{
+    // In some circumstances we want/need to hide the message in the chat, but still want to show it in other parts like the conversation list
+    if ([self getDeckCardUrlForReferenceProvider]) {
+        return nil;
+    }
+
+    return self.parsedMessage;
 }
 
 - (NSMutableAttributedString *)systemMessageFormat

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1539,7 +1539,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     if (message.isObjectShare) {
         shareViewController = [[ShareViewController alloc] initToForwardObjectShareMessage:message fromChatViewController:self];
     } else {
-        shareViewController = [[ShareViewController alloc] initToForwardMessage:message.parsedMessage.string fromChatViewController:self];
+        shareViewController = [[ShareViewController alloc] initToForwardMessage:message.parsedMessageForChat.string fromChatViewController:self];
     }
     shareViewController.delegate = self;
     NCNavigationController *forwardMessageNC = [[NCNavigationController alloc] initWithRootViewController:shareViewController];
@@ -1557,7 +1557,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 
 - (void)didPressCopy:(NCChatMessage *)message {
     UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
-    pasteboard.string = message.parsedMessage.string;
+    pasteboard.string = message.parsedMessageForChat.string;
     [self.view makeToast:NSLocalizedString(@"Message copied", nil) duration:1.5 position:CSToastPositionCenter];
 }
 
@@ -3511,7 +3511,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     }
     
     // Chat messages
-    NSMutableAttributedString *messageString = message.parsedMessage;
+    NSMutableAttributedString *messageString = message.parsedMessageForChat;
     width -= (message.isSystemMessage)? 80.0 : 30.0; // 4*right(10) + dateLabel(40) : 3*right(10)
     if (message.poll) {
         messageString = [[NSMutableAttributedString alloc] initWithString:message.poll.name];

--- a/NextcloudTalk/ReplyMessageView.m
+++ b/NextcloudTalk/ReplyMessageView.m
@@ -154,7 +154,7 @@
     
     self.message = message;
     self.quotedMessageView.actorLabel.text = ([message.actorDisplayName isEqualToString:@""]) ? NSLocalizedString(@"Guest", nil) : message.actorDisplayName;
-    self.quotedMessageView.messageLabel.text = message.parsedMessage.string;
+    self.quotedMessageView.messageLabel.text = message.parsedMessageForChat.string;
     self.quotedMessageView.highlighted = [message isMessageFromUser:userId];
     
     self.visible = YES;


### PR DESCRIPTION
Fixes #935 

Just returning `nil` leads to some problems:
* Forwarding a deck card just shows nothing
* Replying to a deck card just shows nothing
* In the conversation you see `(null)` if the last message was a shared deck card
* Talk-ios crashes when you look for shared items in a conversation and select deck cards, because Swift assumes a non-null return