### PR TITLE
Dispatch track access to WebRTC queue

### DIFF
--- a/NextcloudTalk/NCAudioController.h
+++ b/NextcloudTalk/NCAudioController.h
@@ -27,17 +27,18 @@
 
 extern NSString * const AudioSessionDidChangeRouteNotification;
 extern NSString * const AudioSessionWasActivatedByProviderNotification;
+extern NSString * const AudioSessionDidChangeSpeakerIsActiveNotification;
 
 @interface NCAudioController : NSObject <RTCAudioSessionDelegate>
 
 @property (nonatomic, strong) RTCAudioSession *rtcAudioSession;
+@property (nonatomic, assign) BOOL isSpeakerActive;
 
 + (instancetype)sharedInstance;
 
 - (void)setAudioSessionToVoiceChatMode;
 - (void)setAudioSessionToVideoChatMode;
 - (void)disableAudioSession;
-- (BOOL)isSpeakerActive;
 - (void)providerDidActivateAudioSession:(AVAudioSession *)audioSession;
 - (void)providerDidDeactivateAudioSession:(AVAudioSession *)audioSession;
 

--- a/NextcloudTalk/NCCallController.h
+++ b/NextcloudTalk/NCCallController.h
@@ -30,6 +30,9 @@
 @class RTCVideoTrack;
 @class RTCCameraVideoCapturer;
 
+typedef void (^GetVideoEnabledStateCompletionBlock)(BOOL isEnabled);
+typedef void (^GetAudioEnabledStateCompletionBlock)(BOOL isEnabled);
+
 @protocol NCCallControllerDelegate<NSObject>
 
 - (void)callControllerDidJoinCall:(NCCallController *)callController;
@@ -70,8 +73,8 @@
 - (instancetype)initWithDelegate:(id<NCCallControllerDelegate>)delegate inRoom:(NCRoom *)room forAudioOnlyCall:(BOOL)audioOnly withSessionId:(NSString *)sessionId andVoiceChatMode:(BOOL)voiceChatMode;
 - (void)startCall;
 - (void)leaveCall;
-- (BOOL)isVideoEnabled;
-- (BOOL)isAudioEnabled;
+- (void)getVideoEnabledStateWithCompletionBlock:(GetVideoEnabledStateCompletionBlock)block;
+- (void)getAudioEnabledStateWithCompletionBlock:(GetAudioEnabledStateCompletionBlock)block;
 - (void)switchCamera;
 - (void)enableVideo:(BOOL)enable;
 - (void)enableAudio:(BOOL)enable;


### PR DESCRIPTION
In the webrtc lib access to properties which look "cheap" (like accessing `isActive` on a track) actually do quite some stuff behind the scenes and can lead to a dead lock when executed on the wrong queue. This PR does 2 things:
* Make sure audio and video tracks are only accessed on the webrtc queue
* Make sure `isSpeakerActive` is retrieved without interfering with the webrtc queue