### PR TITLE
Use native UIMenu for account picker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "ThirdParty/SlackTextViewController"]
 	path = ThirdParty/SlackTextViewController
 	url = https://github.com/Ivansss/SlackTextViewController.git
-[submodule "ThirdParty/FTPopOverMenu"]
-	path = ThirdParty/FTPopOverMenu
-	url = https://github.com/Ivansss/FTPopOverMenu.git

--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -87,7 +87,6 @@
 		2C1D13A3253760EE00EC0533 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2C1D13A1253760EE00EC0533 /* LaunchScreen.xib */; };
 		2C1EF36B25505DCE007C9768 /* NCNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C1EF36A25505DCE007C9768 /* NCNavigationController.m */; };
 		2C1EF36D25505DCE007C9768 /* NCNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C1EF36A25505DCE007C9768 /* NCNavigationController.m */; };
-		2C2026A0236832D300DFC89B /* FTPopOverMenu.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C20269F236832D300DFC89B /* FTPopOverMenu.m */; };
 		2C2026A52369F47400DFC89B /* AccountTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2C2026A32369F47400DFC89B /* AccountTableViewCell.xib */; };
 		2C2A788E2359CC8800EEB797 /* NCAppBranding.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C2A788D2359CC8800EEB797 /* NCAppBranding.m */; };
 		2C2E64251F3462AF00D39CE8 /* NCSignalingMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C2E64241F3462AF00D39CE8 /* NCSignalingMessage.m */; };
@@ -2022,7 +2021,6 @@
 				2C78EF951F7E70EB008AFA74 /* NCPeerConnection.m in Sources */,
 				2C06BF6C20AEB0030031EB46 /* RoundedNumberView.m in Sources */,
 				2CEDA88926F10BB20044552B /* UserStatusMessageViewController.swift in Sources */,
-				2C2026A0236832D300DFC89B /* FTPopOverMenu.m in Sources */,
 				2CC007C520D90AE50096D91F /* RoomNameTableViewCell.m in Sources */,
 				2C78EFA01F828C41008AFA74 /* CallViewController.m in Sources */,
 				DA1AEFC3270F1FA90088E519 /* DateLabelCustom.swift in Sources */,

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -29,7 +29,6 @@
 #import "NCChatViewController.h"
 
 #import "AFImageDownloader.h"
-#import "FTPopOverMenu.h"
 #import "JDStatusBarNotification.h"
 #import "NSDate+DateTools.h"
 #import "UIImageView+AFNetworking.h"

--- a/NextcloudTalk/NCSettingsController.m
+++ b/NextcloudTalk/NCSettingsController.m
@@ -179,12 +179,7 @@ NSString * const kDidReceiveCallsFromOldAccount = @"receivedCallsFromOldAccount"
         CGSize imageSize = CGSizeMake(128, 128);
         UIImage *accountImage = [[NCAPIController sharedInstance] userProfileImageForAccount:account withStyle:UIUserInterfaceStyleLight andSize:imageSize];
         if (accountImage) {
-            UIGraphicsBeginImageContextWithOptions(imageSize, NO, [UIScreen mainScreen].scale);
-            CGRect rect = CGRectMake(0, 0, imageSize.width, imageSize.height);
-            [[UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:imageSize.height] addClip];
-            [accountImage drawInRect:rect];
-            accountImage = UIGraphicsGetImageFromCurrentImageContext();
-            UIGraphicsEndImageContext();
+            accountImage = [NCUtils roundedImageFromImage:accountImage];
         }
         DataAccounts *accountData = [[DataAccounts alloc] initWithUrl:account.server user:account.user name:account.userDisplayName image:accountImage];
         [accounts addObject:accountData];

--- a/NextcloudTalk/NCUtils.h
+++ b/NextcloudTalk/NCUtils.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)sha1FromString:(NSString *)string;
 
 + (UIImage *)blurImageFromImage:(UIImage *)image;
++ (UIImage *)roundedImageFromImage:(UIImage *)image;
 
 + (UIColor *)searchbarBGColorForColor:(UIColor *)color;
 

--- a/NextcloudTalk/NCUtils.m
+++ b/NextcloudTalk/NCUtils.m
@@ -259,6 +259,19 @@ static NSString *const nextcloudScheme = @"nextcloud:";
     return resultImage;
 }
 
++ (UIImage *)roundedImageFromImage:(UIImage *)image
+{
+    CGSize imageSize = image.size;
+    UIGraphicsBeginImageContextWithOptions(imageSize, NO, [UIScreen mainScreen].scale);
+    CGRect rect = CGRectMake(0, 0, imageSize.width, imageSize.height);
+    [[UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:imageSize.height] addClip];
+    [image drawInRect:rect];
+    UIImage *resultImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+
+    return resultImage;
+}
+
 + (UIColor *)searchbarBGColorForColor:(UIColor *)color
 {
     CGFloat luma = [self calculateLumaFromColor:color];


### PR DESCRIPTION
Fixes #653 

This PR removes FTPopOverMenu as a dependency and uses UIMenu directly.