### PR TITLE
Store recording

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F1C0D7F29A7F33600D17C6D /* NCNotificationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA38C8F29A4B3C6008871B8 /* NCNotificationAction.swift */; };
 		1F1C999D2909846400EACF02 /* BGTaskHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD9182828C55A73009092AB /* BGTaskHelper.swift */; };
 		1F1C999E2909846400EACF02 /* BGTaskHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD9182828C55A73009092AB /* BGTaskHelper.swift */; };
 		1F24B5A228E0648600654457 /* ReferenceGithubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F24B5A128E0648600654457 /* ReferenceGithubView.swift */; };
@@ -48,6 +49,8 @@
 		1F98DF9C28E7484700E05174 /* ReferenceDeckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F98DF9B28E7484700E05174 /* ReferenceDeckView.swift */; };
 		1F98DF9E28E7485000E05174 /* ReferenceDeckView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1F98DF9D28E7485000E05174 /* ReferenceDeckView.xib */; };
 		1FA20C8A284001D80062B4F3 /* DebounceWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA20C89284001D80062B4F3 /* DebounceWebView.swift */; };
+		1FA38C9029A4B3C6008871B8 /* NCNotificationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA38C8F29A4B3C6008871B8 /* NCNotificationAction.swift */; };
+		1FA38C9129A4B3C6008871B8 /* NCNotificationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA38C8F29A4B3C6008871B8 /* NCNotificationAction.swift */; };
 		1FA732FC2966CBB7003D2103 /* CallFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA732FB2966CBB7003D2103 /* CallFlowLayout.swift */; };
 		1FB52E762842C75E00AC741B /* QRCodeLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB52E752842C75E00AC741B /* QRCodeLoginController.swift */; };
 		1FB6678F28CE381300D29F8D /* SubtitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB6678E28CE381300D29F8D /* SubtitleTableViewCell.swift */; };
