### PR TITLE
Move transition handling to NCSplitViewController

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -84,12 +84,11 @@
     
     [self registerBackgroundFetchTask];
 
-    [NCUserInterfaceController sharedInstance].mainSplitViewController = (NCSplitViewController *) self.window.rootViewController;
     [NCUserInterfaceController sharedInstance].mainViewController = (NCSplitViewController *) self.window.rootViewController;
-    [NCUserInterfaceController sharedInstance].roomsTableViewController = [NCUserInterfaceController sharedInstance].mainSplitViewController.viewControllers.firstObject.childViewControllers.firstObject;
+    [NCUserInterfaceController sharedInstance].roomsTableViewController = [NCUserInterfaceController sharedInstance].mainViewController.viewControllers.firstObject.childViewControllers.firstObject;
 
     if (@available(iOS 14.5, *)) {
-        [NCUserInterfaceController sharedInstance].mainSplitViewController.displayModeButtonVisibility = UISplitViewControllerDisplayModeButtonVisibilityNever;
+        [NCUserInterfaceController sharedInstance].mainViewController.displayModeButtonVisibility = UISplitViewControllerDisplayModeButtonVisibilityNever;
     }
     
     return YES;

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1147,7 +1147,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 - (void)titleButtonPressed:(id)sender
 {
     RoomInfoTableViewController *roomInfoVC = [[RoomInfoTableViewController alloc] initForRoom:_room fromChatViewController:self];
-    NCSplitViewController *splitViewController = [NCUserInterfaceController sharedInstance].mainSplitViewController;
+    NCSplitViewController *splitViewController = [NCUserInterfaceController sharedInstance].mainViewController;
 
     if (splitViewController != nil && !splitViewController.isCollapsed) {
         roomInfoVC.modalPresentationStyle = UIModalPresentationPageSheet;

--- a/NextcloudTalk/NCUserInterfaceController.h
+++ b/NextcloudTalk/NCUserInterfaceController.h
@@ -34,11 +34,7 @@
 
 @interface NCUserInterfaceController : NSObject
 
-// Will be of type NCSplitViewController on iOS >= 14
-// and NCNavigationController on iOS < 13
-@property (nonatomic, strong) UIViewController *mainViewController;
-
-@property (nonatomic, strong) NCSplitViewController *mainSplitViewController;
+@property (nonatomic, strong) NCSplitViewController *mainViewController;
 @property (nonatomic, strong) RoomsTableViewController *roomsTableViewController;
 
 + (instancetype)sharedInstance;

--- a/NextcloudTalk/NCUserInterfaceController.m
+++ b/NextcloudTalk/NCUserInterfaceController.m
@@ -325,32 +325,15 @@
 {
     [_mainViewController dismissViewControllerAnimated:YES completion:nil];
 
-    [_mainSplitViewController popSecondaryColumnToRootViewController];
-    [_mainSplitViewController showColumn:UISplitViewControllerColumnPrimary];
+    [_mainViewController popSecondaryColumnToRootViewController];
+    [_mainViewController showColumn:UISplitViewControllerColumnPrimary];
 }
 
 
 - (void)presentChatViewController:(NCChatViewController *)chatViewController
 {
     [self presentConversationsList];
-
-    if (_mainSplitViewController.transitionCoordinator == nil) {
-        // No ongoing animations -> show chatViewController directly
-        [_mainSplitViewController showDetailViewController:chatViewController sender:self];
-    } else {
-        // Wait until the splitViewController finished all it's animations.
-        // Otherwise the chatViewController might end up in the wrong column.
-        // This mainly happens when being in a conversation and tapping a push notification
-        // of another conversation.
-        [_mainSplitViewController.transitionCoordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-            // Nothing to do here, we are only interested in the completion block
-        } completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [self->_mainSplitViewController showDetailViewController:chatViewController sender:self];
-            });
-        }];
-    }
-
+    [_mainViewController showDetailViewController:chatViewController sender:self];
     [_roomsTableViewController setSelectedRoomToken:chatViewController.room.token];
 }
 


### PR DESCRIPTION
Fixes #958 

* This should fix #958 (it's hard to reproduce this issue, but I hope this fixes it, otherwise feel free to reopen)
* Fixes an issue where on a collapsed split controller (iPhone portrait) you end up in the placeholder view instead of the room list
* Also this PR removes the duplicate viewController in `NCUserInterfaceController` we kept around for iOS 13 support (before raising to iOS >= 14)

How to reproduce the second issue:
* Enable airplane mode
* Enter a room
* Dismiss the "Unable to join room" error message
* Try to leave to room

Expected:
See the room list

Actual:
See the placeholder view. After dismissing the placeholder view, the room list is visible again.