### PR TITLE
Fix permanent disconnected state when configuration changes

### DIFF
--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -119,6 +119,7 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
     // Do not try to connect if the app is running in the background
     if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) {
         [NCUtils log:@"Trying to create websocket connection while app is in the background"];
+        _disconnected = YES;
         return;
     }
 

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -58,16 +58,6 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
 
 @implementation NCExternalSignalingController
 
-+ (NCExternalSignalingController *)sharedInstance
-{
-    static dispatch_once_t once;
-    static NCExternalSignalingController *sharedInstance;
-    dispatch_once(&once, ^{
-        sharedInstance = [[self alloc] init];
-    });
-    return sharedInstance;
-}
-
 - (instancetype)initWithAccount:(TalkAccount *)account server:(NSString *)serverUrl andTicket:(NSString *)ticket
 {
     self = [super init];


### PR DESCRIPTION
Hopefully this is the last follow-up to our external signaling controller for a while.

Currently the changed implementation of the external signaling controller is much more robust than before. Still, there are occasions, where we are unable to join a room in the external signaling controller after opening the app from the background.

Reason:
* When we move the app to the background we disconnect all web sockets and set `_disconnected = YES`.
* After moving to the foreground again, we connect all web sockets (which are disconnected) again.
* When we do a background fetch, the API controller checks if the talk configuration hash changed. If that's the case, we load the new (signaling-)configuration, remove the old external signaling controller and create a new one with the changed configuration. Because we do this in the background, we don't connect to the newly created external signaling controller, but also we don't set the state to `disconnected`. 
* After moving to the foreground again, the newly created controller won't be connected, because it incorrectly has `_disconnected = NO` set. 
* The problem resolves itself after the app is moved for > 20s to the background again, because we then try to disconnect from the web socket again and also set the state to `_disconnected = YES`.

How to test
* Open the app with Xcode attached, make sure the active account is the one to do the following changes
* Do a `Simulate background fetch`
* Change the talk configuration (just add or remove a STUN server)
* Do a `Simulate background fetch` again
* Note the log message in the console "Trying to create websocket connection while app is in the background".
* Without this PR: The websocket will stay disconnected after moving to the foreground and the call buttons stay disabled
* With this PR: The websocket will be connected correctly and the call buttons are available

Other things in this PR:
* Make sure that creating an external signaling controller is guarded by a background task so we can be sure that everything is created correctly and not interrupted by iOS. Because some parts are dispatched to main, we're using a dedicated background task in `setSignalingConfigurationForAccountId`. 
* Remove unused `sharedInstance` from the external signaling controller