### PR TITLE
Callview layout finetuning

### DIFF
--- a/NextcloudTalk/CallParticipantViewCell.h
+++ b/NextcloudTalk/CallParticipantViewCell.h
@@ -52,6 +52,11 @@ extern CGFloat const kCallParticipantCellMinWidth;
 @property (nonatomic, weak) IBOutlet UIButton *audioOffIndicator;
 @property (nonatomic, weak) IBOutlet UIButton *screensharingIndicator;
 @property (nonatomic, weak) IBOutlet UIButton *raisedHandIndicator;
+@property (nonatomic, weak) IBOutlet NSLayoutConstraint *stackViewBottomConstraint;
+@property (nonatomic, weak) IBOutlet NSLayoutConstraint *stackViewLeftConstraint;
+@property (nonatomic, weak) IBOutlet NSLayoutConstraint *stackViewRightConstraint;
+@property (nonatomic, weak) IBOutlet NSLayoutConstraint *screensharingIndiciatorRightConstraint;
+@property (nonatomic, weak) IBOutlet NSLayoutConstraint *screensharingIndiciatorTopConstraint;
 
 
 - (void)setVideoView:(RTCMTLVideoView *)videoView;

--- a/NextcloudTalk/CallParticipantViewCell.m
+++ b/NextcloudTalk/CallParticipantViewCell.m
@@ -65,7 +65,7 @@ CGFloat const kCallParticipantCellMinWidth = 192; // Aspect ratio of 1.5
     self.peerAvatarImageView.layer.cornerRadius = 50;
     self.peerAvatarImageView.layer.masksToBounds = YES;
 
-    self.layer.cornerRadius = 30.0f;
+    self.layer.cornerRadius = 22.0f;
     [self.layer setMasksToBounds:YES];
     
     _showOriginalSize = NO;

--- a/NextcloudTalk/CallParticipantViewCell.m
+++ b/NextcloudTalk/CallParticipantViewCell.m
@@ -62,7 +62,7 @@ CGFloat const kCallParticipantCellMinWidth = 192; // Aspect ratio of 1.5
     self.screensharingIndicator.clipsToBounds = YES;
     
     self.peerAvatarImageView.hidden = YES;
-    self.peerAvatarImageView.layer.cornerRadius = 50;
+    self.peerAvatarImageView.layer.cornerRadius = self.peerAvatarImageView.bounds.size.width / 2;
     self.peerAvatarImageView.layer.masksToBounds = YES;
 
     self.layer.cornerRadius = 22.0f;
@@ -91,6 +91,33 @@ CGFloat const kCallParticipantCellMinWidth = 192; // Aspect ratio of 1.5
     [super applyLayoutAttributes:layoutAttributes];
     
     [self resizeRemoteVideoView];
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+
+    CGRect bounds = self.bounds;
+
+    // Usually we have a padding to the side of the cell of 22 (= cornerRadius)
+    // But when the cell is really small adjust the padding to be 11 (= cornerRadius / 2)
+    if (bounds.size.width <= 200 || bounds.size.height <= 200) {
+        self.stackViewLeftConstraint.constant = 11;
+        self.stackViewRightConstraint.constant = 11;
+        self.stackViewBottomConstraint.constant = 11;
+        self.screensharingIndiciatorTopConstraint.constant = 11;
+        self.screensharingIndiciatorRightConstraint.constant = 11;
+    } else {
+        self.stackViewLeftConstraint.constant = 22;
+        self.stackViewRightConstraint.constant = 22;
+        self.stackViewBottomConstraint.constant = 22;
+        self.screensharingIndiciatorTopConstraint.constant = 22;
+        self.screensharingIndiciatorRightConstraint.constant = 22;
+    }
+
+    [self.contentView layoutSubviews];
+
+    self.peerAvatarImageView.layer.cornerRadius = self.peerAvatarImageView.bounds.size.width / 2;
 }
 
 - (void)toggleZoom

