### PR TITLE
Add sanity check for update participants notification

### DIFF
--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -535,8 +535,14 @@ NSString * const NCExternalSignalingControllerDidUpdateParticipantsNotification 
         [self.delegate externalSignalingController:self didReceivedParticipantListMessage:updateDict];
 
         NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
-        [userInfo setObject:[updateDict objectForKey:@"roomid"] forKey:@"roomToken"];
-        [userInfo setObject:[updateDict objectForKey:@"users"] forKey:@"users"];
+        NSString *roomToken = [updateDict objectForKey:@"roomid"];
+        if (roomToken){
+            [userInfo setObject:roomToken forKey:@"roomToken"];
+        }
+        NSArray *users = [updateDict objectForKey:@"users"];
+        if (users) {
+            [userInfo setObject:users forKey:@"users"];
+        }
         [[NSNotificationCenter defaultCenter] postNotificationName:NCExternalSignalingControllerDidUpdateParticipantsNotification
                                                             object:self
                                                           userInfo:userInfo];


### PR DESCRIPTION
Not all room participants events contain `roomid` or `users`, so we need to check those values before adding them to `userinfo` dictionary.
This PR fixes app crash when receiving a room participants event for leaving the call (when a moderator presses "End call for everyone")