### PR TITLE
Offline messages fixup

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -932,6 +932,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     NSString *alertTitle = NSLocalizedString(@"Could not join conversation", nil);
 
     [[JDStatusBarNotificationPresenter sharedPresenter] presentWithTitle:alertTitle subtitle:alertMessage includedStyle:JDStatusBarNotificationIncludedStyleWarning completion:nil];
+    [[JDStatusBarNotificationPresenter sharedPresenter] dismissAfterDelay:8.0];
 }
 
 #pragma mark - Temporary messages

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -2379,6 +2379,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 - (void)didLeaveRoom:(NSNotification *)notification
 {
     [self disableRoomControls];
+    [self checkRoomControlsAvailability];
 }
 
 #pragma mark - CallKit Manager notifications


### PR DESCRIPTION
1. A potential join error should be auto dismissed
2. After leaving a room (moving the app to the background), the room controls should not only be disabled, it should be checked, which controls are actually available (for example sending a message)