### PR TITLE
NextcloudKit update to 1.3.0 & Performance improvements

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -2810,7 +2810,7 @@
 			repositoryURL = "https://github.com/nextcloud/NextcloudKit";
 			requirement = {
 				kind = exactVersion;
-				version = 1.2.0;
+				version = 1.3.0;
 			};
 		};
 		2CCCD21B2835088F00F076CE /* XCRemoteSwiftPackageReference "OpenSSL" */ = {

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -1794,8 +1794,21 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     [self setupNCCommunicationForAccount:account];
     NSString *serverUrlString = [NSString stringWithFormat:@"%@%@/%@", account.server, [self filesPathForAccount:account], path ? path : @""];
 
+    // We don't need all properties, so we limit the request to the needed ones to reduce size and processing time
+    NSString *body = @"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+            <d:propfind xmlns:d=\"DAV:\" xmlns:oc=\"http://owncloud.org/ns\" xmlns:nc=\"http://nextcloud.org/ns\">\
+                <d:prop>\
+                    <d:getlastmodified />\
+                    <d:getcontenttype />\
+                    <d:resourcetype />\
+                    <fileid xmlns=\"http://owncloud.org/ns\"/>\
+                    <is-encrypted xmlns=\"http://nextcloud.org/ns\"/>\
+                    <has-preview xmlns=\"http://nextcloud.org/ns\"/>\
+                </d:prop>\
+            </d:propfind>";
+
     NKRequestOptions *options = [[NKRequestOptions alloc] initWithEndpoint:nil customHeader:nil customUserAgent:nil contentType:nil e2eToken:nil timeout:60 queue:dispatch_get_main_queue()];
-    [[NextcloudKit shared] readFileOrFolderWithServerUrlFileName:serverUrlString depth:depth showHiddenFiles:NO requestBody:nil options:options completion:^(NSString *account, NSArray<NKFile *> *files, NSData *responseDates, NKError *error) {
+    [[NextcloudKit shared] readFileOrFolderWithServerUrlFileName:serverUrlString depth:depth showHiddenFiles:NO requestBody:[body dataUsingEncoding:NSUTF8StringEncoding] options:options completion:^(NSString *account, NSArray<NKFile *> *files, NSData *responseDates, NKError *error) {
         if (error.errorCode == 0 && block) {
             block(files, nil);
         } else if (block) {


### PR DESCRIPTION
Fixes #946 

This PR updates NextcloudKit to version 1.3.0. In particular the changes at https://github.com/nextcloud/NextcloudKit/pull/7 should result in a noticeable performance increase in our use case.
Also we limit the number of properties requested as discussed in #946 to only the ones we really need. That should improve performance of large folders additionally.
