### PR TITLE
Fix user profile image regression

### DIFF
--- a/NextcloudTalk/NCSettingsController.m
+++ b/NextcloudTalk/NCSettingsController.m
@@ -337,7 +337,9 @@ NSString * const kDidReceiveCallsFromOldAccount = @"receivedCallsFromOldAccount"
             managedActiveAccount.avatarScope = [userProfile objectForKey:kUserProfileAvatarScope];
 
             [realm commitWriteTransaction];
-            [[NCAPIController sharedInstance] saveProfileImageForAccount:account];
+
+            TalkAccount *unmanagedUpdatedAccount = [[TalkAccount alloc] initWithValue:managedActiveAccount];
+            [[NCAPIController sharedInstance] saveProfileImageForAccount:unmanagedUpdatedAccount];
             
             if (block) {
                 block(nil);


### PR DESCRIPTION
A regression was introduced in #1113 
`saveProfileImageForAccount` needs to be called with the updated account (the one that contains the userId)