### PR TITLE
Harden NCSettingsController against race conditions

### DIFF
--- a/NextcloudTalk/DiagnosticsTableViewController.swift
+++ b/NextcloudTalk/DiagnosticsTableViewController.swift
@@ -107,7 +107,7 @@ class DiagnosticsTableViewController: UITableViewController {
         self.account = account
 
         self.serverCapabilities = NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: account.accountId)
-        self.signalingConfiguration = NCSettingsController.sharedInstance().signalingConfigutations[account.accountId] as? NSDictionary
+        self.signalingConfiguration = NCSettingsController.sharedInstance().signalingConfigurations[account.accountId] as? NSDictionary
         self.externalSignalingController = NCSettingsController.sharedInstance().externalSignalingController(forAccountId: account.accountId)
         self.signalingVersion = NCAPIController.sharedInstance().signalingAPIVersion(for: account)
 

--- a/NextcloudTalk/NCConnectionController.m
+++ b/NextcloudTalk/NCConnectionController.m
@@ -110,7 +110,7 @@ NSString * const NCConnectionStateHasChangedNotification    = @"NCConnectionStat
         [[NCUserInterfaceController sharedInstance] presentLoginViewController];
     } else if (!activeAccount.userId || !activeAccount.userDisplayName) {
         [self setAppState:kAppStateMissingUserProfile];
-        [[NCSettingsController sharedInstance] getUserProfileWithCompletionBlock:^(NSError *error) {
+        [[NCSettingsController sharedInstance] getUserProfileForAccountId:activeAccount.accountId withCompletionBlock:^(NSError *error) {
             if (error) {
                 [self notifyAppState];
             } else {
@@ -119,22 +119,23 @@ NSString * const NCConnectionStateHasChangedNotification    = @"NCConnectionStat
         }];
     } else if (!activeAccountSignalingConfig) {
         [self setAppState:kAppStateMissingServerCapabilities];
-        [[NCSettingsController sharedInstance] getCapabilitiesWithCompletionBlock:^(NSError *error) {
+        [[NCSettingsController sharedInstance] getCapabilitiesForAccountId:activeAccount.accountId withCompletionBlock:^(NSError *error) {
             if (error) {
                 [self notifyAppState];
-            } else {
-                [self setAppState:kAppStateMissingSignalingConfiguration];
-                [[NCSettingsController sharedInstance] getSignalingConfigurationWithCompletionBlock:^(NSError *error) {
-                    if (error) {
-                        [self notifyAppState];
-                    } else {
-                        // SetSignalingConfiguration should be called just once
-                        TalkAccount *account = [[NCDatabaseManager sharedInstance] activeAccount];
-                        [[NCSettingsController sharedInstance] setSignalingConfigurationForAccountId:account.accountId];
-                        [self checkAppState];
-                    }
-                }];
+                return;
             }
+
+            [self setAppState:kAppStateMissingSignalingConfiguration];
+            [[NCSettingsController sharedInstance] getSignalingConfigurationForAccountId:activeAccount.accountId withCompletionBlock:^(NSError *error) {
+                if (error) {
+                    [self notifyAppState];
+                    return;
+                }
+
+                // SetSignalingConfiguration should be called just once
+                [[NCSettingsController sharedInstance] setSignalingConfigurationForAccountId:activeAccount.accountId];
+                [self checkAppState];
+            }];
         }];
     } else {
         [self setAppState:kAppStateReady];

--- a/NextcloudTalk/NCConnectionController.m
+++ b/NextcloudTalk/NCConnectionController.m
@@ -103,7 +103,7 @@ NSString * const NCConnectionStateHasChangedNotification    = @"NCConnectionStat
 - (void)checkAppState
 {
     TalkAccount *activeAccount                  = [[NCDatabaseManager sharedInstance] activeAccount];
-    NSDictionary *activeAccountSignalingConfig  = [[[NCSettingsController sharedInstance] signalingConfigutations] objectForKey:activeAccount.accountId];
+    NSDictionary *activeAccountSignalingConfig  = [[[NCSettingsController sharedInstance] signalingConfigurations] objectForKey:activeAccount.accountId];
     
     if (!activeAccount.server || !activeAccount.user) {
         [self setAppState:kAppStateNotServerProvided];

--- a/NextcloudTalk/NCSettingsController.h
+++ b/NextcloudTalk/NCSettingsController.h
@@ -68,10 +68,10 @@ typedef enum NCPreferredFileSorting {
 + (instancetype)sharedInstance;
 - (void)addNewAccountForUser:(NSString *)user withToken:(NSString *)token inServer:(NSString *)server;
 - (void)setActiveAccountWithAccountId:(NSString *)accountId;
-- (void)getUserProfileWithCompletionBlock:(UpdatedProfileCompletionBlock)block;
+- (void)getUserProfileForAccountId:(NSString *)accountId withCompletionBlock:(UpdatedProfileCompletionBlock)block;
 - (void)logoutAccountWithAccountId:(NSString *)accountId withCompletionBlock:(LogoutCompletionBlock)block;
-- (void)getCapabilitiesWithCompletionBlock:(GetCapabilitiesCompletionBlock)block;
-- (void)getSignalingConfigurationWithCompletionBlock:(GetSignalingConfigCompletionBlock)block;
+- (void)getCapabilitiesForAccountId:(NSString *)accountId withCompletionBlock:(GetCapabilitiesCompletionBlock)block;
+- (void)getSignalingConfigurationForAccountId:(NSString *)accountId withCompletionBlock:(GetSignalingConfigCompletionBlock)block;
 - (void)setSignalingConfigurationForAccountId:(NSString *)accountId;
 - (NCExternalSignalingController *)externalSignalingControllerForAccountId:(NSString *)accountId;
 - (void)connectDisconnectedExternalSignalingControllers;

--- a/NextcloudTalk/NCSettingsController.h
+++ b/NextcloudTalk/NCSettingsController.h
@@ -62,7 +62,7 @@ typedef enum NCPreferredFileSorting {
 
 @property (nonatomic, strong) NSMutableArray *supportedBrowsers;
 @property (nonatomic, copy) ARDSettingsModel *videoSettingsModel;
-@property (nonatomic, strong) NSMutableDictionary *signalingConfigutations; // accountId -> signalingConfigutation
+@property (nonatomic, strong) NSMutableDictionary *signalingConfigurations; // accountId -> signalingConfigutation
 @property (nonatomic, strong) NSMutableDictionary *externalSignalingControllers; // accountId -> externalSignalingController
 
 + (instancetype)sharedInstance;

--- a/NextcloudTalk/NCSettingsController.m
+++ b/NextcloudTalk/NCSettingsController.m
@@ -105,7 +105,7 @@ NSString * const kDidReceiveCallsFromOldAccount = @"receivedCallsFromOldAccount"
     self = [super init];
     if (self) {
         _videoSettingsModel = [[ARDSettingsModel alloc] init];
-        _signalingConfigutations = [NSMutableDictionary new];
+        _signalingConfigurations = [NSMutableDictionary new];
         _externalSignalingControllers = [NSMutableDictionary new];
         
         [self configureDatabase];
@@ -436,7 +436,7 @@ NSString * const kDidReceiveCallsFromOldAccount = @"receivedCallsFromOldAccount"
             NSDictionary *signalingConfiguration = [[settings objectForKey:@"ocs"] objectForKey:@"data"];
 
             if (signalingConfiguration && account && account.accountId) {
-                [self->_signalingConfigutations setObject:signalingConfiguration forKey:account.accountId];
+                [self->_signalingConfigurations setObject:signalingConfiguration forKey:account.accountId];
 
                 if (block) {
                     block(nil);
@@ -458,7 +458,7 @@ NSString * const kDidReceiveCallsFromOldAccount = @"receivedCallsFromOldAccount"
 // SetSignalingConfiguration should be called just once
 - (void)setSignalingConfigurationForAccountId:(NSString *)accountId
 {
-    NSDictionary *signalingConfiguration = [_signalingConfigutations objectForKey:accountId];
+    NSDictionary *signalingConfiguration = [_signalingConfigurations objectForKey:accountId];
     NSString *externalSignalingTicket = [signalingConfiguration objectForKey:@"ticket"];
     NSString *externalSignalingServer = nil;
     

--- a/NextcloudTalk/NCUserInterfaceController.m
+++ b/NextcloudTalk/NCUserInterfaceController.m
@@ -457,7 +457,8 @@
     [_mainViewController dismissViewControllerAnimated:YES completion:^{
         [[NCConnectionController sharedInstance] checkAppState];
         // Get server capabilities again to check if user is allowed to use Nextcloud Talk
-        [[NCSettingsController sharedInstance] getCapabilitiesWithCompletionBlock:nil];
+        TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+        [[NCSettingsController sharedInstance] getCapabilitiesForAccountId:activeAccount.accountId withCompletionBlock:nil];
     }];
 }
 
@@ -468,7 +469,8 @@
     [_mainViewController dismissViewControllerAnimated:YES completion:^{
         [[NCConnectionController sharedInstance] checkAppState];
         // Get server capabilities again to check if user is allowed to use Nextcloud Talk
-        [[NCSettingsController sharedInstance] getCapabilitiesWithCompletionBlock:nil];
+        TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+        [[NCSettingsController sharedInstance] getCapabilitiesForAccountId:activeAccount.accountId withCompletionBlock:nil];
     }];
 }
 

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -1638,7 +1638,7 @@ typedef enum FileAction {
         case kRoomInfoSectionSIP:
             if (indexPath.row == kSIPActionSIPInfo) {
                 TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
-                NSDictionary *activeAccountSignalingConfig  = [[[NCSettingsController sharedInstance] signalingConfigutations] objectForKey:activeAccount.accountId];
+                NSDictionary *activeAccountSignalingConfig  = [[[NCSettingsController sharedInstance] signalingConfigurations] objectForKey:activeAccount.accountId];
                 return [self heightForDescription:[activeAccountSignalingConfig objectForKey:@"sipDialinInfo"]];
             }
             break;
@@ -2188,7 +2188,7 @@ typedef enum FileAction {
                         cell = [[RoomDescriptionTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:kRoomDescriptionCellIdentifier];
                     }
                     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
-                    NSDictionary *activeAccountSignalingConfig  = [[[NCSettingsController sharedInstance] signalingConfigutations] objectForKey:activeAccount.accountId];
+                    NSDictionary *activeAccountSignalingConfig  = [[[NCSettingsController sharedInstance] signalingConfigurations] objectForKey:activeAccount.accountId];
                     cell.textView.text = [activeAccountSignalingConfig objectForKey:@"sipDialinInfo"];
                     cell.selectionStyle = UITableViewCellSelectionStyleNone;
                     

--- a/NextcloudTalk/SettingsTableViewController.swift
+++ b/NextcloudTalk/SettingsTableViewController.swift
@@ -200,7 +200,8 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
     // MARK: User Profile
 
     func refreshUserProfile() {
-        NCSettingsController.sharedInstance().getUserProfile { _ in
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        NCSettingsController.sharedInstance().getUserProfile(forAccountId: activeAccount.accountId) { _ in
             self.tableView.reloadData()
         }
         self.getActiveUserStatus()
@@ -268,7 +269,8 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
     // MARK: User phone number
 
     func checkUserPhoneNumber() {
-        NCSettingsController.sharedInstance().getUserProfile { _ in
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        NCSettingsController.sharedInstance().getUserProfile(forAccountId: activeAccount.accountId) { _ in
             let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
             if activeAccount.phone.isEmpty {
                 self.presentSetPhoneNumberDialog()
@@ -435,9 +437,11 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
 
     @objc func readStatusValueChanged(_ sender: Any?) {
         readStatusSwitch.isEnabled = false
-        NCAPIController.sharedInstance().setReadStatusPrivacySettingEnabled(!readStatusSwitch.isOn, for: NCDatabaseManager.sharedInstance().activeAccount()) { error in
+        let account = NCDatabaseManager.sharedInstance().activeAccount()
+
+        NCAPIController.sharedInstance().setReadStatusPrivacySettingEnabled(!readStatusSwitch.isOn, for: account) { error in
             if error == nil {
-                NCSettingsController.sharedInstance().getCapabilitiesWithCompletionBlock { error in
+                NCSettingsController.sharedInstance().getCapabilitiesForAccountId(account.accountId) { error in
                     if error == nil {
                         self.readStatusSwitch.isEnabled = true
                         self.tableView.reloadData()

--- a/NextcloudTalk/UserProfileTableViewController+Utils.swift
+++ b/NextcloudTalk/UserProfileTableViewController+Utils.swift
@@ -38,7 +38,7 @@ extension UserProfileTableViewController {
     }
 
     func refreshUserProfile() {
-        NCSettingsController.sharedInstance().getUserProfile { _ in
+        NCSettingsController.sharedInstance().getUserProfile(forAccountId: account.accountId) { _ in
             self.account = NCDatabaseManager.sharedInstance().activeAccount()
             self.refreshProfileTableView()
         }


### PR DESCRIPTION
I ended up multiple times with the wrong signaling settings or wrong theming capabilities (So theming of account A was visible at account B). Granted, this is the exception and not the rule. Looking at the code it can happen that a request is done on account A but we switched to account B when the request finished (bad connection for example). In this case we would use the active account (now B in this case) to update the settings we just received (from account A). 