### PR TITLE
Do not create publisher peer connection when no media is going to be sent

### DIFF
--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -610,7 +610,10 @@ static NSString * const kNCVideoTrackKind = @"video";
 - (void)createPublisherPeerConnection
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (self->_publisherPeerConnection) {return;}
+        if (self->_publisherPeerConnection || (!self->_localAudioTrack && !self->_localVideoTrack)) {
+            NSLog(@"Not creating publisher peer connection. Already created or no local media.");
+            return;
+        }
         
         NSLog(@"Creating publisher peer connection with sessionId: %@", [self signalingSessionId]);
         


### PR DESCRIPTION
Fixes problem connecting to the call without neither audio nor video publishing permissions.