### PR TITLE
Add recording failed state

### DIFF
--- a/NextcloudTalk/NCRoom.h
+++ b/NextcloudTalk/NCRoom.h
@@ -89,7 +89,8 @@ typedef enum NCCallRecordingState {
     NCCallRecordingStateVideoRunning = 1,
     NCCallRecordingStateAudioRunning = 2,
     NCCallRecordingStateVideoStarting = 3,
-    NCCallRecordingStateAudioStarting = 4
+    NCCallRecordingStateAudioStarting = 4,
+    NCCallRecordingStateFailed = 5
 } NCCallRecordingState;
 
 extern NSString * const NCRoomObjectTypeFile;
@@ -161,6 +162,7 @@ extern NSString * const NCRoomObjectTypeSharePassword;
 - (BOOL)isLeavable;
 - (BOOL)userCanStartCall;
 - (BOOL)hasUnreadMention;
+- (BOOL)callRecordingIsInActiveState;
 - (NSString *)deletionMessage;
 - (NSString *)notificationLevelString;
 - (NSString *)stringForNotificationLevel:(NCRoomNotificationLevel)level;

--- a/NextcloudTalk/NCRoom.m
+++ b/NextcloudTalk/NCRoom.m
@@ -223,6 +223,18 @@ NSString * const NCRoomObjectTypeSharePassword  = @"share:password";
     return YES;
 }
 
+- (BOOL)callRecordingIsInActiveState
+{
+    if ([[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityRecordingV1]) {
+        // Starting states and running states are considered active
+        if (self.callRecording != NCCallRecordingStateStopped && self.callRecording != NCCallRecordingStateFailed) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
 - (BOOL)hasUnreadMention
 {
     return self.unreadMention || self.unreadMentionDirect || (self.type == kNCRoomTypeOneToOne && self.unreadMessages > 0)

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -248,6 +248,9 @@
 "Call options" = "Call options";
 
 /* No comment provided by engineer. */
+"Call recording failed. Please contact your administrator" = "Call recording failed. Please contact your administrator";
+
+/* No comment provided by engineer. */
 "Call recording is starting" = "Call recording is starting";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
Ref: https://github.com/nextcloud/spreed/pull/8720

TODO
- [x] Allow trying to start a recording again after we moved to `FAILED`?
- [x] Hide the recording icon in `FAILED` state (depends on the one above, if we move to `STOPPED` after receiving a `FAILED` signaling message, this would be done automatically).