### PR TITLE
Show a toast when a non-moderator taps the recording icon

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1513,6 +1513,9 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
 - (IBAction)videoRecordingButtonPressed:(id)sender
 {
     if (![_room canModerate]) {
+        NSString *notificationText = NSLocalizedString(@"This call is being recorded", nil);
+        [[JDStatusBarNotificationPresenter sharedPresenter] presentWithText:notificationText dismissAfterDelay:7.0 includedStyle:JDStatusBarNotificationIncludedStyleDark];
+        
         return;
     }
 

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -1412,6 +1412,9 @@
 "There is no account for user %@ in server %@ configured in this app." = "There is no account for user %1$@ in server %2$@ configured in this app.";
 
 /* No comment provided by engineer. */
+"This call is being recorded" = "This call is being recorded";
+
+/* No comment provided by engineer. */
 "This conversation is read-only" = "This conversation is read-only";
 
 /* The meeting start time will be displayed after this text e.g (This meeting is scheduled for tomorrow at 10:00) */


### PR DESCRIPTION
When a non-moderator taps the recording icon, nothing happens. Now we show a toast to inform the user that the call is being recorded.