### PR TITLE
Send current media state and nick repeatedly

### DIFF
--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -954,7 +954,7 @@ static NSString * const kNCVideoTrackKind = @"video";
         [self->_sendCurrentStateTimer invalidate];
         self->_sendCurrentStateTimer = nil;
 
-        [self sendCurrentStateWithTimeInterval:0];
+        [self sendCurrentStateWithTimer:nil];
     });
 }
 
@@ -966,7 +966,7 @@ static NSString * const kNCVideoTrackKind = @"video";
     });
 }
 
-- (void)sendCurrentStateWithTimeInterval:(NSTimer *)timer
+- (void)sendCurrentStateWithTimer:(NSTimer *)timer
 {
     __block NSInteger interval = [[timer.userInfo objectForKey:@"interval"] integerValue];
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -984,7 +984,7 @@ static NSString * const kNCVideoTrackKind = @"video";
         }
 
         NSDictionary *userInfo = @{@"interval" : @(interval)};
-        self->_sendCurrentStateTimer = [NSTimer scheduledTimerWithTimeInterval:interval target:self selector:@selector(sendCurrentStateWithTimeInterval:) userInfo:userInfo repeats:NO];
+        self->_sendCurrentStateTimer = [NSTimer scheduledTimerWithTimeInterval:interval target:self selector:@selector(sendCurrentStateWithTimer:) userInfo:userInfo repeats:NO];
     });
 }
 

--- a/NextcloudTalk/NCPeerConnection.h
+++ b/NextcloudTalk/NCPeerConnection.h
@@ -38,7 +38,7 @@
 - (void)peerConnection:(NCPeerConnection *)peerConnection didChangeIceConnectionState:(RTCIceConnectionState)newState;
 
 /** Status data channel has been opened. */
-- (void)peerConnectionDidOpenStatusDataChannel:(NCPeerConnection *)peerConnection;
+//- (void)peerConnectionDidOpenStatusDataChannel:(NCPeerConnection *)peerConnection;
 
 /** Message received from status data channel has been opened. */
 - (void)peerConnection:(NCPeerConnection *)peerConnection didReceiveStatusDataChannelMessage:(NSString *)type;

--- a/NextcloudTalk/NCPeerConnection.m
+++ b/NextcloudTalk/NCPeerConnection.m
@@ -354,11 +354,11 @@
 - (void)dataChannelDidChangeState:(RTCDataChannel *)dataChannel
 {
     [[WebRTCCommon shared] dispatch:^{
-        NSLog(@"Data cahnnel '%@' did change state: %ld", dataChannel.label, (long)dataChannel.readyState);
+        NSLog(@"Data channel '%@' did change state: %ld", dataChannel.label, (long)dataChannel.readyState);
         
-        if (dataChannel.readyState == RTCDataChannelStateOpen && [dataChannel.label isEqualToString:@"status"]) {
-            [self.delegate peerConnectionDidOpenStatusDataChannel:self];
-        }
+//        if (dataChannel.readyState == RTCDataChannelStateOpen && [dataChannel.label isEqualToString:@"status"]) {
+//            [self.delegate peerConnectionDidOpenStatusDataChannel:self];
+//        }
     }];
 }
 

--- a/NextcloudTalk/NCSignalingMessage.h
+++ b/NextcloudTalk/NCSignalingMessage.h
@@ -105,17 +105,32 @@ typedef enum {
 
 @interface NCMuteMessage : NCSignalingMessage
 
+- (instancetype)initWithFrom:(NSString *)from
+                      sendTo:(NSString *)to
+                 withPayload:(NSDictionary *)payload
+                 forRoomType:(NSString *)roomType;
+
 - (instancetype)initWithValues:(NSDictionary *)values;
 
 @end
 
 @interface NCUnmuteMessage : NCSignalingMessage
 
+- (instancetype)initWithFrom:(NSString *)from
+                      sendTo:(NSString *)to
+                 withPayload:(NSDictionary *)payload
+                 forRoomType:(NSString *)roomType;
+
 - (instancetype)initWithValues:(NSDictionary *)values;
 
 @end
 
 @interface NCNickChangedMessage : NCSignalingMessage
+
+- (instancetype)initWithFrom:(NSString *)from
+                      sendTo:(NSString *)to
+                 withPayload:(NSDictionary *)payload
+                 forRoomType:(NSString *)roomType;
 
 - (instancetype)initWithValues:(NSDictionary *)values;
 

--- a/NextcloudTalk/NCSignalingMessage.m
+++ b/NextcloudTalk/NCSignalingMessage.m
@@ -49,6 +49,7 @@ static NSString * const kNCSignalingMessagePayloadKey = @"payload";
 static NSString * const kNCSignalingMessageRoomTypeKey = @"roomType";
 static NSString * const kNCSignalingMessageNickKey = @"nick";
 static NSString * const kNCSignalingMessageStatusKey = @"status";
+static NSString * const kNCSignalingMessageNameKey = @"name";
 
 static NSString * const kNCSignalingMessageTypeOfferKey = @"offer";
 static NSString * const kNCSignalingMessageTypeAnswerKey = @"answer";
@@ -483,6 +484,16 @@ NSString *const kRoomTypeScreen = @"screen";
 
 @implementation NCMuteMessage
 
+- (instancetype)initWithFrom:(NSString *)from sendTo:(NSString *)to withPayload:(NSDictionary *)payload forRoomType:(NSString *)roomType {
+
+    return [super initWithFrom:from
+                            to:to
+                           sid:[NCSignalingMessage getMessageSid]
+                          type:kNCSignalingMessageTypeMuteKey
+                       payload:payload
+                      roomType:roomType];
+}
+
 - (instancetype)initWithValues:(NSDictionary *)values {
     NSDictionary *dataDict = [[NSDictionary alloc] initWithDictionary:values];
     NSDictionary *payload = [dataDict objectForKey:kNCSignalingMessagePayloadKey];
@@ -502,6 +513,54 @@ NSString *const kRoomTypeScreen = @"screen";
                       roomType:[dataDict objectForKey:kNCSignalingMessageRoomTypeKey]];
 }
 
