### PR TITLE
Update unread marker correctly

### DIFF
--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -625,7 +625,7 @@ NSString * const NCChatControllerDidReceiveCallEndedMessageNotification         
                 
                 for (NCChatMessage *message in storedMessages) {
                     // Update the current room with the new message
-                    if (message.messageId == lastKnownMessage && message.timestamp > self->_room.lastActivity && !message.isUpdateMessage) {
+                    if (message.messageId == lastKnownMessage && message.timestamp >= self->_room.lastActivity && !message.isUpdateMessage) {
                         self->_room.lastActivity = message.timestamp;
                         [[NCRoomsManager sharedInstance] updateLastMessage:message withNoUnreadMessages:YES forRoom:self->_room];
                     }


### PR DESCRIPTION
Fixes #1123

In `startReceivingChatMessagesFromMessagesId` we only check for `message.timestamp > _room.lastActivity`, in all other places (`getInitialChatHistory` for example) we check for `>=`. When we already received a room update, we won't mark it as read anymore, since the `lastActivity` is equal to the processed message, but actually we want to update it even if the timestamps are equal, to remove the unread marker.