@@ -404,6 +407,7 @@
 		1F98DF9B28E7484700E05174 /* ReferenceDeckView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReferenceDeckView.swift; sourceTree = "<group>"; };
 		1F98DF9D28E7485000E05174 /* ReferenceDeckView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReferenceDeckView.xib; sourceTree = "<group>"; };
 		1FA20C89284001D80062B4F3 /* DebounceWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceWebView.swift; sourceTree = "<group>"; };
+		1FA38C8F29A4B3C6008871B8 /* NCNotificationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCNotificationAction.swift; sourceTree = "<group>"; };
 		1FA732FB2966CBB7003D2103 /* CallFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallFlowLayout.swift; sourceTree = "<group>"; };
 		1FB52E752842C75E00AC741B /* QRCodeLoginController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeLoginController.swift; sourceTree = "<group>"; };
 		1FB6678E28CE381300D29F8D /* SubtitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleTableViewCell.swift; sourceTree = "<group>"; };
@@ -1358,6 +1362,7 @@
 		2C9B0B99217F6E3400A4752C /* Notifications */ = {
 			isa = PBXGroup;
 			children = (
+				1FA38C8F29A4B3C6008871B8 /* NCNotificationAction.swift */,
 				2C9B0B9A217F756B00A4752C /* NCNotification.h */,
 				2C9B0B9B217F756B00A4752C /* NCNotification.m */,
 				2CBF82AC1FC888FC00636459 /* NCPushNotification.h */,
@@ -1890,6 +1895,7 @@
 				2CA52AD0267613CB00619610 /* VoiceMessageTableViewCell.m in Sources */,
 				2C1EF36B25505DCE007C9768 /* NCNavigationController.m in Sources */,
 				DA755811278EF3EF00A48A1B /* UserSettingsTableViewCell.swift in Sources */,
+				1FA38C9029A4B3C6008871B8 /* NCNotificationAction.swift in Sources */,
 				2C44B4D127FF05A000AD1C86 /* ReactionsSummaryView.swift in Sources */,
 				DA7558C6279AE67F00A48A1B /* UserStatusTableViewController.swift in Sources */,
 				2CC007B420D7AE990096D91F /* ResultMultiSelectionTableViewController.m in Sources */,
@@ -2057,6 +2063,7 @@
 				2C62AFFD24C1BDA5007E460A /* NCMessageParameter.m in Sources */,
 				1F538197291CFE0A003DA6B7 /* NCAvatarSessionManager.m in Sources */,
 				2C62B00C24C1BDC1007E460A /* NCNotification.m in Sources */,
+				1F1C0D7F29A7F33600D17C6D /* NCNotificationAction.swift in Sources */,
 				2C4446FC265D5C5800DF1DBC /* NCRoomParticipants.m in Sources */,
 				2CB6ACDC2641483800D3D641 /* NCMessageLocationParameter.m in Sources */,
 				2C62AFDF24C1BD8D007E460A /* UIImageView+Letters.m in Sources */,
@@ -2106,6 +2113,7 @@
 				2C4446F6265D593200DF1DBC /* OpenInFirefoxControllerObjC.m in Sources */,
 				1F1C999D2909846400EACF02 /* BGTaskHelper.swift in Sources */,
 				2C4446F4265D51A600DF1DBC /* NCPushNotificationsUtils.m in Sources */,
+				1FA38C9129A4B3C6008871B8 /* NCNotificationAction.swift in Sources */,
 				2CC0019A24A37A7C00A20167 /* UIImageView+Letters.m in Sources */,
 				2C4446DE2658158000DF1DBC /* NCChatBlock.m in Sources */,
 				2C5BFBF3288AA37F00E75118 /* NCPoll.m in Sources */,

--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -232,7 +232,7 @@
 - (void)registerInteractivePushNotification
 {
     // Reply directly to a chat notification action/category
-    UNTextInputNotificationAction *replyAction = [UNTextInputNotificationAction actionWithIdentifier:@"REPLY_CHAT"
+    UNTextInputNotificationAction *replyAction = [UNTextInputNotificationAction actionWithIdentifier:NCNotificationActionReplyToChat
                                                                                           title:NSLocalizedString(@"Reply", nil)
                                                                                         options:UNNotificationActionOptionAuthenticationRequired];
     

--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -231,6 +231,7 @@
 
 - (void)registerInteractivePushNotification
 {
+    // Reply directly to a chat notification action/category
     UNTextInputNotificationAction *replyAction = [UNTextInputNotificationAction actionWithIdentifier:@"REPLY_CHAT"
                                                                                           title:NSLocalizedString(@"Reply", nil)
                                                                                         options:UNNotificationActionOptionAuthenticationRequired];
@@ -239,8 +240,22 @@
                                                                               actions:@[replyAction]
                                                                     intentIdentifiers:@[]
                                                                               options:UNNotificationCategoryOptionNone];
-    
-    NSSet *categories = [NSSet setWithObject:chatCategory];
+
+    // Recording actions/category
+    UNNotificationAction *recordingShareAction = [UNNotificationAction actionWithIdentifier:NCNotificationActionShareRecording
+                                                                                      title:NSLocalizedString(@"Share recording to chat", nil)
+                                                                                    options:UNNotificationActionOptionAuthenticationRequired];
+
+    UNNotificationAction *recordingDismissAction = [UNNotificationAction actionWithIdentifier:NCNotificationActionDismissRecordingNotification
+                                                                                      title:NSLocalizedString(@"Dismiss notification", nil)
+                                                                                    options:UNNotificationActionOptionAuthenticationRequired | UNNotificationActionOptionDestructive];
+
+    UNNotificationCategory *recordingCategory = [UNNotificationCategory categoryWithIdentifier:@"CATEGORY_RECORDING"
+                                                                                       actions:@[recordingShareAction, recordingDismissAction]
+                                                                             intentIdentifiers:@[]
+                                                                                       options:UNNotificationCategoryOptionNone];
+
+    NSSet *categories = [NSSet setWithObjects:chatCategory, recordingCategory, nil];
     [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:categories];
 }
 

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -266,7 +266,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 // Recording
 - (NSURLSessionDataTask *)startRecording:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(StartRecordingCompletionBlock)block;
 - (NSURLSessionDataTask *)stopRecording:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(StopRecordingCompletionBlock)block;
-- (NSURLSessionDataTask *)dismissStoredRecordingWithTimestamp:(NSString *)timestamp forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(DismissStoredRecordingCompletionBlock)block;
+- (NSURLSessionDataTask *)dismissStoredRecordingNotificationWithTimestamp:(NSString *)timestamp forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(DismissStoredRecordingCompletionBlock)block;
 - (NSURLSessionDataTask *)shareStoredRecordingWithTimestamp:(NSString *)timestamp withFileId:(NSString *)fileId forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(ShareStoredRecordingCompletionBlock)block;
 
 @end

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -107,6 +107,8 @@ typedef void (^GetReferenceForUrlStringCompletionBlock)(NSDictionary *references
 
 typedef void (^StartRecordingCompletionBlock)(NSError *error);
 typedef void (^StopRecordingCompletionBlock)(NSError *error);
+typedef void (^DismissStoredRecordingCompletionBlock)(NSError *error);
+typedef void (^ShareStoredRecordingCompletionBlock)(NSError *error);
 
 extern NSInteger const APIv1;
 extern NSInteger const APIv2;
@@ -264,5 +266,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 // Recording
 - (NSURLSessionDataTask *)startRecording:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(StartRecordingCompletionBlock)block;
 - (NSURLSessionDataTask *)stopRecording:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(StopRecordingCompletionBlock)block;
+- (NSURLSessionDataTask *)dismissStoredRecordingWithTimestamp:(NSString *)timestamp forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(DismissStoredRecordingCompletionBlock)block;
+- (NSURLSessionDataTask *)shareStoredRecordingWithTimestamp:(NSString *)timestamp withFileId:(NSString *)fileId forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(ShareStoredRecordingCompletionBlock)block;
 
 @end

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -107,7 +107,7 @@ typedef void (^GetReferenceForUrlStringCompletionBlock)(NSDictionary *references
 
 typedef void (^StartRecordingCompletionBlock)(NSError *error);
 typedef void (^StopRecordingCompletionBlock)(NSError *error);
-typedef void (^DismissStoredRecordingCompletionBlock)(NSError *error);
+typedef void (^DismissStoredRecordingNotificationCompletionBlock)(NSError *error);
 typedef void (^ShareStoredRecordingCompletionBlock)(NSError *error);
 
 extern NSInteger const APIv1;
@@ -266,7 +266,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 // Recording
 - (NSURLSessionDataTask *)startRecording:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(StartRecordingCompletionBlock)block;
 - (NSURLSessionDataTask *)stopRecording:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(StopRecordingCompletionBlock)block;
-- (NSURLSessionDataTask *)dismissStoredRecordingNotificationWithTimestamp:(NSString *)timestamp forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(DismissStoredRecordingCompletionBlock)block;
+- (NSURLSessionDataTask *)dismissStoredRecordingNotificationWithTimestamp:(NSString *)timestamp forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(DismissStoredRecordingNotificationCompletionBlock)block;
 - (NSURLSessionDataTask *)shareStoredRecordingWithTimestamp:(NSString *)timestamp withFileId:(NSString *)fileId forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(ShareStoredRecordingCompletionBlock)block;
 
 @end

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -2643,6 +2643,59 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     return task;
 }
 
+- (NSURLSessionDataTask *)dismissStoredRecordingWithTimestamp:(NSString *)timestamp forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(DismissStoredRecordingCompletionBlock)block
+{
+    NSString *encodedToken = [token stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+    NSString *endpoint = [NSString stringWithFormat:@"recording/%@/notification", encodedToken];
+    NSString *URLString = [self getRequestURLForEndpoint:endpoint withAPIVersion:1 forAccount:account];
+
+    NSDictionary *parameters = @{
+        @"timestamp" : timestamp
+    };
+
+    NCAPISessionManager *apiSessionManager = [_apiSessionManagers objectForKey:account.accountId];
+    NSURLSessionDataTask *task = [apiSessionManager DELETE:URLString parameters:parameters success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+        if (block) {
+            block(nil);
+        }
+    } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
+        NSInteger statusCode = [self getResponseStatusCode:task.response];
+        [self checkResponseStatusCode:statusCode forAccount:account];
+        if (block) {
+            block(error);
+        }
+    }];
+
+    return task;
+}
+
+- (NSURLSessionDataTask *)shareStoredRecordingWithTimestamp:(NSString *)timestamp withFileId:(NSString *)fileId forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(ShareStoredRecordingCompletionBlock)block
+{
+    NSString *encodedToken = [token stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+    NSString *endpoint = [NSString stringWithFormat:@"recording/%@/share-chat", encodedToken];
+    NSString *URLString = [self getRequestURLForEndpoint:endpoint withAPIVersion:1 forAccount:account];
+
+    NSDictionary *parameters = @{
+        @"timestamp" : timestamp,
+        @"fileId" : fileId
+    };
+
+    NCAPISessionManager *apiSessionManager = [_apiSessionManagers objectForKey:account.accountId];
+    NSURLSessionDataTask *task = [apiSessionManager POST:URLString parameters:parameters progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+        if (block) {
+            block(nil);
+        }
+    } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
+        NSInteger statusCode = [self getResponseStatusCode:task.response];
+        [self checkResponseStatusCode:statusCode forAccount:account];
+        if (block) {
+            block(error);
+        }
+    }];
+
+    return task;
+}
+
 #pragma mark - Error handling
 
 - (NSInteger)getResponseStatusCode:(NSURLResponse *)response

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -2643,7 +2643,7 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     return task;
 }
 
-- (NSURLSessionDataTask *)dismissStoredRecordingWithTimestamp:(NSString *)timestamp forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(DismissStoredRecordingCompletionBlock)block
+- (NSURLSessionDataTask *)dismissStoredRecordingNotificationWithTimestamp:(NSString *)timestamp forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(DismissStoredRecordingCompletionBlock)block
 {
     NSString *encodedToken = [token stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
     NSString *endpoint = [NSString stringWithFormat:@"recording/%@/notification", encodedToken];

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -2585,6 +2585,12 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     return task;
 }
 
+- (NSURLRequest *)createReferenceThumbnailRequestForUrl:(NSString *)url
+{
+    NSMutableURLRequest *thumbnailRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url] cachePolicy:NSURLRequestReturnCacheDataElseLoad timeoutInterval:60];
+    return thumbnailRequest;
+}
+
 #pragma - Recording
 
 - (NSURLSessionDataTask *)startRecording:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(StartRecordingCompletionBlock)block
