### PR TITLE
Calculate the minimum width based on the target aspect ratio

### DIFF
--- a/NextcloudTalk/CallFlowLayout.swift
+++ b/NextcloudTalk/CallFlowLayout.swift
@@ -65,24 +65,26 @@ class CallFlowLayout: UICollectionViewFlowLayout {
         guard let collectionView = collectionView else { return 1 }
 
         let contentSize = collectionView.bounds.size
+        let cellMinWidth = kCallParticipantCellMinHeight * targetAspectRatio + minimumInteritemSpacing
 
-        if (contentSize.width / kCallParticipantCellMinWidth).rounded(.down) < 1 {
+        if (contentSize.width / cellMinWidth).rounded(.down) < 1 {
             return 1
         }
 
-        return Int((contentSize.width / kCallParticipantCellMinWidth).rounded(.down))
+        return Int((contentSize.width / cellMinWidth).rounded(.down))
     }
 
     func rowsMax() -> Int {
         guard let collectionView = collectionView else { return 1 }
 
         let contentSize = collectionView.bounds.size
+        let cellMinHeight = kCallParticipantCellMinHeight + minimumLineSpacing
 
-        if (contentSize.height / kCallParticipantCellMinHeight).rounded(.down) < 1 {
+        if (contentSize.height / cellMinHeight).rounded(.down) < 1 {
             return 1
         }
 
-        return Int((contentSize.height / kCallParticipantCellMinHeight).rounded(.down))
+        return Int((contentSize.height / cellMinHeight).rounded(.down))
     }
 
     // Based on the makeGrid method of web:

--- a/NextcloudTalk/CallParticipantViewCell.h
+++ b/NextcloudTalk/CallParticipantViewCell.h
@@ -26,7 +26,6 @@
 extern NSString *const kCallParticipantCellIdentifier;
 extern NSString *const kCallParticipantCellNibName;
 extern CGFloat const kCallParticipantCellMinHeight;
-extern CGFloat const kCallParticipantCellMinWidth;
 
 @class CallParticipantViewCell;
 @protocol CallParticipantViewCellDelegate <NSObject>

--- a/NextcloudTalk/CallParticipantViewCell.m
+++ b/NextcloudTalk/CallParticipantViewCell.m
@@ -35,7 +35,6 @@
 NSString *const kCallParticipantCellIdentifier = @"CallParticipantCellIdentifier";
 NSString *const kCallParticipantCellNibName = @"CallParticipantViewCell";
 CGFloat const kCallParticipantCellMinHeight = 128;
-CGFloat const kCallParticipantCellMinWidth = 192; // Aspect ratio of 1.5
 
 @interface CallParticipantViewCell()
 {


### PR DESCRIPTION
The minimum width of a cell was a fixed value based on a 1.5 aspect ratio. Since we have a target aspect ratio of 1.0 for portrait mode, this lead to weird layouts. Now the minimum width is calculated on the minimum height and the target aspect ratio. Also the spacing is now taken into account.

Before:
<img width="256" src="https://user-images.githubusercontent.com/1580193/217877908-16c1db1f-b840-418a-98b2-f6d960c24abf.png" />

After:
<img width="256" src="https://user-images.githubusercontent.com/1580193/217877931-35f12436-53a4-47d2-9288-0d019479345b.png" />

