### PR TITLE
Change the color of the cell when the display name changes

### DIFF
--- a/NextcloudTalk/CallParticipantViewCell.m
+++ b/NextcloudTalk/CallParticipantViewCell.m
@@ -132,6 +132,7 @@ CGFloat const kCallParticipantCellMinWidth = 192; // Aspect ratio of 1.5
 
     dispatch_async(dispatch_get_main_queue(), ^{
         self.peerNameLabel.text = self->_displayName;
+        [self setBackgroundColor:[[ColorGenerator shared] usernameToColor:self->_displayName]];
     });
 }
 


### PR DESCRIPTION
Background color of a cell is based on the display name, but it can happen, that it is not available when the cell is created. So when we receive the display name, we need to update the background color of the cell as well. (Same can be seen on web, when a guest changes it's name while being in a call, it's cell background is also updated)