@@ -2635,12 +2641,6 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     }];
 
     return task;
-}
-
-- (NSURLRequest *)createReferenceThumbnailRequestForUrl:(NSString *)url
-{
-    NSMutableURLRequest *thumbnailRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url] cachePolicy:NSURLRequestReturnCacheDataElseLoad timeoutInterval:60];
-    return thumbnailRequest;
 }
 
 #pragma mark - Error handling

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -2643,7 +2643,7 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     return task;
 }
 
-- (NSURLSessionDataTask *)dismissStoredRecordingNotificationWithTimestamp:(NSString *)timestamp forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(DismissStoredRecordingCompletionBlock)block
+- (NSURLSessionDataTask *)dismissStoredRecordingNotificationWithTimestamp:(NSString *)timestamp forRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(DismissStoredRecordingNotificationCompletionBlock)block
 {
     NSString *encodedToken = [token stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
     NSString *endpoint = [NSString stringWithFormat:@"recording/%@/notification", encodedToken];

--- a/NextcloudTalk/NCNotification.h
+++ b/NextcloudTalk/NCNotification.h
@@ -25,7 +25,8 @@
 typedef enum NCNotificationType {
     kNCNotificationTypeRoom = 0,
     kNCNotificationTypeChat,
-    kNCNotificationTypeCall
+    kNCNotificationTypeCall,
+    kNCNotificationTypeRecording
 } NCNotificationType;
 
 @interface NCNotification : NSObject
@@ -40,6 +41,8 @@ typedef enum NCNotificationType {
 @property (nonatomic, strong) NSString *message;
 @property (nonatomic, strong) NSString *messageRich;
 @property (nonatomic, strong) NSDictionary *messageRichParameters;
+@property (nonatomic, strong) NSArray *actions;
+@property (nonatomic, strong) NSDate *datetime;
 
 + (instancetype)notificationWithDictionary:(NSDictionary *)notificationDict;
 - (NCNotificationType)notificationType;
@@ -47,5 +50,6 @@ typedef enum NCNotificationType {
 - (NSString *)chatMessageTitle;
 - (NSString *)callDisplayName;
 - (NSString *)roomToken;
+- (NSArray *)notificationActions;
 
 @end

--- a/NextcloudTalk/NCNotification.m
+++ b/NextcloudTalk/NCNotification.m
@@ -22,6 +22,8 @@
 
 #import "NCNotification.h"
 
+#import "NextcloudTalk-Swift.h"
+
 @implementation NCNotification
 
 + (instancetype)notificationWithDictionary:(NSDictionary *)notificationDict
@@ -41,7 +43,11 @@
     notification.message = [notificationDict objectForKey:@"message"];
     notification.messageRich = [notificationDict objectForKey:@"messageRich"];
     notification.messageRichParameters = [notificationDict objectForKey:@"messageRichParameters"];
-    
+    notification.actions = [notificationDict objectForKey:@"actions"];
+
+    NSISO8601DateFormatter *formatter = [[NSISO8601DateFormatter alloc] init];
+    notification.datetime = [formatter dateFromString:[notificationDict objectForKey:@"datetime"]];
+
     if (![notification.subjectRichParameters isKindOfClass:[NSDictionary class]]) {
         notification.subjectRichParameters = @{};
     }
@@ -58,6 +64,8 @@
     NCNotificationType type = kNCNotificationTypeRoom;
     if ([_objectType isEqualToString:@"chat"]) {
         type = kNCNotificationTypeChat;
+    } else if ([_objectType isEqualToString:@"recording"]) {
+        type = kNCNotificationTypeRecording;
     } else if ([_objectType isEqualToString:@"call"]) {
         type = kNCNotificationTypeCall;
     }
@@ -124,6 +132,23 @@
     NSError *error = nil;
     NSRegularExpression *parameterRegex = [NSRegularExpression regularExpressionWithPattern:@"\\{([^}]+)\\}" options:NSRegularExpressionCaseInsensitive error:&error];
     return [parameterRegex matchesInString:text options:0 range:NSMakeRange(0, [text length])];
+}
+
+- (NSArray *)notificationActions
+{
+    if (!self.actions) {
+        return nil;
+    }
+
+    NSMutableArray *resultActions = [[NSMutableArray alloc] init];
+
+    for (NSDictionary *dict in self.actions) {
+        NCNotificationAction *notificationAction = [[NCNotificationAction alloc] initWithDictionary:dict];
+
+        [resultActions addObject:notificationAction];
+    }
+
+    return resultActions;
 }
 
 @end

--- a/NextcloudTalk/NCNotificationAction.swift
+++ b/NextcloudTalk/NCNotificationAction.swift
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2023 Marcel Müller <marcel.mueller@nextcloud.com>
+//
+// Author Marcel Müller <marcel.mueller@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+// Documentation at https://github.com/nextcloud/notifications/blob/master/docs/ocs-endpoint-v2.md
+// Type "Web" is supposed to do a redirect
+@objc enum NCNotificationActionType: Int {
+    case kNotificationActionTypeUnknown = 0
+    case kNotificationActionTypeGet
+    case kNotificationActionTypePost
+    case kNotificationActionTypeDelete
+    case kNotificationActionTypePut
+    case kNotificationActionTypeWeb
+}
+
+@objcMembers class NCNotificationAction: NSObject {
+
+    public let actionLabel: String?
+    public var actionLink: String?
+    public var actionType: NCNotificationActionType = .kNotificationActionTypeUnknown
+    public var isPrimaryAction: Bool
+
+    init(dictionary: [String: Any]) {
+        self.actionLabel = dictionary["label"] as? String
+        self.actionLink = dictionary["link"] as? String
+        self.isPrimaryAction = dictionary["primary"] as? Bool ?? false
+
+        if let actionType = dictionary["type"] as? String {
+            switch actionType.lowercased() {
+            case "get":
+                self.actionType = .kNotificationActionTypeGet
+            case "post":
+                self.actionType = .kNotificationActionTypePost
+            case "delete":
+                self.actionType = .kNotificationActionTypeDelete
+            case "put":
+                self.actionType = .kNotificationActionTypePut
+            case "web":
+                self.actionType = .kNotificationActionTypeWeb
+            default:
+                self.actionType = .kNotificationActionTypeUnknown
+            }
+        }
+
+        super.init()
+    }
+}

--- a/NextcloudTalk/NCNotificationController.h
+++ b/NextcloudTalk/NCNotificationController.h
@@ -27,6 +27,9 @@
 extern NSString * const NCNotificationControllerWillPresentNotification;
 extern NSString * const NCLocalNotificationJoinChatNotification;
 
+extern NSString * const NCNotificationActionShareRecording;
+extern NSString * const NCNotificationActionDismissRecordingNotification;
+
 typedef void (^CheckForNewNotificationsCompletionBlock)(NSError *error);
 
 typedef enum {

--- a/NextcloudTalk/NCNotificationController.h
+++ b/NextcloudTalk/NCNotificationController.h
@@ -37,7 +37,8 @@ typedef enum {
     kNCLocalNotificationTypeCancelledCall,
     kNCLocalNotificationTypeFailedSendChat,
     kNCLocalNotificationTypeCallFromOldAccount,
-    kNCLocalNotificationTypeChatNotification
+    kNCLocalNotificationTypeChatNotification,
+    kNCLocalNotificationTypeFailedToShareRecording
 } NCLocalNotificationType;
 
 @interface NCNotificationController : NSObject

--- a/NextcloudTalk/NCNotificationController.h
+++ b/NextcloudTalk/NCNotificationController.h
@@ -29,6 +29,7 @@ extern NSString * const NCLocalNotificationJoinChatNotification;
 
 extern NSString * const NCNotificationActionShareRecording;
 extern NSString * const NCNotificationActionDismissRecordingNotification;
+extern NSString * const NCNotificationActionReplyToChat;
 
 typedef void (^CheckForNewNotificationsCompletionBlock)(NSError *error);
 

--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -491,7 +491,7 @@ NSString * const NCNotificationActionDismissRecordingNotification   = @"DISMISS_
     NSString *notificationTimestamp = [NSString stringWithFormat:@"%.0f", notificationTimeInterval];
 
     if ([response.actionIdentifier isEqualToString:NCNotificationActionShareRecording]) {
-        NSDictionary *fileParameters = [serverNotification.subjectRichParameters objectForKey:@"file"];
+        NSDictionary *fileParameters = [serverNotification.messageRichParameters objectForKey:@"file"];
 
         if (!fileParameters || ![fileParameters objectForKey:@"id"]) {
             return;

--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -37,6 +37,9 @@
 NSString * const NCNotificationControllerWillPresentNotification    = @"NCNotificationControllerWillPresentNotification";
 NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalNotificationJoinChatNotification";
 
+NSString * const NCNotificationActionShareRecording                 = @"SHARE_RECORDING";
+NSString * const NCNotificationActionDismissRecordingNotification   = @"DISMISS_RECORDING_NOTIFICATION";
+
 @interface NCNotificationController () <UNUserNotificationCenterDelegate>
 
 @property (nonatomic, strong) UNUserNotificationCenter *notificationCenter;

--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -41,6 +41,7 @@ NSString * const NCLocalNotificationJoinChatNotification            = @"NCLocalN
 
 NSString * const NCNotificationActionShareRecording                 = @"SHARE_RECORDING";
 NSString * const NCNotificationActionDismissRecordingNotification   = @"DISMISS_RECORDING_NOTIFICATION";
+NSString * const NCNotificationActionReplyToChat                    = @"REPLY_CHAT";
 
 @interface NCNotificationController () <UNUserNotificationCenterDelegate>
 

--- a/NextcloudTalk/NCPushNotification.h
+++ b/NextcloudTalk/NCPushNotification.h
@@ -30,7 +30,8 @@ typedef NS_ENUM(NSInteger, NCPushNotificationType) {
     NCPushNotificationTypeDelete,
     NCPushNotificationTypeDeleteAll,
     NCPushNotificationTypeDeleteMultiple,
-    NCPushNotificationTypeAdminNotification
+    NCPushNotificationTypeAdminNotification,
+    NCPushNotificationTypeRecording
 };
 
 extern NSString * const kNCPNAppKey;
@@ -42,6 +43,7 @@ extern NSString * const kNCPNNotifIdKey;
 extern NSString * const kNCPNTypeCallKey;
 extern NSString * const kNCPNTypeRoomKey;
 extern NSString * const kNCPNTypeChatKey;
+extern NSString * const kNCPNTypeRecording;
 
 extern NSString * const NCPushNotificationJoinChatNotification;
 extern NSString * const NCPushNotificationJoinAudioCallAcceptedNotification;
@@ -53,7 +55,6 @@ extern NSString * const NCPushNotificationJoinVideoCallAcceptedNotification;
 @property (nonatomic, assign) NCPushNotificationType type;
 @property (nonatomic, copy) NSString *subject;
 @property (nonatomic, copy) NSString *roomToken;
-@property (nonatomic, assign) NSInteger roomId;
 @property (nonatomic, assign) NSInteger notificationId;
 @property (nonatomic, strong) NSArray *notificationIds;
 @property (nonatomic, copy) NSString *accountId;

--- a/NextcloudTalk/NCPushNotification.m
+++ b/NextcloudTalk/NCPushNotification.m
@@ -37,6 +37,7 @@ NSString * const kNCPNTypeChatKey               = @"chat";
 NSString * const kNCPNTypeDeleteKey             = @"delete";
 NSString * const kNCPNTypeDeleteAllKey          = @"delete-all";
 NSString * const kNCPNTypeDeleteMultipleKey     = @"delete-multiple";
+NSString * const kNCPNTypeRecording             = @"recording";
 NSString * const kNCPNAppIdAdminNotificationKey = @"admin_notification_talk";
 
 NSString * const NCPushNotificationJoinChatNotification                 = @"NCPushNotificationJoinChatNotification";
@@ -62,7 +63,6 @@ NSString * const NCPushNotificationJoinVideoCallAcceptedNotification    = @"NCPu
     pushNotification.app = app;
     pushNotification.subject = [jsonDict objectForKey:kNCPNSubjectKey];
     pushNotification.roomToken = [jsonDict objectForKey:kNCPNIdKey];
-    pushNotification.roomId = [[jsonDict objectForKey:kNCPNIdKey] integerValue];
     pushNotification.notificationId = [[jsonDict objectForKey:kNCPNNotifIdKey] integerValue];
     
     NSString *type = [jsonDict objectForKey:kNCPNTypeKey];
@@ -73,6 +73,8 @@ NSString * const NCPushNotificationJoinVideoCallAcceptedNotification    = @"NCPu
         pushNotification.type = NCPushNotificationTypeRoom;
     } else if ([type isEqualToString:kNCPNTypeChatKey]) {
         pushNotification.type = NCPushNotificationTypeChat;
+    } else if ([type isEqualToString:kNCPNTypeRecording]) {
+        pushNotification.type = NCPushNotificationTypeRecording;
     }
     
     pushNotification.accountId = accountId;

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -533,6 +533,9 @@
 "Dismiss" = "Dismiss";
 
 /* No comment provided by engineer. */
+"Dismiss notification" = "Dismiss notification";
+
+/* No comment provided by engineer. */
 "Do not disturb" = "Do not disturb";
 
 /* No comment provided by engineer. */
@@ -690,6 +693,9 @@
 
 /* No comment provided by engineer. */
 "Failed to send message" = "Failed to send message";
+
+/* No comment provided by engineer. */
+"Failed to share recording" = "Failed to share recording";
 
 /* No comment provided by engineer. */
 "Federated" = "Federated";
@@ -1302,6 +1308,9 @@
 
 /* Share the location of a pin that has been dropped in a map view */
 "Share pin location" = "Share pin location";
+
+/* No comment provided by engineer. */
+"Share recording to chat" = "Share recording to chat";
 
 /* No comment provided by engineer. */
 "Share with" = "Share with";

--- a/NotificationServiceExtension/NotificationService.m
+++ b/NotificationServiceExtension/NotificationService.m
@@ -175,17 +175,31 @@
                     [apiSessionManager GET:URLString parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
                         NSDictionary *notification = [[responseObject objectForKey:@"ocs"] objectForKey:@"data"];
                         NCNotification *serverNotification = [NCNotification notificationWithDictionary:notification];
-                        if (serverNotification && serverNotification.notificationType == kNCNotificationTypeChat) {
+
+                        if (!serverNotification) {
+                            self.contentHandler(self.bestAttemptContent);
+                        }
+
+                        // Add the serverNotification as userInfo as well -> this can later be used to access the actions directly
+                        [userInfo setObject:notification forKey:@"serverNotification"];
+                        self.bestAttemptContent.userInfo = userInfo;
+
+                        if (serverNotification.notificationType == kNCNotificationTypeChat) {
                             self.bestAttemptContent.title = serverNotification.chatMessageTitle;
                             self.bestAttemptContent.body = serverNotification.message;
                             self.bestAttemptContent.summaryArgument = serverNotification.chatMessageAuthor;
+                        } else if (serverNotification.notificationType == kNCNotificationTypeRecording) {
+                            self.bestAttemptContent.categoryIdentifier = @"CATEGORY_RECORDING";
+                            self.bestAttemptContent.title = @"";
+                            self.bestAttemptContent.body = serverNotification.subject;
+                            self.bestAttemptContent.summaryArgument = serverNotification.objectId;
                         }
 
                         if (@available(iOS 15.0, *)) {
                             NCRoom *room = [self roomWithToken:pushNotification.roomToken forAccountId:pushNotification.accountId];
 
                             if (room) {
-                                [[NCIntentController sharedInstance] getInteractionForRoom:room withTitle:serverNotification.chatMessageTitle withCompletionBlock:^(INSendMessageIntent *sendMessageIntent) {
+                                [[NCIntentController sharedInstance] getInteractionForRoom:room withTitle:self.bestAttemptContent.title withCompletionBlock:^(INSendMessageIntent *sendMessageIntent) {
                                     __block NSError *error;
 
                                     if (sendMessageIntent) {

--- a/NotificationServiceExtension/NotificationService.m
+++ b/NotificationServiceExtension/NotificationService.m
@@ -190,8 +190,8 @@
                             self.bestAttemptContent.summaryArgument = serverNotification.chatMessageAuthor;
                         } else if (serverNotification.notificationType == kNCNotificationTypeRecording) {
                             self.bestAttemptContent.categoryIdentifier = @"CATEGORY_RECORDING";
-                            self.bestAttemptContent.title = @"";
-                            self.bestAttemptContent.body = serverNotification.subject;
+                            self.bestAttemptContent.title = serverNotification.subject;
+                            self.bestAttemptContent.body = serverNotification.message;
                             self.bestAttemptContent.summaryArgument = serverNotification.objectId;
                         }
 


### PR DESCRIPTION
Implement support for notification type "recording" and allow sharing a recording directly to the conversation after it was processed by the recording server.

It's working (besides the fact that iOS does not play webm files...), but there are a 2 things for a follow-up:
* Adjustments depending on https://github.com/nextcloud/spreed/issues/8835
* Opening a modal when just tapping on a notification and not opening to show the notification actions
