### PR TITLE
Save pending message when app is resigning active

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -570,6 +570,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     _hasReceiveNewMessages = NO;
     _startReceivingMessagesAfterJoin = YES;
     [self removeUnreadMessagesSeparator];
+    [self savePendingMessage];
     [_chatController stopChatController];
     [_messageExpirationTimer invalidate];
     [[NCRoomsManager sharedInstance] leaveChatInRoom:_room.token];


### PR DESCRIPTION
* Write something
* Move the app to the background
* App gets closed by iOS because whoever know why
* Get back to the app
* -> Message is missing

For testing just move the app to the background and kill it ;-)