### PR TITLE
Websocket background fixes

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -470,7 +470,12 @@
             [[NCSettingsController sharedInstance] disconnectAllExternalSignalingControllers];
         }
 
-        [self->_keepAliveBGTask stopBackgroundTask];
+        // Disconnect is dispatched to the main queue, so in theory it can happen that we stop the background task
+        // before the disconnect is run/completed. So we dispatch the stopBackgroundTask to main as well
+        // to be sure it's called after everything else is run.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self->_keepAliveBGTask stopBackgroundTask];
+        });
     }];
 
     [[NSRunLoop mainRunLoop] addTimer:_keepAliveTimer forMode:NSRunLoopCommonModes];

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -137,7 +137,7 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
     _messageId = 1;
     _messagesWithCompletionBlocks = [NSMutableArray new];
     _helloResponseReceived = NO;
-    NSLog(@"Connecting to: %@",  _serverUrl);
+    [NCUtils log:[NSString stringWithFormat:@"Connecting to: %@", _serverUrl]];
     NSURL *url = [NSURL URLWithString:_serverUrl];
     NSURLSession *wsSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:nil];
     NSURLRequest *wsRequest = [[NSURLRequest alloc] initWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:kWebSocketTimeoutInterval];
@@ -156,6 +156,8 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
     if (_reconnectTimer) {
         return;
     }
+
+    [NCUtils log:[NSString stringWithFormat:@"Reconnecting to: %@", _serverUrl]];
 
     [self resetWebSocket];
 
@@ -177,6 +179,8 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
 
 - (void)disconnect
 {
+    [NCUtils log:[NSString stringWithFormat:@"Disconnecting from: %@", _serverUrl]];
+
     dispatch_async(dispatch_get_main_queue(), ^{
         [self invalidateReconnectionTimer];
         [self resetWebSocket];

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -352,6 +352,15 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
 
 - (void)joinRoom:(NSString *)roomId withSessionId:(NSString *)sessionId withCompletionBlock:(JoinRoomExternalSignalingCompletionBlock)block
 {
+
+    if (_disconnected) {
+        [NCUtils log:[NSString stringWithFormat:@"Joining room %@, but the websocket is disconnected.", roomId]];
+    }
+
+    if (_webSocket == nil) {
+        [NCUtils log:[NSString stringWithFormat:@"Joining room %@, but the websocket is nil.", roomId]];
+    }
+
     NSDictionary *messageDict = @{
                                   @"type": @"room",
                                   @"room": @{


### PR DESCRIPTION
* Make sure we end the background task as the last operation on the main queue
* Add logging when joining a room and the websocket is not available
* Add logging to connect/disconnect/reconnect for further troubleshooting