### PR TITLE
Hide speaker button on iPads

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -162,7 +162,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(providerWantsToUpgradeToVideoCall:) name:CallKitManagerWantsToUpgradeToVideoCall object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioSessionDidChangeRoute:) name:AudioSessionDidChangeRouteNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioSessionDidActivate:) name:AudioSessionWasActivatedByProviderNotification object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioSessionDidChangeSpeaker:) name:AudioSessionDidChangeSpeakerIsActiveNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioSessionDidChangeRoutingInformation:) name:AudioSessionDidChangeRoutingInformationNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
     
@@ -463,7 +463,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
     [self adjustSpeakerButton];
 }
 
-- (void)audioSessionDidChangeSpeaker:(NSNotification *)notification
+- (void)audioSessionDidChangeRoutingInformation:(NSNotification *)notification
 {
     [self adjustSpeakerButton];
 

--- a/NextcloudTalk/NCAudioController.h
+++ b/NextcloudTalk/NCAudioController.h
@@ -27,7 +27,7 @@
 
 extern NSString * const AudioSessionDidChangeRouteNotification;
 extern NSString * const AudioSessionWasActivatedByProviderNotification;
-extern NSString * const AudioSessionDidChangeSpeakerIsActiveNotification;
+extern NSString * const AudioSessionDidChangeRoutingInformationNotification;
 
 @interface NCAudioController : NSObject <RTCAudioSessionDelegate>
 

--- a/NextcloudTalk/NCAudioController.h
+++ b/NextcloudTalk/NCAudioController.h
@@ -33,6 +33,7 @@ extern NSString * const AudioSessionDidChangeSpeakerIsActiveNotification;
 
 @property (nonatomic, strong) RTCAudioSession *rtcAudioSession;
 @property (nonatomic, assign) BOOL isSpeakerActive;
+@property (nonatomic, assign) NSInteger numberOfAvailableInputs;
 
 + (instancetype)sharedInstance;
 
@@ -41,5 +42,6 @@ extern NSString * const AudioSessionDidChangeSpeakerIsActiveNotification;
 - (void)disableAudioSession;
 - (void)providerDidActivateAudioSession:(AVAudioSession *)audioSession;
 - (void)providerDidDeactivateAudioSession:(AVAudioSession *)audioSession;
+- (BOOL)isAudioRouteChangeable;
 
 @end

--- a/NextcloudTalk/NCAudioController.m
+++ b/NextcloudTalk/NCAudioController.m
@@ -28,7 +28,7 @@
 
 NSString * const AudioSessionDidChangeRouteNotification             = @"AudioSessionDidChangeRouteNotification";
 NSString * const AudioSessionWasActivatedByProviderNotification     = @"AudioSessionWasActivatedByProviderNotification";
-NSString * const AudioSessionDidChangeSpeakerIsActiveNotification   = @"AudioSessionDidChangeSpeakerIsActiveNotification";
+NSString * const AudioSessionDidChangeRoutingInformationNotification   = @"AudioSessionDidChangeRoutingInformationNotification";
 
 @implementation NCAudioController
 
@@ -145,7 +145,7 @@ NSString * const AudioSessionDidChangeSpeakerIsActiveNotification   = @"AudioSes
         self.isSpeakerActive = NO;
     }
 
-    [[NSNotificationCenter defaultCenter] postNotificationName:AudioSessionDidChangeSpeakerIsActiveNotification
+    [[NSNotificationCenter defaultCenter] postNotificationName:AudioSessionDidChangeRoutingInformationNotification
                                                         object:self
                                                       userInfo:nil];
 }


### PR DESCRIPTION
On iPads we can't switch between ear piece and speaker, so the speaker button only makes sense if there is another route available (bluetooth headset for example). In other cases we can hide the button on iPads