### PR TITLE
Fix richObjectType for GitHub integration

### DIFF
--- a/NextcloudTalk/ReferenceView.swift
+++ b/NextcloudTalk/ReferenceView.swift
@@ -109,7 +109,7 @@
 
         var foundReferenceView = false
 
-        if richObjectType == "integration_github",
+        if richObjectType == "integration_github" || richObjectType == "integration_github_issue_pr",
            let reference = firstReference["richObject"] as? [String: AnyObject] {
 
             let githubView = ReferenceGithubView(frame: self.frame)


### PR DESCRIPTION
The rich object type for GitHub integration was renamed in one of the last versions, now we check for both types.