--- a/NextcloudTalk/CallParticipantViewCell.xib
+++ b/NextcloudTalk/CallParticipantViewCell.xib
@@ -10,43 +10,40 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="" id="gTV-IL-0wX" customClass="CallParticipantViewCell">
-            <rect key="frame" x="0.0" y="0.0" width="295" height="230"/>
+            <rect key="frame" x="0.0" y="0.0" width="295" height="232"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="295" height="230"/>
+                <rect key="frame" x="0.0" y="0.0" width="295" height="232"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2xo-Od-0bZ">
-                        <rect key="frame" x="0.0" y="0.0" width="295" height="230"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bj2-hS-1pF">
-                                <rect key="frame" x="132" y="12" width="32" height="32"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="32" id="7vp-Kk-0hF"/>
-                                    <constraint firstAttribute="width" constant="32" id="Z5s-i5-hgP"/>
-                                </constraints>
-                                <state key="normal" image="screensharing"/>
-                                <connections>
-                                    <action selector="screenSharingButtonPressed:" destination="gTV-IL-0wX" eventType="touchUpInside" id="DzG-u7-nPx"/>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <constraints>
-                            <constraint firstItem="bj2-hS-1pF" firstAttribute="top" secondItem="2xo-Od-0bZ" secondAttribute="top" constant="12" id="0cN-yQ-l1p"/>
-                            <constraint firstItem="bj2-hS-1pF" firstAttribute="centerX" secondItem="2xo-Od-0bZ" secondAttribute="centerX" id="8nf-Dz-VmE"/>
-                            <constraint firstItem="bj2-hS-1pF" firstAttribute="top" secondItem="2xo-Od-0bZ" secondAttribute="top" constant="12" id="jii-H6-grR"/>
-                        </constraints>
+                        <rect key="frame" x="0.0" y="0.0" width="295" height="232"/>
                     </view>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zYx-Of-3tH">
-                        <rect key="frame" x="98" y="65" width="100" height="100"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zYx-Of-3tH">
+                        <rect key="frame" x="97.5" y="66" width="100" height="100"/>
+                        <constraints>
+                            <constraint firstAttribute="width" secondItem="zYx-Of-3tH" secondAttribute="height" multiplier="1:1" id="8TD-LX-PDg"/>
+                            <constraint firstAttribute="width" priority="750" constant="100" id="E1w-Vk-9vO"/>
+                            <constraint firstAttribute="height" priority="750" constant="100" id="hFb-Kv-gry"/>
+                        </constraints>
                     </imageView>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="top" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bj2-hS-1pF">
+                        <rect key="frame" x="241" y="22" width="32" height="32"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="32" id="7vp-Kk-0hF"/>
+                            <constraint firstAttribute="width" constant="32" id="Z5s-i5-hgP"/>
+                        </constraints>
+                        <state key="normal" image="screensharing"/>
+                        <connections>
+                            <action selector="screenSharingButtonPressed:" destination="gTV-IL-0wX" eventType="touchUpInside" id="DzG-u7-nPx"/>
+                        </connections>
+                    </button>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Tog-ZY-cO4">
-                        <rect key="frame" x="12" y="174" width="271" height="44"/>
+                        <rect key="frame" x="22" y="186" width="251" height="24"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BPo-EN-rrM" userLabel="Raised Hand Indicator">
-                                <rect key="frame" x="0.0" y="0.0" width="24" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <size key="titleShadowOffset" width="1" height="1"/>
@@ -54,19 +51,23 @@
                                     <color key="titleShadowColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="248" verticalHuggingPriority="251" text="ghj" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D5h-T2-aB9">
-                                <rect key="frame" x="36" y="0.0" width="199" height="44"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="O0z-z2-KdL"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                                <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.74765580537303389" colorSpace="custom" customColorSpace="sRGB"/>
-                                <size key="shadowOffset" width="1" height="1"/>
-                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Duj-37-SmJ" userLabel="Peer Name Label Container">
+                                <rect key="frame" x="36" y="0.0" width="179" height="24"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="248" verticalHuggingPriority="251" fixedFrame="YES" text="ghj" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D5h-T2-aB9">
+                                        <rect key="frame" x="0.0" y="6" width="179" height="18"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                        <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.74765580537303389" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <size key="shadowOffset" width="1" height="1"/>
+                                    </label>
+                                </subviews>
+                                <edgeInsets key="layoutMargins" top="12" left="8" bottom="2" right="8"/>
+                            </view>
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vlO-GV-Y3B">
-                                <rect key="frame" x="247" y="0.0" width="24" height="44"/>
+                                <rect key="frame" x="227" y="0.0" width="24" height="24"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <size key="titleShadowOffset" width="1" height="1"/>
                                 <state key="normal" image="audio-off">
