### PR TITLE
Hide keyboard when showing attachment options

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1251,6 +1251,9 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 
 - (void)didPressLeftButton:(id)sender
 {
+    // The keyboard will be hidden when the action menu is shown. Depending on what
+    // attachment is shared, not resigning might lead to a currupted chat view
+    [self.textView resignFirstResponder];
     [self presentAttachmentsOptions];
     [super didPressLeftButton:sender];
 }


### PR DESCRIPTION
Fixes #810 

With iOS 16 something else changed, if you 
* Open they keyboard
* Tap the left button to show attachment options
* Share a photo

The input will now be higher than it should be. When you share a contact, the keyboard is visible, but the text input is not, etc.

I think it makes sense to just hide the keyboard, it will auto hide while showing the action sheet, so we also prevent "up and down" here.