### PR TITLE
Dedicated DispatchQueue for WebRTC related methods

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -26,10 +26,6 @@
 #import "AFNetworkActivityIndicatorManager.h"
 
 #import <Intents/Intents.h>
-
-#import <WebRTC/RTCAudioSession.h>
-#import <WebRTC/RTCAudioSessionConfiguration.h>
-
 #import <UserNotifications/UserNotifications.h>
 
 #import <BackgroundTasks/BGTaskScheduler.h>
@@ -75,9 +71,11 @@
     pushRegistry = [[PKPushRegistry alloc] initWithQueue:dispatch_get_main_queue()];
     pushRegistry.delegate = self;
     pushRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
-    
-    NSLog(@"Configure Audio Session");
-    [NCAudioController sharedInstance];
+
+    [[WebRTCCommon shared] dispatch:^{
+        NSLog(@"Configure Audio Session");
+        [NCAudioController sharedInstance];
+    }];
     
     NSLog(@"Configure App Settings");
     [NCSettingsController sharedInstance];

--- a/NextcloudTalk/CallKitManager.m
+++ b/NextcloudTalk/CallKitManager.m
@@ -34,6 +34,8 @@
 #import "NCUserInterfaceController.h"
 #import "NCUtils.h"
 
+#import "NextcloudTalk-Swift.h"
+
 NSString * const CallKitManagerDidAnswerCallNotification        = @"CallKitManagerDidAnswerCallNotification";
 NSString * const CallKitManagerDidEndCallNotification           = @"CallKitManagerDidEndCallNotification";
 NSString * const CallKitManagerDidStartCallNotification         = @"CallKitManagerDidStartCallNotification";
@@ -585,13 +587,19 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
 - (void)provider:(CXProvider *)provider didActivateAudioSession:(AVAudioSession *)audioSession
 {
     NSLog(@"Provider:didActivateAudioSession - %@", audioSession);
-    [[NCAudioController sharedInstance] providerDidActivateAudioSession:audioSession];
+
+    [[WebRTCCommon shared] dispatch:^{
+        [[NCAudioController sharedInstance] providerDidActivateAudioSession:audioSession];
+    }];
 }
 
 - (void)provider:(CXProvider *)provider didDeactivateAudioSession:(nonnull AVAudioSession *)audioSession
 {
     NSLog(@"Provider:didDeactivateAudioSession - %@", audioSession);
-    [[NCAudioController sharedInstance] providerDidDeactivateAudioSession:audioSession];
+
+    [[WebRTCCommon shared] dispatch:^{
+        [[NCAudioController sharedInstance] providerDidDeactivateAudioSession:audioSession];
+    }];
 }
 
 

--- a/NextcloudTalk/NCAudioController.m
+++ b/NextcloudTalk/NCAudioController.m
@@ -24,6 +24,8 @@
 
 #import "CallKitManager.h"
 
+#import "NextcloudTalk-Swift.h"
+
 NSString * const AudioSessionDidChangeRouteNotification         = @"AudioSessionDidChangeRouteNotification";
 NSString * const AudioSessionWasActivatedByProviderNotification = @"AudioSessionWasActivatedByProviderNotification";
 
@@ -80,6 +82,8 @@ NSString * const AudioSessionWasActivatedByProviderNotification = @"AudioSession
 
 - (void)changeAudioSessionConfigurationModeTo:(NSString *)mode
 {
+    [[WebRTCCommon shared] assertQueue];
+
     RTCAudioSessionConfiguration *configuration = [RTCAudioSessionConfiguration webRTCConfiguration];
     configuration.category = AVAudioSessionCategoryPlayAndRecord;
     configuration.mode = mode;
@@ -87,6 +91,7 @@ NSString * const AudioSessionWasActivatedByProviderNotification = @"AudioSession
     [_rtcAudioSession lockForConfiguration];
     BOOL hasSucceeded = NO;
     NSError *error = nil;
+
     if (_rtcAudioSession.isActive) {
         hasSucceeded = [_rtcAudioSession setConfiguration:configuration error:&error];
     } else {
@@ -94,20 +99,27 @@ NSString * const AudioSessionWasActivatedByProviderNotification = @"AudioSession
                                           active:YES
                                            error:&error];
     }
