### PR TITLE
Hide internal participants from call view

### DIFF
--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -1169,12 +1169,15 @@ static NSString * const kNCVideoTrackKind = @"video";
     for (NSMutableDictionary *user in users) {
         NSString *sessionId = [user objectForKey:@"sessionId"];
         NSInteger inCall = [[user objectForKey:@"inCall"] integerValue];
+        BOOL internalClient = [[user objectForKey:@"internal"] boolValue];
+
         // Set inCall flag for app user
         if ([sessionId isEqualToString:[self signalingSessionId]]) {
             _userInCall = inCall;
         }
-        // Add session if inCall
-        if (inCall) {
+
+        // Add session if inCall and if it's not an internal client
+        if (inCall && !internalClient) {
             [sessions addObject:sessionId];
         }
     }


### PR DESCRIPTION
Ref https://github.com/nextcloud/spreed/pull/8756#issuecomment-1442548564

Received list from external signaling:
```javascript
{
    roomid = ...;
    users =     
    (
        {
            inCall = 3;
            lastPing = 1677249332;
            nextcloudSessionId = ...;
            participantPermissions = 254;
            participantType = 1;
            sessionId = ;
        },
        {
            inCall = 1;
            internal = 1;
            lastPing = 1677249361;
            sessionId = ...;
        }
    );
}
```

Check if new participants have `internal` set before adding them (second participant in the above data).

@mahibi Something for you to check on android as well?!