### PR TITLE
Always allow sharing a conversation link

### DIFF
--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -2088,7 +2088,7 @@ typedef enum FileAction {
                         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:shareLinkCellIdentifier];
                     }
 
-                    cell.textLabel.text = NSLocalizedString(@"Share conversation link", nil);
+                    cell.textLabel.text = NSLocalizedString(@"Share link", nil);
                     [cell.imageView setImage:[[UIImage imageNamed:@"share"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
                     cell.imageView.tintColor = [UIColor colorWithRed:0.43 green:0.43 blue:0.45 alpha:1];
 

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -394,7 +394,8 @@ typedef enum FileAction {
     NSMutableArray *actions = [[NSMutableArray alloc] init];
     // Public room toggle
     [actions addObject:[NSNumber numberWithInt:kGuestActionPublicToggle]];
-    // Password protection & Share link
+
+    // Password protection
     if (_room.isPublic) {
         [actions addObject:[NSNumber numberWithInt:kGuestActionPassword]];
     }

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -441,7 +441,9 @@ typedef enum FileAction {
         }
     }
 
-    [actions addObject:[NSNumber numberWithInt:kConversationActionShareLink]];
+    if (_room.type != kNCRoomTypeChangelog) {
+        [actions addObject:[NSNumber numberWithInt:kConversationActionShareLink]];
+    }
     
     return [NSArray arrayWithArray:actions];
 }

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -72,7 +72,6 @@ typedef enum NotificationAction {
 typedef enum GuestAction {
     kGuestActionPublicToggle = 0,
     kGuestActionPassword,
-    kGuestActionShareLink,
     kGuestActionResendInvitations
 } GuestAction;
 
@@ -80,7 +79,8 @@ typedef enum ConversationAction {
     kConversationActionMessageExpiration = 0,
     kConversationActionListable,
     kConversationActionListableForEveryone,
-    kConversationActionReadOnly
+    kConversationActionReadOnly,
+    kConversationActionShareLink
 } ConversationAction;
 
 typedef enum WebinarAction {
@@ -397,7 +397,6 @@ typedef enum FileAction {
     // Password protection & Share link
     if (_room.isPublic) {
         [actions addObject:[NSNumber numberWithInt:kGuestActionPassword]];
-        [actions addObject:[NSNumber numberWithInt:kGuestActionShareLink]];
     }
     // Resend invitations
     if (_room.isPublic && [[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilitySIPSupport]) {
@@ -420,10 +419,12 @@ typedef enum FileAction {
 - (NSArray *)getConversationActions
 {
     NSMutableArray *actions = [[NSMutableArray alloc] init];
+
     // Message expiration action
     if (_room.isUserOwnerOrModerator && [[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityMessageExpiration]) {
         [actions addObject:[NSNumber numberWithInt:kConversationActionMessageExpiration]];
     }
+
     if (_room.canModerate) {
         // Listable room action
         if ([[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityListableRooms]) {
@@ -439,6 +440,8 @@ typedef enum FileAction {
             [actions addObject:[NSNumber numberWithInt:kConversationActionReadOnly]];
         }
     }
+
+    [actions addObject:[NSNumber numberWithInt:kConversationActionShareLink]];
     
     return [NSArray arrayWithArray:actions];
 }
@@ -1979,22 +1982,7 @@ typedef enum FileAction {
                     return cell;
                 }
                     break;
-                    
-                case kGuestActionShareLink:
-                {
-                    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:shareLinkCellIdentifier];
-                    if (!cell) {
-                        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:shareLinkCellIdentifier];
-                    }
-                    
-                    cell.textLabel.text = NSLocalizedString(@"Share conversation link", nil);
-                    [cell.imageView setImage:[[UIImage imageNamed:@"share"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
-                    cell.imageView.tintColor = [UIColor colorWithRed:0.43 green:0.43 blue:0.45 alpha:1];
-                    
-                    return cell;
-                }
-                    break;
-                    
+
                 case kGuestActionResendInvitations:
                 {
                     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:resendInvitationsCellIdentifier];
@@ -2085,6 +2073,21 @@ typedef enum FileAction {
                     [cell.imageView setImage:[[UIImage imageNamed:@"message-text-lock"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
                     cell.imageView.tintColor = [UIColor colorWithRed:0.43 green:0.43 blue:0.45 alpha:1];
                     
+                    return cell;
+                }
+                    break;
+
+                case kConversationActionShareLink:
+                {
+                    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:shareLinkCellIdentifier];
+                    if (!cell) {
+                        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:shareLinkCellIdentifier];
+                    }
+
+                    cell.textLabel.text = NSLocalizedString(@"Share conversation link", nil);
+                    [cell.imageView setImage:[[UIImage imageNamed:@"share"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]];
+                    cell.imageView.tintColor = [UIColor colorWithRed:0.43 green:0.43 blue:0.45 alpha:1];
+
                     return cell;
                 }
                     break;
@@ -2387,9 +2390,6 @@ typedef enum FileAction {
                 case kGuestActionPassword:
                     [self showPasswordOptions];
                     break;
-                case kGuestActionShareLink:
-                    [self shareRoomLinkFromIndexPath:indexPath];
-                    break;
                 case kGuestActionResendInvitations:
                     [self resendInvitations];
                     break;
@@ -2405,6 +2405,9 @@ typedef enum FileAction {
             switch (action) {
                 case kConversationActionMessageExpiration:
                     [self presentMessageExpirationSelector];
+                    break;
+                case kConversationActionShareLink:
+                    [self shareRoomLinkFromIndexPath:indexPath];
                     break;
                 default:
                     break;

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -956,8 +956,9 @@ typedef enum FileAction {
 {
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
     NSString *joinConversationString = NSLocalizedString(@"Join the conversation at", nil);
-    if (_room.name && ![_room.name isEqualToString:@""]) {
-        joinConversationString = [NSString stringWithFormat:NSLocalizedString(@"Join the conversation %@ at", nil), [NSString stringWithFormat:@"\"%@\"", _room.name]];
+
+    if (_room.displayName && ![_room.displayName isEqualToString:@""]) {
+        joinConversationString = [NSString stringWithFormat:NSLocalizedString(@"Join the conversation %@ at", nil), [NSString stringWithFormat:@"\"%@\"", _room.displayName]];
     }
     NSString *shareMessage = [NSString stringWithFormat:@"%@ %@/index.php/call/%@", joinConversationString, activeAccount.server, _room.token];
     NSArray *items = @[shareMessage];

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -833,7 +833,8 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
     
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
     NSString *joinConversationString = NSLocalizedString(@"Join the conversation at", nil);
-    if (room.name && ![room.name isEqualToString:@""]) {
+    
+    if (room.displayName && ![room.displayName isEqualToString:@""]) {
         joinConversationString = [NSString stringWithFormat:NSLocalizedString(@"Join the conversation %@ at", nil), [NSString stringWithFormat:@"\"%@\"", room.name]];
     }
     NSString *shareMessage = [NSString stringWithFormat:@"%@ %@/index.php/call/%@", joinConversationString, activeAccount.server, room.token];
@@ -1023,10 +1024,11 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
         [notificationsAction setValue:[[UIImage imageNamed:@"notifications"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forKey:@"image"];
         [optionsActionSheet addAction:notificationsAction];
     }
+
     // Share link
-    if (room.isPublic) {
+    if (room.type != kNCRoomTypeChangelog) {
         // Share Link
-        UIAlertAction *shareLinkAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Share conversation link", nil)
+        UIAlertAction *shareLinkAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Share link", nil)
                                                                   style:UIAlertActionStyleDefault
                                                                 handler:^void (UIAlertAction *action) {
                                                                     [self shareLinkFromRoomAtIndexPath:indexPath];
@@ -1034,6 +1036,7 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
         [shareLinkAction setValue:[[UIImage imageNamed:@"share"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forKey:@"image"];
         [optionsActionSheet addAction:shareLinkAction];
     }
+
     // Room info
     UIAlertAction *roomInfoAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Conversation info", nil)
                                                              style:UIAlertActionStyleDefault

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -1307,10 +1307,10 @@
 "Share a file from your Nextcloud" = "Share a file from your Nextcloud";
 
 /* No comment provided by engineer. */
-"Share conversation link" = "Share conversation link";
+"Share current location" = "Share current location";
 
 /* No comment provided by engineer. */
-"Share current location" = "Share current location";
+"Share link" = "Share link";
 
 /* No comment provided by engineer. */
 "Share location" = "Share location";


### PR DESCRIPTION
As discussed with @nickvergessen, the share link option should always be available for conversations (except the changelog conversation).