### PR TITLE
Fix disconnected and joined state

### DIFF
--- a/NextcloudTalk/AppDelegate.h
+++ b/NextcloudTalk/AppDelegate.h
@@ -33,6 +33,7 @@
 @property (assign, nonatomic) BOOL shouldLockInterfaceOrientation;
 @property (assign, nonatomic) UIInterfaceOrientation lockedInterfaceOrientation;
 
+- (void)keepExternalSignalingConnectionAliveTemporarily;
 
 @end
 

--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -464,8 +464,9 @@
 
     _keepAliveBGTask = [BGTaskHelper startBackgroundTaskWithName:@"NCWebSocketKeepAlive" expirationHandler:nil];
     _keepAliveTimer = [NSTimer scheduledTimerWithTimeInterval:20 repeats:NO block:^(NSTimer * _Nonnull timer) {
-        // Stop the external signaling connections only if the app keeps in the background
-        if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) {
+        // Stop the external signaling connections only if the app keeps in the background and not in a call
+        if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground &&
+            ![NCRoomsManager sharedInstance].callViewController) {
             [[NCSettingsController sharedInstance] disconnectAllExternalSignalingControllers];
         }
 

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -2391,6 +2391,8 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 
 - (void)didLeaveRoom:(NSNotification *)notification
 {
+    _hasJoinedRoom = NO;
+    
     [self disableRoomControls];
     [self checkRoomControlsAvailability];
 }

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -159,11 +159,7 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
     
     [self executeAllCompletionBlocksWithError];
 
-    [_webSocket cancel];
-    _webSocket = nil;
-    _helloResponseReceived = NO;
-    [_helloMessage ignoreCompletionBlock];
-    _helloMessage = nil;
+    [self resetWebSocket];
 
     [self setReconnectionTimer];
 }
@@ -180,11 +176,18 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         [self invalidateReconnectionTimer];
-        [self->_webSocket cancel];
-        self->_webSocket = nil;
-        self->_helloResponseReceived = NO;
-        self->_disconnected = YES;
+        [self resetWebSocket];
     });
+}
+
+- (void)resetWebSocket
+{
+    [_webSocket cancel];
+    _webSocket = nil;
+    _helloResponseReceived = NO;
+    [_helloMessage ignoreCompletionBlock];
+    _helloMessage = nil;
+    _disconnected = YES;
 }
 
 - (void)setReconnectionTimer

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -24,6 +24,7 @@
 
 #import <Realm/Realm.h>
 
+#import "AppDelegate.h"
 #import "CallKitManager.h"
 #import "NCChatViewController.h"
 #import "NCAPIController.h"
@@ -812,6 +813,11 @@ static NSInteger kIgnoreStatusCode = 999;
         NSString *token = [_callViewController.room.token copy];
         _callViewController = nil;
         [self callDidEndInRoomWithToken:token];
+        // Keep connection alive temporarily when a call was finished while the app in the background
+        if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) {
+            AppDelegate *appDelegate = (AppDelegate*)[UIApplication sharedApplication].delegate;
+            [appDelegate keepExternalSignalingConnectionAliveTemporarily];
+        }
     }
 }
 


### PR DESCRIPTION
* When we leave a room, correctly reset `hasJoinedRoom` property to `false`
* Currently when we reconnect, we don't set `disconnected` to `true`. This can lead to a situation, where the websocket is `nil`, but won't be connected, because of the missing property. 