### PR TITLE
Fix ShareExtension plist & image downloader

### DIFF
--- a/ShareExtension/Info.plist
+++ b/ShareExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Nextcloud Talk</string>
+	<string>ShareExtension</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ShareExtension/ShareTableViewCell.m
+++ b/ShareExtension/ShareTableViewCell.m
@@ -45,13 +45,6 @@ CGFloat const kShareTableCellHeight = 56.0f;
     self.avatarImageView.layer.masksToBounds = YES;
     self.avatarImageView.backgroundColor = [NCAppBranding placeholderColor];
     self.avatarImageView.contentMode = UIViewContentModeCenter;
-    
-    AFImageDownloader *imageDownloader = [[AFImageDownloader alloc]
-                                          initWithSessionManager:[NCAvatarSessionManager sharedInstance]
-                                          downloadPrioritization:AFImageDownloadPrioritizationFIFO
-                                          maximumActiveDownloads:4
-                                          imageCache:[[AFAutoPurgingImageCache alloc] init]];
-    [ShareAvatarImageView setSharedImageDownloader:imageDownloader];
 }
 
 - (void)prepareForReuse

--- a/ShareExtension/ShareViewController.m
+++ b/ShareExtension/ShareViewController.m
@@ -26,6 +26,7 @@
 
 #import "NCAPIController.h"
 #import "NCAppBranding.h"
+#import "NCAvatarSessionManager.h"
 #import "NCDatabaseManager.h"
 #import "NCIntentController.h"
 #import "NCRoom.h"
@@ -131,6 +132,15 @@
         [RLMRealmConfiguration setDefaultConfiguration:configuration];
     }
     _realm = [RLMRealm realmWithConfiguration:configuration error:&error];
+
+    // Setup image downloader
+    AFImageDownloader *imageDownloader = [[AFImageDownloader alloc]
+                                          initWithSessionManager:[NCAvatarSessionManager sharedInstance]
+                                          downloadPrioritization:AFImageDownloadPrioritizationFIFO
+                                          maximumActiveDownloads:4
+                                          imageCache:[[AFAutoPurgingImageCache alloc] init]];
+    
+    [ShareAvatarImageView setSharedImageDownloader:imageDownloader];
     
     if (self.extensionContext && self.extensionContext.intent && [self.extensionContext.intent isKindOfClass:[INSendMessageIntent class]]) {
         INSendMessageIntent *intent = (INSendMessageIntent *)self.extensionContext.intent;


### PR DESCRIPTION
I stumbled on this while hunting another bug in the ShareExtension. So I'm not totally sure if there was a reason to do it like it was done. The BundleDisplayName of the ShareExtension should not be "NextcloudTalk" (see NotificationServiceExtension for example), but "ShareExtension". Also the image downloader should only be set up once, not for every cell and then used globally (therefore essentially always creating a new AFAutoPurgingImageCache).