### PR TITLE
Add notification when a call recording was started/stopped

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1715,6 +1715,14 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
 - (void)callControllerDidChangeRecording:(NCCallController *)callController
 {
     [self adjustTopBar];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->_room.callRecording) {
+            [[JDStatusBarNotificationPresenter sharedPresenter] presentWithText:NSLocalizedString(@"Call recording started", nil) dismissAfterDelay:7.0 includedStyle:JDStatusBarNotificationIncludedStyleDark];
+        } else {
+            [[JDStatusBarNotificationPresenter sharedPresenter] presentWithText:NSLocalizedString(@"Call recording stopped", nil) dismissAfterDelay:7.0 includedStyle:JDStatusBarNotificationIncludedStyleDark];
+        }
+    });
 }
 
 #pragma mark - Screensharing

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -248,6 +248,12 @@
 "Call options" = "Call options";
 
 /* No comment provided by engineer. */
+"Call recording started" = "Call recording started";
+
+/* No comment provided by engineer. */
+"Call recording stopped" = "Call recording stopped";
+
+/* No comment provided by engineer. */
 "Call without notification" = "Call without notification";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
Ref https://github.com/nextcloud/spreed/issues/8324#issuecomment-1344070936
Show a notification when a recording was started or stopped.