### PR TITLE
Fix badge update after removing notifications

### DIFF
--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -271,6 +271,8 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
         for (UNNotificationRequest *notificationRequest in requests) {
             removeNotification(notificationRequest, YES);
         }
+
+        [self updateAppIconBadgeNumber];
     }];
 
     // Check in delivered notifications
@@ -278,9 +280,9 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
         for (UNNotification *notification in notifications) {
             removeNotification(notification.request, NO);
         }
+
+        [self updateAppIconBadgeNumber];
     }];
-    
-    [self updateAppIconBadgeNumber];
 }
 
 - (void)checkForNewNotificationsWithCompletionBlock:(CheckForNewNotificationsCompletionBlock)block


### PR DESCRIPTION
Since the notifications are removed in a completion block `updateAppIconBadgeNumber` is run before the notifications were actually removed. This PR makes sure to update the badge count after the notification deletion is done.