@@ -75,22 +76,31 @@
                             </button>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="height" constant="44" id="eyv-6K-4Fu"/>
+                            <constraint firstAttribute="height" constant="24" id="eyv-6K-4Fu"/>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" id="tc0-yY-uLq"/>
                         </constraints>
                     </stackView>
                 </subviews>
             </view>
             <constraints>
+                <constraint firstAttribute="trailing" secondItem="bj2-hS-1pF" secondAttribute="trailing" constant="22" id="0vQ-dJ-Ozc"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="zYx-Of-3tH" secondAttribute="bottom" constant="22" id="25D-wO-Pd3"/>
                 <constraint firstAttribute="bottom" secondItem="2xo-Od-0bZ" secondAttribute="bottom" id="6BS-bd-V7e"/>
                 <constraint firstItem="2xo-Od-0bZ" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="7ax-NA-Mp7"/>
+                <constraint firstItem="zYx-Of-3tH" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="22" id="Cpi-Oj-lKf"/>
+                <constraint firstItem="zYx-Of-3tH" firstAttribute="centerY" secondItem="gTV-IL-0wX" secondAttribute="centerY" id="Ejn-6A-Tbm"/>
                 <constraint firstItem="2xo-Od-0bZ" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="KOw-nZ-G8t"/>
-                <constraint firstItem="Tog-ZY-cO4" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="12" id="RH0-ZW-O57"/>
-                <constraint firstAttribute="bottom" secondItem="Tog-ZY-cO4" secondAttribute="bottom" constant="12" id="UXP-Gm-lYX"/>
+                <constraint firstItem="Tog-ZY-cO4" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="22" id="RH0-ZW-O57"/>
+                <constraint firstAttribute="bottom" secondItem="Tog-ZY-cO4" secondAttribute="bottom" constant="22" id="UXP-Gm-lYX"/>
+                <constraint firstItem="bj2-hS-1pF" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="22" id="f5w-bM-AbI"/>
+                <constraint firstItem="zYx-Of-3tH" firstAttribute="centerX" secondItem="gTV-IL-0wX" secondAttribute="centerX" id="fL4-Jy-Q1U"/>
                 <constraint firstAttribute="trailing" secondItem="2xo-Od-0bZ" secondAttribute="trailing" id="gTd-Es-Nku"/>
-                <constraint firstAttribute="trailing" secondItem="Tog-ZY-cO4" secondAttribute="trailing" constant="12" id="k7o-jB-7o3"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="zYx-Of-3tH" secondAttribute="trailing" constant="22" id="h85-nY-ag4"/>
+                <constraint firstAttribute="trailing" secondItem="Tog-ZY-cO4" secondAttribute="trailing" constant="22" id="k7o-jB-7o3"/>
+                <constraint firstItem="Tog-ZY-cO4" firstAttribute="top" relation="greaterThanOrEqual" secondItem="zYx-Of-3tH" secondAttribute="bottom" constant="-2" id="rpk-9a-BBU"/>
+                <constraint firstItem="zYx-Of-3tH" firstAttribute="top" relation="greaterThanOrEqual" secondItem="gTV-IL-0wX" secondAttribute="top" constant="22" id="wL8-E7-J74"/>
             </constraints>
-            <size key="customSize" width="295" height="200"/>
+            <size key="customSize" width="295" height="202"/>
             <connections>
                 <outlet property="audioOffIndicator" destination="vlO-GV-Y3B" id="cIm-dZ-peB"/>
                 <outlet property="peerAvatarImageView" destination="zYx-Of-3tH" id="fkR-av-PMY"/>
