### PR TITLE
Allow to make a websocket connection while the app is running in the background if we are in a call

### DIFF
--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -126,8 +126,9 @@ static NSTimeInterval kWebSocketTimeoutInterval = 15;
 
 - (void)connect:(BOOL)force
 {
-    // Do not try to connect if the app is running in the background
-    if (!force && [[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) {
+    BOOL forceConnect = force || [NCRoomsManager sharedInstance].callViewController;
+    // Do not try to connect if the app is running in the background (unless forcing a connection or in a call)
+    if (!forceConnect && [[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) {
         [NCUtils log:@"Trying to create websocket connection while app is in the background"];
         _disconnected = YES;
         return;


### PR DESCRIPTION
This fixes the scenario where the websocket connection is lost and we are in a call while the app is in the background.
Without this PR the app doesn't try to reconnect because it's running in the background.
With this PR the app will try to reconnect because we are currently in a call (no matter that the app is running in the background).