### PR TITLE
Use shared PeerConnectionFactory to create a peerConnection object

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		1F7AE07A29142E62009F72AD /* NextcloudKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1F7AE07929142E62009F72AD /* NextcloudKit */; };
 		1F7AE07C29142E6A009F72AD /* NextcloudKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1F7AE07B29142E6A009F72AD /* NextcloudKit */; };
 		1F7AE07D29158878009F72AD /* IntentsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F90EFC225FE489B00F3FA55 /* IntentsUI.framework */; };
+		1F8995B52973547700CABA33 /* WebRTCCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8995B42973547700CABA33 /* WebRTCCommon.swift */; };
 		1F90EFBC25FE39F800F3FA55 /* NCIntentController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F90EFBB25FE39F800F3FA55 /* NCIntentController.m */; };
 		1F90EFBD25FE39F800F3FA55 /* NCIntentController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F90EFBB25FE39F800F3FA55 /* NCIntentController.m */; };
 		1F90EFBE25FE39F800F3FA55 /* NCIntentController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F90EFBB25FE39F800F3FA55 /* NCIntentController.m */; };
@@ -394,6 +395,7 @@
 		1F785DDA2707865F00AC4B40 /* VoiceMessageTranscribeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VoiceMessageTranscribeViewController.m; sourceTree = "<group>"; };
 		1F785DDB2707865F00AC4B40 /* VoiceMessageTranscribeViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = VoiceMessageTranscribeViewController.xib; sourceTree = "<group>"; };
 		1F785DDC2707865F00AC4B40 /* VoiceMessageTranscribeViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VoiceMessageTranscribeViewController.h; sourceTree = "<group>"; };
+		1F8995B42973547700CABA33 /* WebRTCCommon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCCommon.swift; sourceTree = "<group>"; };
 		1F90EFBA25FE39F800F3FA55 /* NCIntentController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NCIntentController.h; sourceTree = "<group>"; };
 		1F90EFBB25FE39F800F3FA55 /* NCIntentController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NCIntentController.m; sourceTree = "<group>"; };
 		1F90EFC225FE489B00F3FA55 /* IntentsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IntentsUI.framework; path = System/Library/Frameworks/IntentsUI.framework; sourceTree = SDKROOT; };
@@ -1307,6 +1309,7 @@
 				2CD5F3232142781A006B71BF /* NCExternalSignalingController.m */,
 				2C69323B2923ECAA00017AD2 /* WSMessage.h */,
 				2C69323C2923ECAA00017AD2 /* WSMessage.m */,
+				1F8995B42973547700CABA33 /* WebRTCCommon.swift */,
 			);
 			name = WebRTC;
 			sourceTree = "<group>";
@@ -1921,6 +1924,7 @@
 				2C4CDCD126A84E500023F403 /* ShareTableViewCell.m in Sources */,
 				2C8CDD0621C2EDE8004E2997 /* AvatarBackgroundImageView.m in Sources */,
 				2C9B0B9C217F756B00A4752C /* NCNotification.m in Sources */,
+				1F8995B52973547700CABA33 /* WebRTCCommon.swift in Sources */,
 				2C4CDCCC269618240023F403 /* RoomDescriptionTableViewCell.m in Sources */,
 				2CC007BD20D8F24B0096D91F /* RoomCreation2TableViewController.m in Sources */,
 				DA66583127B6B24E00B46B11 /* UserProfileTableViewController+Utils.swift in Sources */,

--- a/NextcloudTalk/NCPeerConnection.m
+++ b/NextcloudTalk/NCPeerConnection.m
@@ -34,11 +34,11 @@
 #import "ARDSDPUtils.h"
 
 #import "NCSignalingMessage.h"
+#import "NextcloudTalk-Swift.h"
 
 
 @interface NCPeerConnection () <RTCPeerConnectionDelegate, RTCDataChannelDelegate>
 
-@property (nonatomic, strong) RTCPeerConnectionFactory *peerConnectionFactory;
 @property (nonatomic, strong) NSMutableArray *queuedRemoteCandidates;
 
 @end
@@ -50,10 +50,6 @@
     self = [super init];
     
     if (self) {
-        RTCDefaultVideoEncoderFactory *encoderFactory = [[RTCDefaultVideoEncoderFactory alloc] init];
-        RTCDefaultVideoDecoderFactory *decoderFactory = [[RTCDefaultVideoDecoderFactory alloc] init];
-        _peerConnectionFactory = [[RTCPeerConnectionFactory alloc] initWithEncoderFactory:encoderFactory decoderFactory:decoderFactory];
-        
         RTCMediaConstraints* constraints = [[RTCMediaConstraints alloc]
                                             initWithMandatoryConstraints:nil
                                             optionalConstraints:nil];
@@ -61,10 +57,11 @@
         RTCConfiguration *config = [[RTCConfiguration alloc] init];
         [config setIceServers:iceServers];
         [config setSdpSemantics:RTCSdpSemanticsUnifiedPlan];
-        
-        RTCPeerConnection *peerConnection = [_peerConnectionFactory peerConnectionWithConfiguration:config
-                                                                                        constraints:constraints
-                                                                                           delegate:self];
+
+        RTCPeerConnectionFactory *peerConnectionFactory = [WebRTCCommon shared].peerConnectionFactory;
+        RTCPeerConnection *peerConnection = [peerConnectionFactory peerConnectionWithConfiguration:config
+                                                                                       constraints:constraints
+                                                                                          delegate:self];
         
         _peerConnection = peerConnection;
         _peerId = sessionId;

--- a/NextcloudTalk/WebRTCCommon.swift
+++ b/NextcloudTalk/WebRTCCommon.swift
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2023 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+@objcMembers class WebRTCCommon: NSObject {
+
+    public static let shared = WebRTCCommon()
+
+    public let peerConnectionFactory: RTCPeerConnectionFactory
+
+    private let encoderFactory: RTCVideoEncoderFactory
+    private let decoderFactory: RTCVideoDecoderFactory
+
+    private override init() {
+        encoderFactory = RTCDefaultVideoEncoderFactory()
+        decoderFactory = RTCDefaultVideoDecoderFactory()
+        peerConnectionFactory = RTCPeerConnectionFactory(encoderFactory: encoderFactory, decoderFactory: decoderFactory)
+
+        super.init()
+    }
+}


### PR DESCRIPTION
This one fixes #952 and also improves the creation of a peerConnection object a lot. Should definitely help in situations like https://github.com/nextcloud/spreed/issues/8549