### PR TITLE
External signaling followup

### DIFF
--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -549,6 +549,20 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
     });
 }
 
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (task != self->_webSocket) {
+            return;
+        }
+
+        if (error) {
+            NSLog(@"WebSocket session didCompleteWithError: %@", error.description);
+            [self reconnect];
+        }
+    });
+}
+
 - (void)receiveMessage {
     __weak NCExternalSignalingController *weakSelf = self;
     __block NSURLSessionWebSocketTask *receivingWebSocket = _webSocket;
@@ -600,20 +614,6 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
             });
         }
     }];
-}
-
-- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (task != self->_webSocket) {
-            return;
-        }
-
-        if (error) {
-            NSLog(@"WebSocket session didCompleteWithError: %@", error.description);
-            [self reconnect];
-        }
-    });
 }
 
 - (void)URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -286,10 +286,8 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
     NSString *serverVersion = [[helloDict objectForKey:@"server"] objectForKey:@"version"];
     dispatch_async(dispatch_get_main_queue(), ^{
         BGTaskHelper *bgTask = [BGTaskHelper startBackgroundTaskWithName:@"NCUpdateSignalingVersionTransaction" expirationHandler:nil];
-        [NCUtils log:@"Start update signaling version transaction"];
         [[NCDatabaseManager sharedInstance] setExternalSignalingServerVersion:serverVersion forAccountId:self->_account.accountId];
         [bgTask stopBackgroundTask];
-        [NCUtils log:@"End update signaling version transaction"];
     });
     
     // Send pending messages

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -390,18 +390,13 @@ static NSInteger kIgnoreStatusCode = 999;
 
 - (void)updateRoomsUpdatingUserStatus:(BOOL)updateStatus withCompletionBlock:(UpdateRoomsCompletionBlock)block
 {
-    [NCUtils log:@"Start updateRoomsUpdatingUserStatus"];
-
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
     [[NCAPIController sharedInstance] getRoomsForAccount:activeAccount updateStatus:updateStatus withCompletionBlock:^(NSArray *rooms, NSError *error, NSInteger statusCode) {
         NSMutableDictionary *userInfo = [NSMutableDictionary new];
         NSMutableArray *roomsWithNewMessages = [NSMutableArray new];
 
-        [NCUtils log:@"Start getRoomsForAccount completionBlock"];
-        
         if (!error) {
             BGTaskHelper *bgTask = [BGTaskHelper startBackgroundTaskWithName:@"NCUpdateRoomsTransaction" expirationHandler:nil];
-            [NCUtils log:@"Start transaction"];
 
             RLMRealm *realm = [RLMRealm defaultRealm];
             [realm transactionWithBlock:^{
@@ -430,7 +425,6 @@ static NSInteger kIgnoreStatusCode = 999;
             }];
 
             [bgTask stopBackgroundTask];
-            [NCUtils log:@"End transaction"];
         } else {
             [userInfo setObject:error forKey:@"error"];
             [NCUtils log:[NSString stringWithFormat:@"Could not update rooms. Error: %@", error.description]];
@@ -443,8 +437,6 @@ static NSInteger kIgnoreStatusCode = 999;
         if (block) {
             block(roomsWithNewMessages, error);
         }
-
-        [NCUtils log:@"End getRoomsForAccount completionBlock"];
     }];
 }
 


### PR DESCRIPTION
After further testing of the latest external signaling changes in #975, it was discovered that there's a good chance of a race condition in case of a reconnection. This happens, because the NSURL delegates are called on the NSURL background queue, whereas other parts run on the main thread. This leads to the following problems:

* It is possible to schedule a reconnect twice. One will always fail, sometimes both will fail. This counts as a "join-try", in the end the user gets prompted with a error message saying that the server was not reached.
* The reconnection timer should only be scheduled on the main thread where a run loop is guaranteed (as should the invalidation of it).
* We should check in all cases that we're still working with the webSocket we think we're working with before doing a reconnect.

In my tests I couldn't reproduce any issue until now. Easiest might be to go commit-by-commit through this PR. 