### PR TITLE
Fix pick up call when phone is locked

### DIFF
--- a/NextcloudTalk/NCExternalSignalingController.h
+++ b/NextcloudTalk/NCExternalSignalingController.h
@@ -64,6 +64,7 @@ typedef void (^JoinRoomExternalSignalingCompletionBlock)(NSError *error);
 - (NSString *)getUserIdFromSessionId:(NSString *)sessionId;
 - (NSString *)getDisplayNameFromSessionId:(NSString *)sessionId;
 - (void)connect;
+- (void)forceConnect;
 - (void)disconnect;
 - (void)forceReconnect;
 

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -116,8 +116,18 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
 
 - (void)connect
 {
+    [self connect:NO];
+}
+
+- (void)forceConnect
+{
+    [self connect:YES];
+}
+
+- (void)connect:(BOOL)force
+{
     // Do not try to connect if the app is running in the background
-    if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) {
+    if (!force && [[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) {
         [NCUtils log:@"Trying to create websocket connection while app is in the background"];
         _disconnected = YES;
         return;

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -757,6 +757,13 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
             }
         }
 
+        // Make sure the external signaling contoller is connected.
+        // Could be that the call has been received while the app was inactive or in the background,
+        // so the external signaling controller might be disconnected at this point.
+        if ([extSignalingController disconnected]) {
+            [extSignalingController forceConnect];
+        }
+
         if (_chatViewController) {
             if ([chatViewControllerRoomToken isEqualToString:joiningRoomToken]) {
                 // We're in the chat of the room we want to start a call, so stop chat for now


### PR DESCRIPTION
This PR fixes the problem where the user is not connecting to the call when the call is picked up from the lock screen.
This is because the external signaling controller is not connected when the app is in the background.
With this PR we make sure we connect the external signaling controller before starting a call even if the app is running in the background.