### PR TITLE
Remove unneeded constraint for the profile button

### DIFF
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -737,11 +737,6 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
     
     _settingsButton = [[UIBarButtonItem alloc] initWithCustomView:profileButton];
     [self setUnreadMessageForInactiveAccountsIndicator];
-
-    NSLayoutConstraint *width = [_settingsButton.customView.widthAnchor constraintEqualToConstant:30];
-    width.active = YES;
-    NSLayoutConstraint *height = [_settingsButton.customView.heightAnchor constraintEqualToConstant:30];
-    height.active = YES;
     
     [self.navigationItem setLeftBarButtonItem:_settingsButton];
 }


### PR DESCRIPTION
This fixes a new animation introduced recently with the use of UIMenu. In my tests these constraints were not needed