### PR TITLE
Fix speaking detection

### DIFF
--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -530,15 +530,19 @@ static NSString * const kNCVideoTrackKind = @"video";
 
 - (void)startMonitoringMicrophoneAudioLevel
 {
-    _micAudioLevelTimer = [NSTimer scheduledTimerWithTimeInterval:1.0  target:self selector:@selector(checkMicAudioLevel) userInfo:nil repeats:YES];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_micAudioLevelTimer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(checkMicAudioLevel) userInfo:nil repeats:YES];
+    });
 }
 
 - (void)stopMonitoringMicrophoneAudioLevel
 {
-    [_micAudioLevelTimer invalidate];
-    _micAudioLevelTimer = nil;
-    [_recorder stop];
-    _recorder = nil;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self->_micAudioLevelTimer invalidate];
+        self->_micAudioLevelTimer = nil;
+        [self->_recorder stop];
+        self->_recorder = nil;
+    });
 }
 
 - (void)initRecorder


### PR DESCRIPTION
Since we start the timer in the webrtc dispatch queue, it won't ever fire. Make sure we use the main queue in this case.