### PR TITLE
Support for writing messages when offline

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -388,6 +388,13 @@
 
     [NCUtils log:@"Start performBackgroundFetchWithCompletionHandler"];
 
+    dispatch_group_enter(backgroundRefreshGroup);
+    [[NCRoomsManager sharedInstance] resendOfflineMessagesWithCompletionBlock:^{
+        [NCUtils log:@"CompletionHandler resendOfflineMessagesWithCompletionBlock"];
+
+        dispatch_group_leave(backgroundRefreshGroup);
+    }];
+
     /* Disable checking for new messages for now, until we can prevent them from showing twice
     dispatch_group_enter(backgroundRefreshGroup);
     [[NCNotificationController sharedInstance] checkForNewNotificationsWithCompletionBlock:^(NSError *error) {

--- a/NextcloudTalk/NCChatController.h
+++ b/NextcloudTalk/NCChatController.h
@@ -23,6 +23,8 @@
 #import <Foundation/Foundation.h>
 #import <Realm/Realm.h>
 
+#import "NCChatMessage.h"
+
 typedef void (^UpdateHistoryInBackgroundCompletionBlock)(NSError *error);
 
 @class NCRoom;
@@ -45,6 +47,7 @@ extern NSString * const NCChatControllerDidReceiveCallEndedMessageNotification;
 
 - (instancetype)initForRoom:(NCRoom *)room;
 - (void)sendChatMessage:(NSString *)message replyTo:(NSInteger)replyTo referenceId:(NSString *)referenceId silently:(BOOL)silently;
+- (void)sendChatMessage:(NCChatMessage *)message;
 - (NSMutableArray *)getTemporaryMessages;
 - (void)getInitialChatHistory;
 - (void)getInitialChatHistoryForOfflineMode;

--- a/NextcloudTalk/NCChatMessage.h
+++ b/NextcloudTalk/NCChatMessage.h
@@ -75,6 +75,9 @@ typedef void (^GetReferenceDataCompletionBlock)(NCChatMessage *message, NSDictio
 @property (nonatomic, assign) BOOL sendingFailed;
 @property (nonatomic, assign) BOOL isGroupMessage;
 @property (nonatomic, assign) BOOL isDeleting;
+@property (nonatomic, assign) BOOL isSilent;
+@property (nonatomic, assign) BOOL isOfflineMessage;
+@property (nonatomic, assign) NSInteger offlineMessageRetryCount;
 
 + (instancetype)messageWithDictionary:(NSDictionary *)messageDict;
 + (instancetype)messageWithDictionary:(NSDictionary *)messageDict andAccountId:(NSString *)accountId;
@@ -100,7 +103,9 @@ typedef void (^GetReferenceDataCompletionBlock)(NCChatMessage *message, NSDictio
 - (NSMutableAttributedString *)parsedMessage;
 - (NSMutableAttributedString *)parsedMessageForChat;
 - (NSMutableAttributedString *)systemMessageFormat;
+- (NSString *)sendingMessage;
 - (NCChatMessage *)parent;
+- (NSInteger)parentMessageId;
 - (NSMutableArray *)reactionsArray;
 - (BOOL)isReactionBeingModified:(NSString *)reaction;
 - (void)addTemporaryReaction:(NSString *)reaction;

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -195,6 +195,8 @@ NSString * const kSharedItemTypeVoice       = @"voice";
     messageCopy.sendingFailed = _sendingFailed;
     messageCopy.isGroupMessage = _isGroupMessage;
     messageCopy.isDeleting = _isDeleting;
+    messageCopy.isOfflineMessage = _isOfflineMessage;
+    messageCopy.isSilent = _isSilent;
     
     return messageCopy;
 }
@@ -492,6 +494,19 @@ NSString * const kSharedItemTypeVoice       = @"voice";
     return message;
 }
 
+- (NSString *)sendingMessage
+{
+    NSString *resultMessage = [[self.message copy] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+
+    for (NSString *parameterKey in self.messageParameters.allKeys) {
+        NCMessageParameter *parameter = [self.messageParameters objectForKey:parameterKey];
+        NSString *parameterKeyString = [[NSString alloc] initWithFormat:@"{%@}", parameterKey];
+        resultMessage = [resultMessage stringByReplacingOccurrencesOfString:parameterKeyString withString:parameter.mentionDisplayName];
+    }
+    
+    return resultMessage;
+}
+
 - (NCChatMessage *)parent
 {
     if (self.parentId) {
@@ -504,6 +519,12 @@ NSString * const kSharedItemTypeVoice       = @"voice";
     }
     
     return nil;
+}
+
+- (NSInteger)parentMessageId
+{
+    NSInteger messageId = self.parent ? self.parent.messageId : -1;
+    return messageId;
 }
 
 - (NSMutableArray *)temporaryReactions

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -33,7 +33,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 42;
+uint64_t const kTalkDatabaseSchemaVersion           = 43;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";

--- a/NextcloudTalk/NCRoomsManager.h
+++ b/NextcloudTalk/NCRoomsManager.h
@@ -37,6 +37,7 @@ extern NSString * const NCRoomsManagerDidStartCallNotification;
 
 typedef void (^UpdateRoomsCompletionBlock)(NSArray *roomsWithNewMessages, NSError *error);
 typedef void (^UpdateRoomsAndChatsCompletionBlock)(NSError *error);
+typedef void (^SendOfflineMessagesCompletionBlock)(void);
 
 @interface NCRoomController : NSObject
 
@@ -64,6 +65,8 @@ typedef void (^UpdateRoomsAndChatsCompletionBlock)(NSError *error);
 - (void)updateLastCommonReadMessage:(NSInteger)messageId forRoom:(NCRoom *)room;
 - (void)joinRoom:(NSString *)token;
 - (void)rejoinRoom:(NSString *)token;
+- (void)resendOfflineMessagesWithCompletionBlock:(SendOfflineMessagesCompletionBlock)block;
+- (void)resendOfflineMessagesForToken:(NSString *)token withCompletionBlock:(SendOfflineMessagesCompletionBlock)block;
 // Chat
 - (void)startChatInRoom:(NCRoom *)room;
 - (void)leaveChatInRoom:(NSString *)token;

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -363,6 +363,10 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
 {
     [[NCRoomsManager sharedInstance] updateRoomsAndChatsUpdatingUserStatus:YES withCompletionBlock:nil];
 
+    if ([NCConnectionController sharedInstance].connectionState == kConnectionStateConnected) {
+        [[NCRoomsManager sharedInstance] resendOfflineMessagesWithCompletionBlock:nil];
+    }
+
     dispatch_async(dispatch_get_main_queue(), ^{
         // Dispatch to main, otherwise the traitCollection is not updated yet and profile buttons shows wrong style
         [self setProfileButton];


### PR DESCRIPTION
Fixes #961 
Fixes #664 

- [x] Allow writing and "sending" messages independent of online status and room joined
- [x] Retry sending those messages in background fetch cycle
- [x] Retry sending those messages when the room refresh timer fires and we're online
- [x] When successfully joining a room: Retry sending offline messages of that room
- [x] When connection state changes to `connected` while in chat: Retry sending offline messages of that room 
- [x] Only allow voice messages and file/objects when we're not offline 
- [x] Guard sending messages by background task
- [x] Mark sending as failed after 5 retry attempts or messages being older than 12h