+- (NSData *)JSONData {
+    NSError *error = nil;
+    NSData *data =
+    [NSJSONSerialization dataWithJSONObject:[self functionDict]
+                                    options:NSJSONWritingPrettyPrinted
+                                      error:&error];
+    if (error) {
+        RTCLogError(@"Error serializing JSON: %@", error);
+        return nil;
+    }
+
+    return data;
+}
+
+- (NSString *)functionJSONSerialization
+{
+    NSError *error;
+    NSString *jsonString = nil;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:[self functionDict]
+                                                       options:0
+                                                         error:&error];
+
+    if (! jsonData) {
+        NSLog(@"Error serializing JSON: %@", error);
+    } else {
+        jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    }
+
+    return jsonString;
+}
+
+- (NSDictionary *)messageDict {
+    return @{
+             kNCSignalingMessageEventKey: kNCSignalingMessageKey,
+             kNCSignalingMessageFunctionKey: [self functionJSONSerialization],
+             kNCSignalingMessageSessionIdKey: self.from
+             };
+}
+
+- (NSDictionary *)functionDict {
+    return @{
+             kNCSignalingMessageToKey: self.to,
+             kNCSignalingMessageRoomTypeKey: self.roomType,
+             kNCSignalingMessageTypeKey: self.type,
+             kNCSignalingMessagePayloadKey: self.payload,
+             };
+}
+
 - (NCSignalingMessageType)messageType {
     return kNCSignalingMessageTypeMute;
 }
@@ -509,6 +568,16 @@ NSString *const kRoomTypeScreen = @"screen";
 @end
 
 @implementation NCUnmuteMessage
+
+- (instancetype)initWithFrom:(NSString *)from sendTo:(NSString *)to withPayload:(NSDictionary *)payload forRoomType:(NSString *)roomType {
+
+    return [super initWithFrom:from
+                            to:to
+                           sid:[NCSignalingMessage getMessageSid]
+                          type:kNCSignalingMessageTypeUnmuteKey
+                       payload:payload
+                      roomType:roomType];
+}
 
 - (instancetype)initWithValues:(NSDictionary *)values {
     NSDictionary *dataDict = [[NSDictionary alloc] initWithDictionary:values];
@@ -529,6 +598,54 @@ NSString *const kRoomTypeScreen = @"screen";
                       roomType:[dataDict objectForKey:kNCSignalingMessageRoomTypeKey]];
 }
 
+- (NSData *)JSONData {
+    NSError *error = nil;
+    NSData *data =
+    [NSJSONSerialization dataWithJSONObject:[self functionDict]
+                                    options:NSJSONWritingPrettyPrinted
+                                      error:&error];
+    if (error) {
+        RTCLogError(@"Error serializing JSON: %@", error);
+        return nil;
+    }
+
+    return data;
+}
+
+- (NSString *)functionJSONSerialization
+{
+    NSError *error;
+    NSString *jsonString = nil;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:[self functionDict]
+                                                       options:0
+                                                         error:&error];
+
+    if (! jsonData) {
+        NSLog(@"Error serializing JSON: %@", error);
+    } else {
+        jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    }
+
+    return jsonString;
+}
+
+- (NSDictionary *)messageDict {
+    return @{
+             kNCSignalingMessageEventKey: kNCSignalingMessageKey,
+             kNCSignalingMessageFunctionKey: [self functionJSONSerialization],
+             kNCSignalingMessageSessionIdKey: self.from
+             };
+}
+
+- (NSDictionary *)functionDict {
+    return @{
+             kNCSignalingMessageToKey: self.to,
+             kNCSignalingMessageRoomTypeKey: self.roomType,
+             kNCSignalingMessageTypeKey: self.type,
+             kNCSignalingMessagePayloadKey: self.payload,
+             };
+}
+
 - (NCSignalingMessageType)messageType {
     return kNCSignalingMessageTypeUnmute;
 }
@@ -536,6 +653,16 @@ NSString *const kRoomTypeScreen = @"screen";
 @end
 
 @implementation NCNickChangedMessage
+
+- (instancetype)initWithFrom:(NSString *)from sendTo:(NSString *)to withPayload:(NSDictionary *)payload forRoomType:(NSString *)roomType {
+
+    return [super initWithFrom:from
+                            to:to
+                           sid:[NCSignalingMessage getMessageSid]
+                          type:kNCSignalingMessageTypeNickChangedKey
+                       payload:payload
+                      roomType:roomType];
+}
 
 - (instancetype)initWithValues:(NSDictionary *)values {
     NSDictionary *dataDict = [[NSDictionary alloc] initWithDictionary:values];


### PR DESCRIPTION
Send nick and current media state repeatedly after a new peer connection is established.
Also send if view signaling message when an external signaling server is used.
This PR fixes the problem of wrong state showed for Talk iOS users in some calls.