### PR TITLE
Joining room fixes

### DIFF
--- a/NextcloudTalk/NCExternalSignalingController.h
+++ b/NextcloudTalk/NCExternalSignalingController.h
@@ -27,6 +27,12 @@
 @class NCExternalSignalingController;
 @class TalkAccount;
 
+typedef enum NCExternalSignalingSendMessageStatus {
+    SendMessageSuccess = 0,
+    SendMessageSocketError,
+    SendMessageApplicationError
+} NCExternalSignalingSendMessageStatus;
+
 @protocol NCExternalSignalingControllerDelegate <NSObject>
 
 - (void)externalSignalingController:(NCExternalSignalingController *)externalSignalingController didReceivedSignalingMessage:(NSDictionary *)signalingMessageDict;
@@ -38,7 +44,7 @@
 
 @interface NCExternalSignalingController : NSObject
 
-typedef void (^SendMessageCompletionBlock)(NSURLSessionWebSocketTask *task, NSError *error);
+typedef void (^SendMessageCompletionBlock)(NSURLSessionWebSocketTask *task, NCExternalSignalingSendMessageStatus status);
 typedef void (^JoinRoomExternalSignalingCompletionBlock)(NSError *error);
 
 @property (nonatomic, strong) NSString *currentRoom;

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -223,6 +223,11 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
 
     // Add message as pending message if websocket is not connected
     if (!_helloResponseReceived && !wsMessage.isHelloMessage) {
+        if (wsMessage.isJoinMessage) {
+            // We join a new room, so any message which wasn't send by now is not relevant for the new room anymore
+            _pendingMessages = [NSMutableArray new];
+        }
+
         [_pendingMessages addObject:wsMessage];
         return;
     }

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -175,13 +175,14 @@ static NSInteger kIgnoreStatusCode = 999;
 {
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
     _joinRoomTask = [[NCAPIController sharedInstance] joinRoom:token forAccount:activeAccount withCompletionBlock:^(NSString *sessionId, NSError *error, NSInteger statusCode) {
-        if (!self->_joiningRoomToken) {
+        if (!self->_joiningRoomToken || ![self->_joiningRoomToken isEqualToString:token]) {
             [NCUtils log:@"Not joining the room any more. Ignore response."];
             if (block) {
                 block(nil, nil, kIgnoreStatusCode);
             }
             return;
         }
+        
         if (!error) {
             [NCUtils log:[NSString stringWithFormat:@"Joined room %@ in NC successfully.", token]];
             NCExternalSignalingController *extSignalingController = [[NCSettingsController sharedInstance] externalSignalingControllerForAccountId:activeAccount.accountId];

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -182,28 +182,33 @@ static NSInteger kIgnoreStatusCode = 999;
             }
             return;
         }
-        
-        if (!error) {
-            [NCUtils log:[NSString stringWithFormat:@"Joined room %@ in NC successfully.", token]];
-            NCExternalSignalingController *extSignalingController = [[NCSettingsController sharedInstance] externalSignalingControllerForAccountId:activeAccount.accountId];
-            if ([extSignalingController isEnabled]) {
-                [NCUtils log:[NSString stringWithFormat:@"Trying to join room %@ in external signaling server...", token]];
-                [extSignalingController joinRoom:token withSessionId:sessionId withCompletionBlock:^(NSError *error) {
-                    if (!error) {
-                        [NCUtils log:[NSString stringWithFormat:@"Joined room %@ in external signaling server successfully.", token]];
-                        block(sessionId, nil, 0);
-                    } else if (block) {
-                        [NCUtils log:[NSString stringWithFormat:@"Failed joining room %@ in external signaling server.", token]];
-                        block(nil, error, statusCode);
-                    }
-                }];
-            } else if (block) {
-                // Joined room in NC successfully and no external signaling server configured.
-                block(sessionId, nil, 0);
+
+        if (error) {
+            if (block) {
+                // Failed to join room in NC.
+                block(nil, error, statusCode);
             }
+
+            return;
+        }
+
+        [NCUtils log:[NSString stringWithFormat:@"Joined room %@ in NC successfully.", token]];
+        NCExternalSignalingController *extSignalingController = [[NCSettingsController sharedInstance] externalSignalingControllerForAccountId:activeAccount.accountId];
+        
+        if ([extSignalingController isEnabled]) {
+            [NCUtils log:[NSString stringWithFormat:@"Trying to join room %@ in external signaling server...", token]];
+            [extSignalingController joinRoom:token withSessionId:sessionId withCompletionBlock:^(NSError *error) {
+                if (!error) {
+                    [NCUtils log:[NSString stringWithFormat:@"Joined room %@ in external signaling server successfully.", token]];
+                    block(sessionId, nil, 0);
+                } else if (block) {
+                    [NCUtils log:[NSString stringWithFormat:@"Failed joining room %@ in external signaling server.", token]];
+                    block(nil, error, statusCode);
+                }
+            }];
         } else if (block) {
-            // Failed to join room in NC.
-            block(nil, error, statusCode);
+            // Joined room in NC successfully and no external signaling server configured.
+            block(sessionId, nil, 0);
         }
     }];
 }

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -120,6 +120,7 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
     _joiningRoomToken = nil;
     _joiningSessionId = nil;
     _joiningAttempts = 0;
+    [_joinRoomTask cancel];
 
     [self joinRoomHelper:token forCall:call];
 }

--- a/NextcloudTalk/WSMessage.h
+++ b/NextcloudTalk/WSMessage.h
@@ -36,8 +36,7 @@
 - (BOOL)isHelloMessage;
 - (void)setMessageTimeout;
 - (void)ignoreCompletionBlock;
-- (void)executeCompletionBlockWithSuccess;
-- (void)executeCompletionBlockWithError;
+- (void)executeCompletionBlockWithStatus:(NCExternalSignalingSendMessageStatus)status;
 - (void)sendMessageWithWebSocket:(NSURLSessionWebSocketTask *)webSocketTask;
 
 @end

--- a/NextcloudTalk/WSMessage.h
+++ b/NextcloudTalk/WSMessage.h
@@ -34,6 +34,7 @@
 - (instancetype)initWithMessage:(NSDictionary *)message withCompletionBlock:(SendMessageCompletionBlock)block;
 - (NSString *)webSocketMessage;
 - (BOOL)isHelloMessage;
+- (BOOL)isJoinMessage;
 - (void)setMessageTimeout;
 - (void)ignoreCompletionBlock;
 - (void)executeCompletionBlockWithStatus:(NCExternalSignalingSendMessageStatus)status;

--- a/NextcloudTalk/WSMessage.m
+++ b/NextcloudTalk/WSMessage.m
@@ -138,7 +138,6 @@ static NSTimeInterval kSendMessageTimeoutInterval = 15;
     }
 
     NSLog(@"Sending: %@", self.webSocketMessage);