@@ -98,8 +108,13 @@
                 <outlet property="peerVideoView" destination="2xo-Od-0bZ" id="YvZ-QP-fUW"/>
                 <outlet property="raisedHandIndicator" destination="BPo-EN-rrM" id="Dwq-96-Waf"/>
                 <outlet property="screensharingIndicator" destination="bj2-hS-1pF" id="VFt-FC-Oum"/>
+                <outlet property="screensharingIndiciatorRightConstraint" destination="0vQ-dJ-Ozc" id="kx1-q2-1Sk"/>
+                <outlet property="screensharingIndiciatorTopConstraint" destination="f5w-bM-AbI" id="d5y-18-ICg"/>
+                <outlet property="stackViewBottomConstraint" destination="UXP-Gm-lYX" id="UJp-3p-DeZ"/>
+                <outlet property="stackViewLeftConstraint" destination="RH0-ZW-O57" id="sks-d4-NES"/>
+                <outlet property="stackViewRightConstraint" destination="k7o-jB-7o3" id="17X-EJ-Ekm"/>
             </connections>
-            <point key="canvasLocation" x="34.399999999999999" y="128.63568215892056"/>
+            <point key="canvasLocation" x="32.799999999999997" y="133.13343328335833"/>
         </collectionViewCell>
     </objects>
     <resources>

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -192,11 +192,11 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
     [self.hangUpButton.layer setCornerRadius:self.hangUpButton.frame.size.height / 2];
     [self.closeScreensharingButton.layer setCornerRadius:16.0f];
 
-    [self.collectionView.layer setCornerRadius:30.0f];
+    [self.collectionView.layer setCornerRadius:22.0f];
     [self.collectionView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentAlways];
 
     [self.sideBarView setClipsToBounds:YES];
-    [self.sideBarView.layer setCornerRadius:30.0f];
+    [self.sideBarView.layer setCornerRadius:22.0f];
 
     _airplayView = [[AVRoutePickerView alloc] initWithFrame:CGRectMake(0, 0, 48, 56)];
     _airplayView.tintColor = [UIColor whiteColor];

--- a/NextcloudTalk/CallViewController.xib
+++ b/NextcloudTalk/CallViewController.xib
@@ -222,7 +222,7 @@
                     <rect key="frame" x="0.0" y="88" width="1024" height="1258"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N0N-Ny-Aeg" userLabel="CloseScreenshareView">
-                            <rect key="frame" x="976" y="16" width="32" height="32"/>
+                            <rect key="frame" x="980" y="12" width="32" height="32"/>
                             <color key="backgroundColor" white="0.5" alpha="0.95060911873318499" colorSpace="calibratedWhite"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="32" id="uMi-V0-B3H"/>
@@ -237,8 +237,8 @@
                     <viewLayoutGuide key="safeArea" id="j53-tu-e0T"/>
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstItem="j53-tu-e0T" firstAttribute="trailing" secondItem="N0N-Ny-Aeg" secondAttribute="trailing" constant="16" id="Pxi-mX-3dC"/>
-                        <constraint firstItem="N0N-Ny-Aeg" firstAttribute="top" secondItem="j53-tu-e0T" secondAttribute="top" constant="16" id="pDR-Pt-2K8"/>
+                        <constraint firstItem="j53-tu-e0T" firstAttribute="trailing" secondItem="N0N-Ny-Aeg" secondAttribute="trailing" constant="12" id="Pxi-mX-3dC"/>
+                        <constraint firstItem="N0N-Ny-Aeg" firstAttribute="top" secondItem="j53-tu-e0T" secondAttribute="top" constant="12" id="pDR-Pt-2K8"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TXj-7E-NAa" userLabel="LocalVideo" customClass="RTCCameraPreviewView">
@@ -270,7 +270,7 @@
                 <constraint firstItem="reh-cY-1Qv" firstAttribute="leading" secondItem="bbs-K4-b33" secondAttribute="leading" id="AhA-F1-rqp"/>
                 <constraint firstItem="fSY-ZT-xIC" firstAttribute="top" secondItem="bbs-K4-b33" secondAttribute="top" constant="8" id="ENd-Oe-5YE"/>
                 <constraint firstItem="aUh-Z0-hO6" firstAttribute="top" secondItem="reh-cY-1Qv" secondAttribute="bottom" id="GtW-pl-edb"/>
