### PR TITLE
Use non-modal notification to show join error

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -30,6 +30,7 @@
 
 #import "AFImageDownloader.h"
 #import "FTPopOverMenu.h"
+#import "JDStatusBarNotification.h"
 #import "NSDate+DateTools.h"
 #import "UIImageView+AFNetworking.h"
 #import "UIImageView+Letters.h"
@@ -454,6 +455,8 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     [self savePendingMessage];
     [self saveLastReadMessage];
     [self stopVoiceMessagePlayer];
+
+    [[JDStatusBarNotificationPresenter sharedPresenter] dismiss];
     
     _isVisible = NO;
 }
@@ -934,20 +937,9 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 
 - (void)presentJoinError:(NSString *)alertMessage
 {
-    NSString *alertTitle = [NSString stringWithFormat:NSLocalizedString(@"Could not join %@", nil), _room.displayName];
-    if (_room.type == kNCRoomTypeOneToOne) {
-        alertTitle = [NSString stringWithFormat:NSLocalizedString(@"Could not join conversation with %@", nil), _room.displayName];
-    }
+    NSString *alertTitle = NSLocalizedString(@"Could not join conversation", nil);
 
-    UIAlertController * alert = [UIAlertController alertControllerWithTitle:alertTitle
-                                                                    message:alertMessage
-                                                             preferredStyle:UIAlertControllerStyleAlert];
-    
-    UIAlertAction* okButton = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
-                                                       style:UIAlertActionStyleDefault
-                                                     handler:nil];
-    [alert addAction:okButton];
-    [[NCUserInterfaceController sharedInstance] presentAlertViewController:alert];
+    [[JDStatusBarNotificationPresenter sharedPresenter] presentWithTitle:alertTitle subtitle:alertMessage includedStyle:JDStatusBarNotificationIncludedStyleWarning completion:nil];
 }
 
 #pragma mark - Temporary messages

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -419,16 +419,13 @@
 "Could not delete conversation" = "Could not delete conversation";
 
 /* No comment provided by engineer. */
-"Could not join %@" = "Could not join %@";
-
-/* No comment provided by engineer. */
 "Could not join %@ call" = "Could not join %@ call";
 
 /* No comment provided by engineer. */
 "Could not join call with %@" = "Could not join call with %@";
 
 /* No comment provided by engineer. */
-"Could not join conversation with %@" = "Could not join conversation with %@";
+"Could not join conversation" = "Could not join conversation";
 
 /* No comment provided by engineer. */
 "Could not leave conversation" = "Could not leave conversation";


### PR DESCRIPTION
In the light of #1004 the join error should be a non-modal.