### PR TITLE
Set timeout for sendChatMessage to 25s

### DIFF
--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -1245,6 +1245,12 @@ NSInteger const kReceivedChatMessagesLimit = 100;
         [self initSessionManagers];
         apiSessionManager = [_apiSessionManagers objectForKey:account.accountId];
     }
+
+    // In case a request times out, we need to make sure the completionblock is called so the message
+    // is marked as an offline message. As we can run max. 30s in the background, we need to lower the
+    // default timeout from 60s to something < 30s.
+    [apiSessionManager.requestSerializer setTimeoutInterval:25];
+
     NSURLSessionDataTask *task = [apiSessionManager POST:URLString parameters:parameters progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         if (block) {
             block(nil);


### PR DESCRIPTION
The default timeout is set to 60s. When we send a chat message, we start a background task so that the sending process is not interrupted when moving the app to the background. Background tasks on iOS can only live for max. 30s. Therefore it can happen, that the app gets killed by the OS, but the request did not time out before that, therefore not marking the message as an offline message.
To resolve this issue we lower the timeout for the sendChatMessage method to 25s. 

To prevent the app from getting killed by the OS it makes sense to do this for all background tasks backed calls in the future (push proxy subscription for example).