-    [NCUtils trace:[NSString stringWithFormat:@"Sending: %@", self.webSocketMessage]];
     NSURLSessionWebSocketMessage *message = [[NSURLSessionWebSocketMessage alloc] initWithString:self.webSocketMessage];
     [webSocketTask sendMessage:message completionHandler:^(NSError * _Nullable error) {
         if (error && self.completionBlock) {

--- a/NextcloudTalk/WSMessage.m
+++ b/NextcloudTalk/WSMessage.m
@@ -70,6 +70,15 @@ static NSTimeInterval kSendMessageTimeoutInterval = 15;
     return NO;
 }
 
+- (BOOL)isJoinMessage
+{
+    if ([[_message objectForKey:@"type"] isEqualToString:@"room"]) {
+        return YES;
+    }
+
+    return NO;
+}
+
 - (void)setMessageTimeout
 {
     // NSTimer uses the runloop of the current thread. Only the main thread guarantees a runloop, so make sure we dispatch it to main!

--- a/NextcloudTalk/WSMessage.m
+++ b/NextcloudTalk/WSMessage.m
@@ -21,6 +21,7 @@
  */
 
 #import "WSMessage.h"
+#import "NCUtils.h"
 
 static NSTimeInterval kSendMessageTimeoutInterval = 15;
 
@@ -74,19 +75,7 @@ static NSTimeInterval kSendMessageTimeoutInterval = 15;
     // NSTimer uses the runloop of the current thread. Only the main thread guarantees a runloop, so make sure we dispatch it to main!
     // This is mainly a problem for the "hello message", because it's send from a NSURL delegate and the timer sometimes fails to run
     dispatch_async(dispatch_get_main_queue(), ^{
-        self->_timeoutTimer = [NSTimer scheduledTimerWithTimeInterval:kSendMessageTimeoutInterval target:self selector:@selector(executeCompletionBlockWithError) userInfo:nil repeats:NO];
-    });
-}
-
-- (void)executeCompletionBlock:(NSError *)error
-{
-    // As the timer was create on the main thread, it needs to be invalidated on the main thread as well
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (self.completionBlock) {
-            self.completionBlock(self.webSocketTask, error);
-            self.completionBlock = nil;
-            [self->_timeoutTimer invalidate];
-        }
+        self->_timeoutTimer = [NSTimer scheduledTimerWithTimeInterval:kSendMessageTimeoutInterval target:self selector:@selector(executeCompletionBlockWithSocketError) userInfo:nil repeats:NO];
     });
 }
 
@@ -98,15 +87,21 @@ static NSTimeInterval kSendMessageTimeoutInterval = 15;
     });
 }
 
-- (void)executeCompletionBlockWithSuccess
+- (void)executeCompletionBlockWithStatus:(NCExternalSignalingSendMessageStatus)status
 {
-    [self executeCompletionBlock:nil];
+    // As the timer was create on the main thread, it needs to be invalidated on the main thread as well
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self.completionBlock) {
+            self.completionBlock(self.webSocketTask, status);
+            self.completionBlock = nil;
+            [self->_timeoutTimer invalidate];
+        }
+    });
 }
 
