### PR TITLE
Use shared deck card in case there is no reference data available

### DIFF
--- a/NextcloudTalk/ChatMessageTableViewCell.m
+++ b/NextcloudTalk/ChatMessageTableViewCell.m
@@ -380,7 +380,15 @@
         }
 
         [message getReferenceDataWithCompletionBlock:^(NCChatMessage *message, NSDictionary *referenceData, NSString *url) {
-            if ([self.message isSameMessage:message]) {
+            if (![self.message isSameMessage:message]) {
+                return;
+            }
+
+            if (!referenceData && message.deckCard) {
+                // In case we were unable to retrieve reference data (for example if the user has no permissions)
+                // but the message is a shared deck card, we use the shared information to show the deck view
+                [self.referenceView updateFor:message.deckCard];
+            } else {
                 [self.referenceView updateFor:referenceData and:url];
             }
         }];

--- a/NextcloudTalk/GroupedChatMessageTableViewCell.m
+++ b/NextcloudTalk/GroupedChatMessageTableViewCell.m
@@ -134,7 +134,15 @@
         _vConstraint[3].constant = 100;
 
         [message getReferenceDataWithCompletionBlock:^(NCChatMessage *message, NSDictionary *referenceData, NSString *url) {
-            if ([self.message isSameMessage:message]) {
+            if (![self.message isSameMessage:message]) {
+                return;
+            }
+
+            if (!referenceData && message.deckCard) {
+                // In case we were unable to retrieve reference data (for example if the user has no permissions)
+                // but the message is a shared deck card, we use the shared information to show the deck view
+                [self.referenceView updateFor:message.deckCard];
+            } else {
                 [self.referenceView updateFor:referenceData and:url];
             }
         }];

--- a/NextcloudTalk/ReferenceDeckView.swift
+++ b/NextcloudTalk/ReferenceDeckView.swift
@@ -69,6 +69,16 @@ import Foundation
         }
     }
 
+    func update(for sharedDeckCard: NCDeckCardParameter) {
+        referenceTypeIcon.image = UIImage(named: "deck-item")
+
+        self.url = sharedDeckCard.link
+        referenceTitle.text = sharedDeckCard.name ?? ""
+        referenceDescription.isHidden = true
+        referenceDueDate.isHidden = true
+        referenceDueDateIcon.isHidden = true
+    }
+
     func update(for reference: [String: AnyObject], and url: String) {
         self.url = url
 

--- a/NextcloudTalk/ReferenceView.swift
+++ b/NextcloudTalk/ReferenceView.swift
@@ -81,6 +81,16 @@
         referenceView.addSubview(defaultView)
     }
 
+    func update(for sharedDeckCard: NCDeckCardParameter) {
+        let deckView = ReferenceDeckView(frame: self.frame)
+        deckView.update(for: sharedDeckCard)
+        deckView.frame = self.bounds
+        deckView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+        referenceView.addSubview(deckView)
+        self.hideIndicatorView()
+    }
+
     func update(for references: [String: [String: AnyObject]]?, and url: String) {
         referenceView.subviews.forEach({ $0.removeFromSuperview() })
 


### PR DESCRIPTION
If a deck card is shared to a conversation, this does not imply that users of that conversation have access to that deck card. If that's the case, the reference provider will return no data and instead of a deck card, the URL is shown. With this PR we now use the information provided by the shared deck card to show at least the title of the card.

Fixes #934 