### PR TITLE
Performance improvements CallView / Logging

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1430,7 +1430,7 @@ typedef NS_ENUM(NSInteger, CallState) {
 
                 [self updatePeer:remotePeer block:^(CallParticipantViewCell *cell) {
                     [cell setVideoView:renderView];
-                    [cell setVideoDisabled:!self->_isAudioOnly];
+                    [cell setVideoDisabled:self->_isAudioOnly];
                 }];
             }
         } else if ([remotePeer.roomType isEqualToString:kRoomTypeScreen]) {

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1311,9 +1311,7 @@ typedef NS_ENUM(NSInteger, CallState) {
     NCPeerConnection *peerConnection = [_peersInCall objectAtIndex:indexPath.row];
     cell.peerId = peerConnection.peerId;
     cell.actionsDelegate = self;
-    
-    [self updateParticipantCell:cell withPeerConnection:peerConnection];
-    
+        
     return cell;
 }
 

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1418,12 +1418,20 @@ typedef NS_ENUM(NSInteger, CallState) {
         if ([remotePeer.roomType isEqualToString:kRoomTypeVideo]) {
             [self->_videoRenderersDict setObject:renderView forKey:remotePeer.peerId];
             NSIndexPath *indexPath = [self indexPathForPeerId:remotePeer.peerId];
+
             if (!indexPath) {
+                // This is a new peer, add it to the collection view
+                
                 [self->_peersInCall addObject:remotePeer];
                 NSIndexPath *insertionIndexPath = [NSIndexPath indexPathForRow:self->_peersInCall.count - 1 inSection:0];
                 [self.collectionView insertItemsAtIndexPaths:@[insertionIndexPath]];
             } else {
-                [self.collectionView reloadItemsAtIndexPaths:@[indexPath]];
+                // This peer already exists in the collection view, so we can just update its cell
+
+                [self updatePeer:remotePeer block:^(CallParticipantViewCell *cell) {
+                    [cell setVideoView:renderView];
+                    [cell setVideoDisabled:!self->_isAudioOnly];
+                }];
             }
         } else if ([remotePeer.roomType isEqualToString:kRoomTypeScreen]) {
             [self->_screenRenderersDict setObject:renderView forKey:remotePeer.peerId];

--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -684,7 +684,8 @@ static NSString * const kNCVideoTrackKind = @"video";
 
 - (void)externalSignalingController:(NCExternalSignalingController *)externalSignalingController didReceivedSignalingMessage:(NSDictionary *)signalingMessageDict
 {
-    NSLog(@"External signaling message received: %@", signalingMessageDict);
+    //NSLog(@"External signaling message received: %@", signalingMessageDict);
+    
     NCSignalingMessage *signalingMessage = [NCSignalingMessage messageFromExternalSignalingJSONDictionary:signalingMessageDict];
     [self checkIfPendingOffer:signalingMessage];
     [self processSignalingMessage:signalingMessage];
@@ -692,7 +693,7 @@ static NSString * const kNCVideoTrackKind = @"video";
 
 - (void)externalSignalingController:(NCExternalSignalingController *)externalSignalingController didReceivedParticipantListMessage:(NSDictionary *)participantListMessageDict
 {
-    NSLog(@"External participants message received: %@", participantListMessageDict);
+    //NSLog(@"External participants message received: %@", participantListMessageDict);
     
     NSArray *usersInRoom = [participantListMessageDict objectForKey:@"users"];
     
@@ -954,7 +955,7 @@ static NSString * const kNCVideoTrackKind = @"video";
             [sessions addObject:sessionId];
         }
     }
-    NSLog(@"InCall sessions: %@", sessions);
+    //NSLog(@"InCall sessions: %@", sessions);
     return sessions;
 }
 

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -503,7 +503,7 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
 {
     NSString *eventType = [eventDict objectForKey:@"type"];
     if ([eventType isEqualToString:@"update"]) {
-        NSLog(@"Participant list changed: %@", [eventDict objectForKey:@"update"]);
+        //NSLog(@"Participant list changed: %@", [eventDict objectForKey:@"update"]);
         [self.delegate externalSignalingController:self didReceivedParticipantListMessage:[eventDict objectForKey:@"update"]];
     } else {
         NSLog(@"Unknown room event: %@", eventDict);
@@ -512,7 +512,7 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
 
 - (void)messageReceived:(NSDictionary *)messageDict
 {
-    NSLog(@"Message received");
+    //NSLog(@"Message received");
     [self.delegate externalSignalingController:self didReceivedSignalingMessage:messageDict];
 }
 
@@ -600,7 +600,7 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
                 messageString = [[NSString alloc] initWithData:messageData encoding:NSUTF8StringEncoding];
             }
 
-            NSLog(@"WebSocket didReceiveMessage: %@", messageString);
+            //NSLog(@"WebSocket didReceiveMessage: %@", messageString);
             NSDictionary *messageDict = [weakSelf getWebSocketMessageFromJSONData:messageData];
             NSString *messageType = [messageDict objectForKey:@"type"];
             if ([messageType isEqualToString:@"hello"]) {

--- a/NextcloudTalk/NCPeerConnection.m
+++ b/NextcloudTalk/NCPeerConnection.m
@@ -404,7 +404,8 @@
     }
     
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSLog(@"Did create local session description of type %@ for peer %@", [RTCSessionDescription stringForType:sdp.type], self->_peerId);
+        //NSLog(@"Did create local session description of type %@ for peer %@", [RTCSessionDescription stringForType:sdp.type], self->_peerId);
+
         // Set H264 as preferred codec.
         RTCSessionDescription *sdpPreferringCodec = [ARDSDPUtils descriptionForDescription:sdp preferredVideoCodec:@"H264"];
         __weak NCPeerConnection *weakSelf = self;
@@ -429,10 +430,12 @@
     }
     
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSLog(@"Did set remote session description of type %@ for peer %@", [RTCSessionDescription stringForType:sessionDescription.type], self->_peerId);
+        //NSLog(@"Did set remote session description of type %@ for peer %@", [RTCSessionDescription stringForType:sessionDescription.type], self->_peerId);
+
         // If we just set a remote offer we need to create an answer and set it as local description.
         if (self->_peerConnection.signalingState == RTCSignalingStateHaveRemoteOffer) {
-            NSLog(@"Creating answer for peer %@", self->_peerId);
+            //NSLog(@"Creating answer for peer %@", self->_peerId);
+            
             //Create data channel before sending answer
             RTCDataChannelConfiguration* config = [[RTCDataChannelConfiguration alloc] init];
             config.isNegotiated = NO;

--- a/NextcloudTalk/WSMessage.m
+++ b/NextcloudTalk/WSMessage.m
@@ -137,7 +137,7 @@ static NSTimeInterval kSendMessageTimeoutInterval = 15;
         [self setMessageTimeout];
     }
 
-    NSLog(@"Sending: %@", self.webSocketMessage);
+    //NSLog(@"Sending: %@", self.webSocketMessage);
     NSURLSessionWebSocketMessage *message = [[NSURLSessionWebSocketMessage alloc] initWithString:self.webSocketMessage];
     [webSocketTask sendMessage:message completionHandler:^(NSError * _Nullable error) {
         if (error && self.completionBlock) {


### PR DESCRIPTION
This PR does the following
* Decrease the amount of logs. Until we have a better solution to select the log level, we shouldn't just log everything.
* Don't update the participant cell already at `cellForItemAtIndexPath` as `willDisplayCell` will be called directly after this, no need to do it twice
* If a video stream is added for a participant, don't reload the whole cell, just add the renderer to the cell.