-                <constraint firstItem="Zzc-Pq-hMC" firstAttribute="trailing" secondItem="bbs-K4-b33" secondAttribute="trailing" id="IS9-3G-cQz"/>
+                <constraint firstItem="bbs-K4-b33" firstAttribute="trailing" secondItem="Zzc-Pq-hMC" secondAttribute="trailing" id="IS9-3G-cQz"/>
                 <constraint firstItem="bbs-K4-b33" firstAttribute="trailing" secondItem="aUh-Z0-hO6" secondAttribute="trailing" constant="-14" id="MON-Nu-TFX"/>
                 <constraint firstItem="Zzc-Pq-hMC" firstAttribute="top" secondItem="reh-cY-1Qv" secondAttribute="bottom" id="SEj-Nc-c8l"/>
                 <constraint firstItem="bbs-K4-b33" firstAttribute="bottom" secondItem="aUh-Z0-hO6" secondAttribute="bottom" id="TOU-Pk-3pi"/>

--- a/NextcloudTalk/CallViewController.xib
+++ b/NextcloudTalk/CallViewController.xib
@@ -57,6 +57,7 @@
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="aZ2-oa-X4M"/>
                             </constraints>
+                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                             <color key="tintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <inset key="contentEdgeInsets" minX="16" minY="0.0" maxX="8" maxY="0.0"/>
                             <inset key="imageEdgeInsets" minX="-8" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -294,7 +295,7 @@
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Waiting for others to the call..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="ihe-9I-8ts">
                     <rect key="frame" x="44" y="32" width="936" height="42"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>
                 </label>

--- a/NextcloudTalk/NCChatTitleView.xib
+++ b/NextcloudTalk/NCChatTitleView.xib
@@ -21,7 +21,7 @@
             <rect key="frame" x="0.0" y="0.0" width="290" height="44"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="IxN-fr-8tD" userLabel="AvatarImageView">
+                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="IxN-fr-8tD" userLabel="AvatarImageView">
                     <rect key="frame" x="0.0" y="7" width="30" height="30"/>
                     <constraints>
                         <constraint firstAttribute="width" secondItem="IxN-fr-8tD" secondAttribute="height" multiplier="1:1" id="JYW-6K-xTq"/>
@@ -62,8 +62,10 @@
                 <constraint firstItem="I8S-E1-SNm" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="Nu8-OF-w5n"/>
                 <constraint firstItem="I8S-E1-SNm" firstAttribute="leading" secondItem="IxN-fr-8tD" secondAttribute="trailing" constant="10" id="RzK-wZ-yG9"/>
                 <constraint firstItem="IxN-fr-8tD" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="V8v-Q7-D6r"/>
+                <constraint firstItem="IxN-fr-8tD" firstAttribute="top" relation="greaterThanOrEqual" secondItem="vUN-kp-3ea" secondAttribute="top" id="aw0-kd-xYR"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="6PH-NC-M0F" secondAttribute="bottom" id="bSL-rZ-FxA"/>
                 <constraint firstItem="IxN-fr-8tD" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="bfS-1h-ijV"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="IxN-fr-8tD" secondAttribute="bottom" id="j06-qO-wp3"/>
                 <constraint firstItem="6PH-NC-M0F" firstAttribute="top" secondItem="IxN-fr-8tD" secondAttribute="top" priority="750" constant="22" id="mVF-Yo-XXC"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="I8S-E1-SNm" secondAttribute="trailing" id="tGw-MV-n1a"/>
                 <constraint firstItem="I8S-E1-SNm" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="xX6-0N-eyd"/>


### PR DESCRIPTION
Some fine tuning for the call view:
* Adjust font sizes to be the same (and not 3 different ones)
* Adjust the screensharing indicator to be on top of the avatar and move it to the top right
* Make sure the text is not above the avatar
* Move the UILabel inside a view and align it to the bottom
* Fix avatar size for iOS 15 in TitleView