### PR TITLE
Show user status in one2one conversation's title

### DIFF
--- a/NextcloudTalk/NCChatTitleView.m
+++ b/NextcloudTalk/NCChatTitleView.m
@@ -139,17 +139,14 @@
     }
 
     NSString *subtitle = nil;
-
-    /*
-     Disabled, until https://github.com/nextcloud/spreed/issues/8411 is fixed
-
+    
+    if ([[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilitySingleConvStatus]) {
         // User status
         [self setStatusImageForUserStatus:room.status];
 
         // User status message
         if (!room.statusMessage || [room.statusMessage isEqualToString:@""]) {
             // We don't have a dedicated statusMessage -> check the room status itself
-
             if ([room.status isEqualToString:kUserStatusDND]) {
                 subtitle = NSLocalizedString(@"Do not disturb", nil);
             } else if ([room.status isEqualToString:kUserStatusAway]) {
@@ -157,14 +154,13 @@
             }
         } else if (room.statusMessage && ![room.statusMessage isEqualToString:@""]) {
             // A dedicated statusMessage was set -> use it
-
             if (room.statusIcon && ![room.statusIcon isEqualToString:@""]) {
                 subtitle = [NSString stringWithFormat:@"%@ %@", room.statusIcon, room.statusMessage];
             } else {
                 subtitle = room.statusMessage;
             }
         }
-     */
+    }
 
     // Show description in group conversations
     if (room.type != kNCRoomTypeOneToOne && ![room.roomDescription isEqualToString:@""]) {

--- a/NextcloudTalk/NCDatabaseManager.h
+++ b/NextcloudTalk/NCDatabaseManager.h
@@ -71,6 +71,7 @@ extern NSString * const kCapabilitySendCallNotification;
 extern NSString * const kCapabilityTalkPolls;
 extern NSString * const kCapabilityRaiseHand;
 extern NSString * const kCapabilityRecordingV1;
+extern NSString * const kCapabilitySingleConvStatus;
 
 extern NSString * const kMinimumRequiredTalkCapability;
 

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -75,6 +75,7 @@ NSString * const kCapabilitySendCallNotification    = @"send-call-notification";
 NSString * const kCapabilityTalkPolls               = @"talk-polls";
 NSString * const kCapabilityRaiseHand               = @"raise-hand";
 NSString * const kCapabilityRecordingV1             = @"recording-v1";
+NSString * const kCapabilitySingleConvStatus        = @"single-conversation-status";
 
 NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages; // Talk 4.0 is the minimum required version
 


### PR DESCRIPTION
Only if `single-conversation-status` capability is there.
Ref: https://github.com/nextcloud/spreed/pull/8773