### PR TITLE
Fix force-muting with HPB

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1502,7 +1502,7 @@ typedef NS_ENUM(NSInteger, CallState) {
 
 - (void)callController:(NCCallController *)callController didReceiveForceMuteActionForPeerId:(NSString *)peerId
 {
-    if ([peerId isEqualToString:callController.userSessionId]) {
+    if ([peerId isEqualToString:callController.signalingSessionId]) {
         [self forceMuteAudio];
     } else {
         NSLog(@"Peer was force muted: %@", peerId);

--- a/NextcloudTalk/NCCallController.h
+++ b/NextcloudTalk/NCCallController.h
@@ -74,5 +74,6 @@
 - (void)enableVideo:(BOOL)enable;
 - (void)enableAudio:(BOOL)enable;
 - (NSString *)getUserIdFromSessionId:(NSString *)sessionId;
+- (NSString *)signalingSessionId;
 
 @end


### PR DESCRIPTION
Need to check the sessionId of the HPB instead of the userSession. The now exposed `signalingSessionId` takes care of both.