### PR TITLE
Resize avatarImage according to height of NCChatTitleView

### DIFF
--- a/NextcloudTalk/CallViewController.xib
+++ b/NextcloudTalk/CallViewController.xib
@@ -162,10 +162,10 @@
                             </subviews>
                         </stackView>
                         <view contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="NY0-IT-mMr" userLabel="TitleView" customClass="NCChatTitleView">
-                            <rect key="frame" x="8" y="69" width="0.0" height="44"/>
+                            <rect key="frame" x="8" y="67" width="0.0" height="48"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="44" id="TeG-Qy-adB"/>
+                                <constraint firstAttribute="height" constant="48" id="TeG-Qy-adB"/>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" id="eXn-Ro-wDA"/>
                             </constraints>
                         </view>

--- a/NextcloudTalk/NCChatTitleView.m
+++ b/NextcloudTalk/NCChatTitleView.m
@@ -83,6 +83,12 @@
     [self setTitle:@"" withSubtitle:nil];
 }
 
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    self.avatarimage.layer.cornerRadius = self.avatarimage.bounds.size.width / 2;
+}
+
 - (void)updateForRoom:(NCRoom *)room
 {
     // Set room image

--- a/NextcloudTalk/NCChatTitleView.xib
+++ b/NextcloudTalk/NCChatTitleView.xib
@@ -21,17 +21,18 @@
             <rect key="frame" x="0.0" y="0.0" width="290" height="44"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="IxN-fr-8tD" userLabel="AvatarImageView">
+                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="IxN-fr-8tD" userLabel="AvatarImageView">
                     <rect key="frame" x="0.0" y="7" width="30" height="30"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="30" id="AV4-n4-Bp3"/>
-                        <constraint firstAttribute="width" constant="30" id="p6J-hG-Tuw"/>
+                        <constraint firstAttribute="width" secondItem="IxN-fr-8tD" secondAttribute="height" multiplier="1:1" id="JYW-6K-xTq"/>
                     </constraints>
                 </imageView>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6PH-NC-M0F" userLabel="UserStatusImageView">
                     <rect key="frame" x="22" y="29" width="12" height="12"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="12" id="7he-r6-ppR"/>
+                        <constraint firstAttribute="width" secondItem="6PH-NC-M0F" secondAttribute="height" multiplier="1:1" id="Dmi-zu-h9S"/>
+                        <constraint firstItem="IxN-fr-8tD" firstAttribute="height" secondItem="6PH-NC-M0F" secondAttribute="width" multiplier="2.5" id="MFf-tf-BOP"/>
                         <constraint firstAttribute="height" constant="12" id="qvI-6m-Hy5"/>
                     </constraints>
                 </imageView>
@@ -55,7 +56,8 @@
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <constraints>
-                <constraint firstItem="6PH-NC-M0F" firstAttribute="leading" secondItem="IxN-fr-8tD" secondAttribute="leading" constant="22" id="Bbu-wt-u4J"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="IxN-fr-8tD" secondAttribute="bottom" constant="7" id="1Ih-4p-ulE"/>
+                <constraint firstItem="6PH-NC-M0F" firstAttribute="trailing" secondItem="IxN-fr-8tD" secondAttribute="trailing" constant="4" id="Bbu-wt-u4J"/>
                 <constraint firstItem="I8S-E1-SNm" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="Nu8-OF-w5n"/>
                 <constraint firstItem="I8S-E1-SNm" firstAttribute="leading" secondItem="IxN-fr-8tD" secondAttribute="trailing" constant="10" id="RzK-wZ-yG9"/>
                 <constraint firstItem="IxN-fr-8tD" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="V8v-Q7-D6r"/>
@@ -63,6 +65,7 @@
                 <constraint firstItem="6PH-NC-M0F" firstAttribute="top" secondItem="IxN-fr-8tD" secondAttribute="top" constant="22" id="mVF-Yo-XXC"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="I8S-E1-SNm" secondAttribute="trailing" id="tGw-MV-n1a"/>
                 <constraint firstItem="I8S-E1-SNm" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="xX6-0N-eyd"/>
+                <constraint firstItem="IxN-fr-8tD" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="7" id="yax-W8-R8c"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="-83.200000000000003" y="-265.36731634182911"/>

--- a/NextcloudTalk/NCChatTitleView.xib
+++ b/NextcloudTalk/NCChatTitleView.xib
@@ -21,7 +21,7 @@
             <rect key="frame" x="0.0" y="0.0" width="290" height="44"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="IxN-fr-8tD" userLabel="AvatarImageView">
+                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="IxN-fr-8tD" userLabel="AvatarImageView">
                     <rect key="frame" x="0.0" y="7" width="30" height="30"/>
                     <constraints>
                         <constraint firstAttribute="width" secondItem="IxN-fr-8tD" secondAttribute="height" multiplier="1:1" id="JYW-6K-xTq"/>
@@ -30,10 +30,10 @@
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6PH-NC-M0F" userLabel="UserStatusImageView">
                     <rect key="frame" x="22" y="29" width="12" height="12"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="12" id="7he-r6-ppR"/>
+                        <constraint firstAttribute="width" priority="750" constant="12" id="7he-r6-ppR"/>
                         <constraint firstAttribute="width" secondItem="6PH-NC-M0F" secondAttribute="height" multiplier="1:1" id="Dmi-zu-h9S"/>
                         <constraint firstItem="IxN-fr-8tD" firstAttribute="height" secondItem="6PH-NC-M0F" secondAttribute="width" multiplier="2.5" id="MFf-tf-BOP"/>
-                        <constraint firstAttribute="height" constant="12" id="qvI-6m-Hy5"/>
+                        <constraint firstAttribute="height" priority="750" constant="12" id="qvI-6m-Hy5"/>
                     </constraints>
                 </imageView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="tailTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="I8S-E1-SNm" userLabel="TitleButton">
@@ -56,16 +56,21 @@
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <constraints>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="IxN-fr-8tD" secondAttribute="bottom" constant="7" id="1Ih-4p-ulE"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="IxN-fr-8tD" secondAttribute="bottom" constant="7" id="1Ih-4p-ulE">
+                    <variation key="heightClass=compact" constant="0.0"/>
+                </constraint>
                 <constraint firstItem="6PH-NC-M0F" firstAttribute="trailing" secondItem="IxN-fr-8tD" secondAttribute="trailing" constant="4" id="Bbu-wt-u4J"/>
                 <constraint firstItem="I8S-E1-SNm" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="Nu8-OF-w5n"/>
                 <constraint firstItem="I8S-E1-SNm" firstAttribute="leading" secondItem="IxN-fr-8tD" secondAttribute="trailing" constant="10" id="RzK-wZ-yG9"/>
                 <constraint firstItem="IxN-fr-8tD" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="V8v-Q7-D6r"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="6PH-NC-M0F" secondAttribute="bottom" id="bSL-rZ-FxA"/>
                 <constraint firstItem="IxN-fr-8tD" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="bfS-1h-ijV"/>
-                <constraint firstItem="6PH-NC-M0F" firstAttribute="top" secondItem="IxN-fr-8tD" secondAttribute="top" constant="22" id="mVF-Yo-XXC"/>
+                <constraint firstItem="6PH-NC-M0F" firstAttribute="top" secondItem="IxN-fr-8tD" secondAttribute="top" priority="750" constant="22" id="mVF-Yo-XXC"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="I8S-E1-SNm" secondAttribute="trailing" id="tGw-MV-n1a"/>
                 <constraint firstItem="I8S-E1-SNm" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="xX6-0N-eyd"/>
-                <constraint firstItem="IxN-fr-8tD" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="7" id="yax-W8-R8c"/>
+                <constraint firstItem="IxN-fr-8tD" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="7" id="yax-W8-R8c">
+                    <variation key="heightClass=compact" constant="0.0"/>
+                </constraint>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="-83.200000000000003" y="-265.36731634182911"/>


### PR DESCRIPTION
* Make sure the avatar is always round
* Constraint the height/width of the avatar view to the chat title view height
* Constraint the position of the status image to the trailing edge of the avatar view
* Keep the same aspect ratio between status image and avatar image