-- (void)executeCompletionBlockWithError
+- (void)executeCompletionBlockWithSocketError
 {
-    NSError *error = [NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:nil];
-    [self executeCompletionBlock:error];
+    [self executeCompletionBlockWithStatus:SendMessageSocketError];
 }
 
 - (NSString *)webSocketMessage
@@ -134,10 +129,11 @@ static NSTimeInterval kSendMessageTimeoutInterval = 15;
     }
 
     NSLog(@"Sending: %@", self.webSocketMessage);
+    [NCUtils trace:[NSString stringWithFormat:@"Sending: %@", self.webSocketMessage]];
     NSURLSessionWebSocketMessage *message = [[NSURLSessionWebSocketMessage alloc] initWithString:self.webSocketMessage];
     [webSocketTask sendMessage:message completionHandler:^(NSError * _Nullable error) {
         if (error && self.completionBlock) {
-            [self executeCompletionBlockWithError];
+            [self executeCompletionBlockWithSocketError];
         }
     }];
 }


### PR DESCRIPTION
Summary:

* When we receive `no_such_session` error, we now gracefully recover by sending the hello message again without a resumeId (no need to reconnect, as the socket is still alive)
* In the external signaling controller we now distinguish between application errors and socket errors. When we receive an application error (like `no_such_room`), there's no need to instantly reconnect the whole websocket.
* The join process in `NCRoomsManager` got refactored, the main point being that we now ignore completion blocks from the external signaling controller, when we're not joining the room anymore or we're joining with a different sessionId. This previously lead to an increase in the join attempts when multiple join processes were running in parallel and therefore ended in `Could not join the conversation` message.

For details, this happened in one of my tests with the current master:
```
2022-12-17 9:07:40.8050 DidReceiveMessage: {"type":"welcome","welcome":{"version":"1.0.0-1~ubuntu20.04","features":["audio-video-permissions","hello-v2","incall-all","mcu","simulcast","transient-data","update-sdp","virtual-sessions","welcome"]}}
2022-12-17 9:07:40.8130 Sending: {"type":"hello","hello":{"version":"1.0","resumeid":"..."},"id":"1"}
2022-12-17 9:07:40.9600 DidReceiveMessage: {"id":"1","type":"hello","hello":{"version":"1.0","sessionid":"...","resumeid":"...","userid":"marcelm","server":{"version":"1.0.0-1~ubuntu20.04","features":["audio-video-permissions","hello-v2","incall-all","mcu","simulcast","transient-data","update-sdp","welcome"]}}}
2022-12-17 9:07:40.9730 Sending: {"type":"room","id":"2","room":{"roomid":"2738090896","sessionid":"Zd31zcVomeN..."}}
2022-12-17 9:07:40.9860 Sending: {"type":"room","id":"3","room":{"roomid":"2738090896","sessionid":"U+FF4ArJdde..."}}
2022-12-17 9:07:40.9980 Sending: {"type":"room","id":"4","room":{"roomid":"2738090896","sessionid":"\/X3SXE56Z0..."}}
2022-12-17 9:07:41.0030 DidReceiveMessage: {"type":"event","event":{"target":"roomlist","type":"update","update":{"roomid":"2738090896","properties":{"name":"Private Unterhaltung","type":1,"lobby-state":0,"lobby-timer":null,"read-only":0,"listable":0,"active-since":null,"sip-enabled":0,"participant-list":"refresh"}}}}
2022-12-17 9:07:41.0100 DidReceiveMessage: {"type":"event","event":{"target":"roomlist","type":"update","update":{"roomid":"2738090896","properties":{"name":"Private Unterhaltung","type":1,"lobby-state":0,"lobby-timer":null,"read-only":0,"listable":0,"active-since":null,"sip-enabled":0,"participant-list":"refresh"}}}}
2022-12-17 9:07:41.0140 DidReceiveMessage: {"type":"event","event":{"target":"roomlist","type":"update","update":{"roomid":"2738090896","properties":{"name":"Private Unterhaltung","type":1,"lobby-state":0,"lobby-timer":null,"read-only":0,"listable":0,"active-since":null,"sip-enabled":0,"participant-list":"refresh"}}}}
2022-12-17 9:07:41.1010 DidReceiveMessage: {"id":"2","type":"error","error":{"code":"no_such_room","message":"The user is not invited to this room."}}
```

So because the websocket wasn't connected, there were multiple join attempts for the same room, but with different sessionIds. Obviously two of them must fail, because the sessionId was invalid at this point. The error `no_such_room` then triggered a reconnect and execution of all message completion blocks with an error, leading to the aforementioned `Could not join..` error. We now handle application errors without an immediate reconnect and also ignore completion blocks of previous join attempts, which are already superseded by another join attempt.