+
     if (!hasSucceeded) {
         NSLog(@"Error setting configuration: %@", error.localizedDescription);
     }
+
     [_rtcAudioSession unlockForConfiguration];
 }
 
 - (void)disableAudioSession
 {
+    [[WebRTCCommon shared] assertQueue];
+
     [_rtcAudioSession lockForConfiguration];
+
     NSError *error = nil;
     BOOL hasSucceeded = [_rtcAudioSession setActive:NO error:&error];
+
     if (!hasSucceeded) {
         NSLog(@"Error setting configuration: %@", error.localizedDescription);
     }
+
     [_rtcAudioSession unlockForConfiguration];
 }
 
@@ -118,9 +130,11 @@ NSString * const AudioSessionWasActivatedByProviderNotification = @"AudioSession
 
 - (void)providerDidActivateAudioSession:(AVAudioSession *)audioSession
 {
+    [[WebRTCCommon shared] assertQueue];
+
     [_rtcAudioSession audioSessionDidActivate:audioSession];
     _rtcAudioSession.isAudioEnabled = YES;
-    
+
     [[NSNotificationCenter defaultCenter] postNotificationName:AudioSessionWasActivatedByProviderNotification
                                                         object:self
                                                       userInfo:nil];
@@ -128,6 +142,8 @@ NSString * const AudioSessionWasActivatedByProviderNotification = @"AudioSession
 
 - (void)providerDidDeactivateAudioSession:(AVAudioSession *)audioSession
 {
+    [[WebRTCCommon shared] assertQueue];
+
     [_rtcAudioSession audioSessionDidDeactivate:audioSession];
     _rtcAudioSession.isAudioEnabled = NO;
 }

--- a/NextcloudTalk/NCPeerConnection.h
+++ b/NextcloudTalk/NCPeerConnection.h
@@ -83,7 +83,6 @@
 - (void)sendDataChannelMessageOfType:(NSString *)type withPayload:(id)payload;
 - (void)setStatusForDataChannelMessageType:(NSString *)type withPayload:(id)payload;
 - (void)drainRemoteCandidates;
-- (void)removeRemoteCandidates;
 - (void)close;
 
 @end

--- a/NextcloudTalk/WebRTCCommon.swift
+++ b/NextcloudTalk/WebRTCCommon.swift
@@ -21,7 +21,7 @@
 
 import Foundation
 
-@objcMembers class WebRTCCommon: NSObject {
+@objcMembers final class WebRTCCommon: NSObject {
 
     public static let shared = WebRTCCommon()
 

--- a/NextcloudTalk/WebRTCCommon.swift
+++ b/NextcloudTalk/WebRTCCommon.swift
@@ -37,7 +37,7 @@ import Foundation
         return RTCDefaultVideoDecoderFactory()
     }()
 
-    public let webrtcClientDispatchQueue = DispatchQueue(label: "webrtcClientDispatchQueue")
+    private let webrtcClientDispatchQueue = DispatchQueue(label: "webrtcClientDispatchQueue")
 
     private override init() {
         super.init()


### PR DESCRIPTION
According to the WebRTC documentation at https://webrtc.googlesource.com/src/+/refs/heads/main/api/g3doc/threading_design.md there should be a single thread ("client thread") that does webrtc related calls into the library. Currently we did not care about what thread makes which calls into the library, most of the time it was just the main thread. This can lead to performance problems and sometimes even deadlocks on larger meetings.

This PR aims to introduce a single dispatch queue where everything webrtc related is done and can additionally used for processing (e.g. received signaling messages).
To not enter "dispatch everything"-land, some methods now have an assert added, to make sure they are called from the correct queue. This should help with any future development not thinking about this change.