### PR TITLE
Do not receive video streams in audio only calls

### DIFF
--- a/NextcloudTalk/NCPeerConnection.m
+++ b/NextcloudTalk/NCPeerConnection.m
@@ -467,6 +467,17 @@
         self->_localDataChannel = [self->_peerConnection dataChannelForLabel:@"status" configuration:config];
         self->_localDataChannel.delegate = self;
 
+        // Stop video transceiver in audio only peer connections
+        // Constraints are no longer supported when creating answers (with Unified Plan semantics)
+        if (_isAudioOnly) {
+            for (RTCRtpTransceiver *transceiver in self->_peerConnection.transceivers) {
+                if (transceiver.mediaType == RTCRtpMediaTypeVideo) {
+                    [transceiver stopInternal];
+                    NSLog(@"Stop video transceiver in audio only peer connections.");
+                }
+            }
+        }
+
         // Create answer
         RTCMediaConstraints *constraints = [self defaultAnswerConstraints];
 


### PR DESCRIPTION
Since we move to Unified Plan semantics, constraints are no longer supported when creating answers ([source](https://docs.google.com/document/d/1PPHWV6108znP1tk_rkCnyagH9FK205hHeE9k5mhUzOg/edit#heading=h.9dcmkavg608r))
That's why we need to stop video transceivers when we want to receive just audio.
Screensharing peer connections won't be affected since they are not "audioOnly" peer connections.
