### PR TITLE
Improve calculation of grid columns/rows

### DIFF
--- a/NextcloudTalk/CallFlowLayout.swift
+++ b/NextcloudTalk/CallFlowLayout.swift
@@ -26,13 +26,24 @@ import UIKit
 @objcMembers
 class CallFlowLayout: UICollectionViewFlowLayout {
 
+    private let targetAspectRatioPortrait = 1.0
+    private let targetAspectRatioLandscape = 1.5
+
+    private var numberOfColumns = 1
+    private var numberOfRows = 1
+    private var targetAspectRatio: Double
+
     override init() {
+        self.targetAspectRatio = self.targetAspectRatioLandscape
+
         super.init()
 
         commonInit()
     }
 
     required init?(coder aDecoder: NSCoder) {
+        self.targetAspectRatio = self.targetAspectRatioLandscape
+
         super.init(coder: aDecoder)
 
         commonInit()
@@ -50,26 +61,121 @@ class CallFlowLayout: UICollectionViewFlowLayout {
         return collectionView.bounds.size.width < collectionView.bounds.size.height
     }
 
-    func numberOfColumns(for numberOfCells: Int) -> Int {
-        if isPortrait() {
-            if numberOfCells <= 2 {
-                return 1
-            } else if numberOfCells <= 6 {
-                return 2
+    func columnsMax() -> Int {
+        guard let collectionView = collectionView else { return 1 }
+
+        let contentSize = collectionView.bounds.size
+
+        if (contentSize.width / kCallParticipantCellMinWidth).rounded(.down) < 1 {
+            return 1
+        }
+
+        return Int((contentSize.width / kCallParticipantCellMinWidth).rounded(.down))
+    }
+
+    func rowsMax() -> Int {
+        guard let collectionView = collectionView else { return 1 }
+
+        let contentSize = collectionView.bounds.size
+
+        if (contentSize.height / kCallParticipantCellMinHeight).rounded(.down) < 1 {
+            return 1
+        }
+
+        return Int((contentSize.height / kCallParticipantCellMinHeight).rounded(.down))
+    }
+
+    // Based on the makeGrid method of web:
+    // https://github.com/nextcloud/spreed/blob/5ba554c3f751ba8b8035c7fc8404ca6194d3c16a/src/components/CallView/Grid/Grid.vue#L664
+    func makeGrid() {
+        guard let collectionView = collectionView else { return }
+
+        let numberOfCells = collectionView.numberOfItems(inSection: 0)
+
+        if numberOfCells == 0 {
+            self.numberOfColumns = 0
+            self.numberOfRows = 0
+
+            return
+        }
+
+        if self.isPortrait() {
+            self.targetAspectRatio = self.targetAspectRatioPortrait
+        } else {
+            self.targetAspectRatio = self.targetAspectRatioLandscape
+        }
+
+        // Start with the maximum number of allowed columns/rows
+        self.numberOfColumns = self.columnsMax()
+        self.numberOfRows = self.rowsMax()
+
+        // Try to adjust the number of columns/rows based on the number of cells
+        self.shrinkGrid()
+    }
+
+    func shrinkGrid() {
+        if self.numberOfRows == 1, self.numberOfColumns == 1 {
+            return
+        }
+
+        guard let collectionView = collectionView else { return }
+        let contentSize = collectionView.bounds.size
+
+        var currentColumns = self.numberOfColumns
+        var currentRows = self.numberOfRows
+        var currentSlots = currentColumns * currentRows
+        let numberOfCells = collectionView.numberOfItems(inSection: 0)
+
+        while numberOfCells < currentSlots {
+            let previousColumns = currentColumns
+            let previousRows = currentRows
+
+            let videoWidth = contentSize.width / CGFloat(currentColumns)
+            let videoHeight = contentSize.height / CGFloat(currentRows)
+
+            let videoWidthWithOneColumnLess = contentSize.width / CGFloat(currentColumns - 1)
+            let videoHeightWithOneRowLess = contentSize.height / CGFloat(currentRows - 1)
+
+            let aspectRatioWithOneColumnLess = videoWidthWithOneColumnLess / videoHeight
+            let aspectRatioWithOneRowLess = videoWidth / videoHeightWithOneRowLess
+
+            let deltaAspectRatioWithOneColumnLess = abs(aspectRatioWithOneColumnLess - targetAspectRatio)
+            let deltaAspectRatioWithOneRowLess = abs(aspectRatioWithOneRowLess - targetAspectRatio)
+
+            // Based on the aspect ratio we want to achieve, try to either reduce the number of columns or rows
+            if deltaAspectRatioWithOneColumnLess <= deltaAspectRatioWithOneRowLess {
+                if currentColumns >= 2 {
+                    currentColumns -= 1
+                }
+
+                currentSlots = currentColumns * currentRows
+
+                if numberOfCells > currentSlots {
+                    currentColumns += 1
+
+                    break
+                }
+            } else {
+                if currentRows >= 2 {
+                    currentRows -= 1
+                }
+
+                currentSlots = currentColumns * currentRows
+
+                if numberOfCells > currentSlots {
+                    currentRows += 1
+
+                    break
+                }
             }
 
-            return 3
+            if previousColumns == currentColumns, previousRows == currentRows {
+                break
+            }
         }
 
-        if numberOfCells == 1 {
-            return 1
-        } else if numberOfCells <= 2 || numberOfCells == 4 {
-            return 2
-        } else if numberOfCells == 3 || numberOfCells == 5 {
-            return 3
-        }
-
-        return 4
+        self.numberOfColumns = currentColumns
+        self.numberOfRows = currentRows
     }
 
     override func prepare() {
@@ -78,9 +184,8 @@ class CallFlowLayout: UICollectionViewFlowLayout {
         guard let collectionView = collectionView else { return }
 
         let contentSize = collectionView.bounds.size
-        let numberOfCells = collectionView.numberOfItems(inSection: 0)
-        let numberOfColumns = numberOfColumns(for: numberOfCells)
-        let numberOfRows = (CGFloat(numberOfCells) / CGFloat(numberOfColumns)).rounded(.up)
+
+        self.makeGrid()
 
         // Calculate cell width
         let sectionInsetWidth = sectionInset.left + sectionInset.right

--- a/NextcloudTalk/CallParticipantViewCell.h
+++ b/NextcloudTalk/CallParticipantViewCell.h
@@ -26,6 +26,7 @@
 extern NSString *const kCallParticipantCellIdentifier;
 extern NSString *const kCallParticipantCellNibName;
 extern CGFloat const kCallParticipantCellMinHeight;
+extern CGFloat const kCallParticipantCellMinWidth;
 
 @class CallParticipantViewCell;
 @protocol CallParticipantViewCellDelegate <NSObject>

--- a/NextcloudTalk/CallParticipantViewCell.m
+++ b/NextcloudTalk/CallParticipantViewCell.m
@@ -35,6 +35,7 @@
 NSString *const kCallParticipantCellIdentifier = @"CallParticipantCellIdentifier";
 NSString *const kCallParticipantCellNibName = @"CallParticipantViewCell";
 CGFloat const kCallParticipantCellMinHeight = 128;
+CGFloat const kCallParticipantCellMinWidth = 192; // Aspect ratio of 1.5
 
 @interface CallParticipantViewCell()
 {


### PR DESCRIPTION
This is based on the `makeGrid` method used in the Web (https://github.com/nextcloud/spreed/blob/5ba554c3f751ba8b8035c7fc8404ca6194d3c16a/src/components/CallView/Grid/Grid.vue#L664) and calculates the number of columns / rows based on a target aspect ratio and number of participants.