### PR TITLE
Add dedicated zoomable view

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F11FB7229C07B04001E21E7 /* NCZoomableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11FB7129C07B04001E21E7 /* NCZoomableView.swift */; };
 		1F1C0D7F29A7F33600D17C6D /* NCNotificationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA38C8F29A4B3C6008871B8 /* NCNotificationAction.swift */; };
 		1F1C0D8729AFB88800D17C6D /* VLCKitVideoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1F1C0D8629AFB88800D17C6D /* VLCKitVideoViewController.xib */; };
 		1F1C0D8929AFB89900D17C6D /* VLCKitVideoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1C0D8829AFB89900D17C6D /* VLCKitVideoViewController.swift */; };
@@ -376,6 +377,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1F11FB7129C07B04001E21E7 /* NCZoomableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NCZoomableView.swift; sourceTree = "<group>"; };
 		1F1C0D8629AFB88800D17C6D /* VLCKitVideoViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = VLCKitVideoViewController.xib; sourceTree = "<group>"; };
 		1F1C0D8829AFB89900D17C6D /* VLCKitVideoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCKitVideoViewController.swift; sourceTree = "<group>"; };
 		1F24B5A128E0648600654457 /* ReferenceGithubView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReferenceGithubView.swift; sourceTree = "<group>"; };
@@ -994,6 +996,7 @@
 				1FB6678E28CE381300D29F8D /* SubtitleTableViewCell.swift */,
 				1F468E7728DCC7310099597B /* EmojiTextField.swift */,
 				2C16A82B28E7284D00EDE523 /* NCButton.swift */,
+				1F11FB7129C07B04001E21E7 /* NCZoomableView.swift */,
 				1F8995B22970644C00CABA33 /* ColorGenerator.swift */,
 				1F1C0D8629AFB88800D17C6D /* VLCKitVideoViewController.xib */,
 				1F1C0D8829AFB89900D17C6D /* VLCKitVideoViewController.swift */,
@@ -1953,6 +1956,7 @@
 				2C9E6CCE1F6F34F000399B7A /* ARDSDPUtils.m in Sources */,
 				2C06330F2046CC8B0043481A /* NCUserInterfaceController.m in Sources */,
 				2CB304222264775E0053078A /* UIView+SLKAdditions.m in Sources */,
+				1F11FB7229C07B04001E21E7 /* NCZoomableView.swift in Sources */,
 				2C4446F0265D454200DF1DBC /* NotificationCenterNotifications.m in Sources */,
 				1F3D3B22255F109E00230DAE /* BarButtonItemWithActivity.m in Sources */,
 				2C0574821EDD9E8E00D9E7F2 /* main.m in Sources */,

--- a/NextcloudTalk/CallViewController.h
+++ b/NextcloudTalk/CallViewController.h
@@ -28,6 +28,7 @@
 #import "NCChatTitleView.h"
 
 @class CallViewController;
+@class NCZoomableView;
 @protocol CallViewControllerDelegate <NSObject>
 
 - (void)callViewControllerWantsToBeDismissed:(CallViewController *)viewController;
@@ -47,7 +48,7 @@
 @property (nonatomic, assign) BOOL silentCall;
 
 @property (nonatomic, strong) IBOutlet RTCCameraPreviewView *localVideoView;
-@property (nonatomic, strong) IBOutlet UIView *screensharingView;
+@property (nonatomic, strong) IBOutlet NCZoomableView *screensharingView;
 @property (nonatomic, strong) IBOutlet UIButton *closeScreensharingButton;
 @property (nonatomic, strong) IBOutlet UIButton *toggleChatButton;
 @property (nonatomic, strong) IBOutlet UIView *waitingView;

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -79,7 +79,6 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
     NCCallController *_callController;
     NCChatViewController *_chatViewController;
     UINavigationController *_chatNavigationController;
-    UIView <RTCVideoRenderer> *_screenView;
     CGSize _screensharingSize;
     UITapGestureRecognizer *_tapGestureForDetailedView;
     NSTimer *_detailedViewTimer;
@@ -103,9 +102,6 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
     NSMutableArray *_pendingPeerDeletions;
     NSMutableArray *_pendingPeerUpdates;
     NSTimer *_batchUpdateTimer;
-    UIPinchGestureRecognizer *_screenViewPinchGestureRecognizer;
-    UIPanGestureRecognizer *_screenViewPanGestureRecognizer;
-    UITapGestureRecognizer *_screenViewDoubleTapGestureRecognizer;
 }
 
 @property (nonatomic, strong) IBOutlet UIButton *audioMuteButton;
@@ -290,7 +286,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
     
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
         [self setLocalVideoRect];
-        [self resizeScreensharingView];
+        [self->_screensharingView resizeContentView];
         [self adjustTopBar];
     } completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
     }];
@@ -1487,7 +1483,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
 
             strongSelf->_chatNavigationController = nil;
 
-            if ((!strongSelf->_isAudioOnly && strongSelf->_callState == CallStateInCall) || strongSelf->_screenView) {
+            if (!strongSelf->_isAudioOnly && strongSelf->_callState == CallStateInCall) {
                 [strongSelf addTapGestureForDetailedView];
                 [strongSelf showDetailedViewWithTimer];
             }
@@ -1860,35 +1856,16 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         RTCMTLVideoView *renderView = [self->_screenRenderersDict objectForKey:peerId];
-        [self->_screenView removeFromSuperview];
-        [self->_screenView removeGestureRecognizer:self->_screenViewPinchGestureRecognizer];
-        [self->_screenView removeGestureRecognizer:self->_screenViewPanGestureRecognizer];
-        [self->_screenView removeGestureRecognizer:self->_screenViewDoubleTapGestureRecognizer];
-        self->_screenView = nil;
 
-        self->_screenView = renderView;
-        self->_screensharingSize = renderView.frame.size;
-        [self->_screensharingView addSubview:self->_screenView];
+        [self->_screensharingView replaceContentView:renderView];
         [self->_screensharingView bringSubviewToFront:self->_closeScreensharingButton];
-
-        self->_screenViewPinchGestureRecognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(screenViewPinch:)];
-        self->_screenViewPinchGestureRecognizer.delegate = self;
-        [self->_screenView addGestureRecognizer:self->_screenViewPinchGestureRecognizer];
-
-        self->_screenViewPanGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(screenViewPan:)];
-        self->_screenViewPanGestureRecognizer.delegate = self;
-        [self->_screenView addGestureRecognizer:self->_screenViewPanGestureRecognizer];
-
-        self->_screenViewDoubleTapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(screenViewDoubleTap:)];
-        [self->_screenViewDoubleTapGestureRecognizer setNumberOfTapsRequired:2];
-        [self->_screenView addGestureRecognizer:self->_screenViewDoubleTapGestureRecognizer];
 
         [UIView transitionWithView:self->_screensharingView duration:0.4
                            options:UIViewAnimationOptionTransitionCrossDissolve
                         animations:^{self->_screensharingView.hidden = NO;}
                         completion:nil];
-        [self resizeScreensharingView];
     });
+
     // Enable/Disable detailed view with tap gesture
     // in voice only call when screensharing is enabled
     if (_isAudioOnly) {
@@ -1906,7 +1883,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
             [cell setScreenShared:NO];
         }];
 
-        if (self->_screenView == screenRenderer) {
+        if (self->_screensharingView.contentView == screenRenderer) {
             [self closeScreensharingButtonPressed:self];
         }
 
@@ -1916,166 +1893,21 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
     });
 }
 
-- (void)resizeScreensharingView {
-    // We need to reset the transform here, because otherwise panning would be based on that invalid transform
-    _screenView.transform = CGAffineTransformIdentity;
-    
-    CGRect bounds = _screensharingView.bounds;
-    CGSize videoSize = _screensharingSize;
-    
-    if (videoSize.width > 0 && videoSize.height > 0) {
-        // Aspect fill remote video into bounds.
-        CGRect remoteVideoFrame = AVMakeRectWithAspectRatioInsideRect(videoSize, bounds);
-        CGFloat scale = 1;
-        remoteVideoFrame.size.height *= scale;
-        remoteVideoFrame.size.width *= scale;
-        _screenView.frame = remoteVideoFrame;
-        _screenView.center = CGPointMake(CGRectGetMidX(bounds), CGRectGetMidY(bounds));
-    } else {
-        _screenView.frame = bounds;
-    }
-}
-
 - (IBAction)closeScreensharingButtonPressed:(id)sender
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self->_screenView removeFromSuperview];
-        [self->_screenView removeGestureRecognizer:self->_screenViewPinchGestureRecognizer];
-        [self->_screenView removeGestureRecognizer:self->_screenViewPanGestureRecognizer];
-        self->_screenView = nil;
-        
         [UIView transitionWithView:self->_screensharingView duration:0.4
                            options:UIViewAnimationOptionTransitionCrossDissolve
                         animations:^{self->_screensharingView.hidden = YES;}
                         completion:nil];
     });
+
     // Back to normal voice only UI
     if (_isAudioOnly) {
         [self invalidateDetailedViewTimer];
         [self showDetailedView];
         [self removeTapGestureForDetailedView];
     }
-}
-
-- (void)screenViewPinch:(UIPinchGestureRecognizer *)recognizer
-{
-    [self zoomView:recognizer.view toPoint:[recognizer locationInView:recognizer.view] usingScale:recognizer.scale];
-    recognizer.scale = 1.0;
-
-    if (recognizer.state == UIGestureRecognizerStateEnded) {
-        CGRect bounds = _screensharingView.bounds;
-        CGSize videoSize = _screensharingSize;
-        CGSize zoomedSize = recognizer.view.frame.size;
-
-        CGRect remoteVideoFrame = AVMakeRectWithAspectRatioInsideRect(videoSize, bounds);
-
-        // Don't zoom smaller than the original size
-        if (zoomedSize.width < remoteVideoFrame.size.width || zoomedSize.height < remoteVideoFrame.size.height) {
-            [UIView animateWithDuration:0.3 animations:^{
-                [self resizeScreensharingView];
-            }];
-        } else {
-            [self adjustScreenViewPosition];
-        }
-    }
-}
-
-- (void)screenViewPan:(UIPanGestureRecognizer *)recognizer
-{
-    CGPoint point = [recognizer translationInView:_screenView];
-
-    // We need to take the current scaling into account when panning
-    // As we have the same scale factor for X and Y, we can take only one here
-    CGFloat scaleFactor = _screenView.transform.a;
-
-    _screenView.center = CGPointMake(_screenView.center.x + point.x * scaleFactor, _screenView.center.y + point.y * scaleFactor);
-    [recognizer setTranslation:CGPointZero inView:self->_screenView];
-
-    if (recognizer.state == UIGestureRecognizerStateEnded) {
-        [self adjustScreenViewPosition];
-    }
-}
-
-- (void)screenViewDoubleTap:(UIPanGestureRecognizer *)recognizer
-{
-    if (recognizer.state == UIGestureRecognizerStateRecognized) {
-        // We need to take the current scaling into account when panning
-        // As we have the same scale factor for X and Y, we can take only one here
-        CGFloat scaleFactor = _screenView.transform.a;
-
-        [UIView animateWithDuration:0.3 animations:^{
-            if (scaleFactor > 1) {
-                // Set screenView's original size
-                [self resizeScreensharingView];
-            } else {
-                // Zoom 3x screenView into the tap point
-                [self zoomView:recognizer.view toPoint:[recognizer locationInView:recognizer.view] usingScale:3];
-            }
-        }];
-        [self adjustScreenViewPosition];
-    }
-}
-
-- (void)zoomView:(UIView *)view toPoint:(CGPoint)point usingScale:(CGFloat)scale
-{
-    CGRect bounds = view.bounds;
-    point.x -= CGRectGetMidX(bounds);
-    point.y -= CGRectGetMidY(bounds);
-    CGAffineTransform transform = view.transform;
-    transform = CGAffineTransformTranslate(transform, point.x, point.y);
-    transform = CGAffineTransformScale(transform, scale, scale);
-    transform = CGAffineTransformTranslate(transform, -point.x, -point.y);
-    view.transform = transform;
-}
-
-- (void)adjustScreenViewPosition
-{
-    CGSize parentSize = _screenView.superview.frame.size;
-    CGSize size = _screenView.frame.size;
-    CGPoint position = _screenView.frame.origin;
-
-    CGFloat viewLeft = position.x;
-    CGFloat viewRight = position.x + size.width;
-    CGFloat viewTop = position.y;
-    CGFloat viewBottom = position.y + size.height;
-
-    // Left align screenView if it has been moved to the center (and it is wide enough)
-    if (viewLeft > 0 && size.width >= parentSize.width) {
-        position = CGPointMake(0, position.y);
-    }
-
-    // Top align screenView if it has been moved to the center (and it is tall enough)
-    if (viewTop > 0 && size.height >= parentSize.height) {
-        position = CGPointMake(position.x, 0);
-    }
-
-    // Right align screenView if it has been moved to the center (and it is wide enough)
-    if (viewRight < parentSize.width && size.width >= parentSize.width) {
-        position = CGPointMake(parentSize.width - size.width, position.y);
-    }
-
-    // Bottom align screenView if it has been moved to the center (and it is tall enough)
-    if (viewBottom < parentSize.height && size.height >= parentSize.height) {
-        position = CGPointMake(position.x, parentSize.height - size.height);
-    }
-
-    // Align screenView vertically
-    if (size.width <= parentSize.width) {
-        position = CGPointMake(parentSize.width / 2 - size.width / 2, position.y);
-    }
-
-    // Align screenView horizontally
-    if (size.height <= parentSize.height) {
-        position = CGPointMake(position.x, parentSize.height / 2 - size.height / 2);
-    }
-
-    CGRect frame = _screenView.frame;
-    frame.origin.x = position.x;
-    frame.origin.y = position.y;
-
-    [UIView animateWithDuration:0.3 animations:^{
-        self->_screenView.frame = frame;
-    }];
 }
 
 #pragma mark - GestureDelegate
@@ -2106,9 +1938,10 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
         for (RTCMTLVideoView *rendererView in [self->_screenRenderersDict allValues]) {
             if ([videoView isEqual:rendererView]) {
                 rendererView.frame = CGRectMake(0, 0, size.width, size.height);
-                if ([self->_screenView isEqual:rendererView]) {
+                if ([self.screensharingView.contentView isEqual:rendererView]) {
                     self->_screensharingSize = rendererView.frame.size;
-                    [self resizeScreensharingView];
+                    [self->_screensharingView setContentViewSize:rendererView.frame.size];
+                    [self->_screensharingView resizeContentView];
                 }
             }
         }

--- a/NextcloudTalk/CallViewController.xib
+++ b/NextcloudTalk/CallViewController.xib
@@ -50,10 +50,10 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="reh-cY-1Qv" userLabel="TopBar">
-                    <rect key="frame" x="0.0" y="0.0" width="1024" height="64"/>
+                    <rect key="frame" x="0.0" y="0.0" width="1024" height="88"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Rl8-bS-FJ5" userLabel="HangupButton">
-                            <rect key="frame" x="915" y="8" width="48" height="48"/>
+                            <rect key="frame" x="915" y="32" width="48" height="48"/>
                             <color key="backgroundColor" systemColor="systemRedColor"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="48" id="aZ2-oa-X4M"/>
@@ -68,7 +68,7 @@
                             </connections>
                         </button>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sX5-HH-Bl6" userLabel="Separator">
-                            <rect key="frame" x="971" y="16" width="1" height="32"/>
+                            <rect key="frame" x="971" y="40" width="1" height="32"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="32" id="BU7-Cl-egd"/>
@@ -79,7 +79,7 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vBI-Mz-P4p" userLabel="ToggleChatButton">
-                            <rect key="frame" x="976" y="4" width="44" height="56"/>
+                            <rect key="frame" x="976" y="28" width="44" height="56"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="44" id="9DJ-Sj-p8R"/>
@@ -91,7 +91,7 @@
                             </connections>
                         </button>
                         <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="FHx-ks-wEy">
-                            <rect key="frame" x="551" y="4" width="356" height="56"/>
+                            <rect key="frame" x="551" y="28" width="356" height="56"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aQX-QQ-eLT" userLabel="RecordingButton">
                                     <rect key="frame" x="0.0" y="0.0" width="44" height="56"/>
@@ -173,7 +173,7 @@
                             </subviews>
                         </stackView>
                         <view contentMode="left" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="NY0-IT-mMr" userLabel="TitleView" customClass="NCChatTitleView">
-                            <rect key="frame" x="8" y="8" width="535" height="48"/>
+                            <rect key="frame" x="8" y="32" width="535" height="48"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="48" id="TeG-Qy-adB"/>
@@ -206,7 +206,7 @@
                     </constraints>
                 </view>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="aUh-Z0-hO6">
-                    <rect key="frame" x="0.0" y="64" width="1024" height="1302"/>
+                    <rect key="frame" x="0.0" y="88" width="1024" height="1258"/>
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" sectionInsetReference="safeArea" id="iSf-tu-VMU" customClass="CallFlowLayout" customModule="NextcloudTalk" customModuleProvider="target">
                         <size key="itemSize" width="50" height="50"/>
@@ -219,8 +219,8 @@
                         <outlet property="delegate" destination="-1" id="rTW-Ir-7cH"/>
                     </connections>
                 </collectionView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zzc-Pq-hMC" userLabel="ScreenshareView">
-                    <rect key="frame" x="0.0" y="64" width="1024" height="1302"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zzc-Pq-hMC" userLabel="ScreenshareView" customClass="NCZoomableView" customModule="NextcloudTalk" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="88" width="1024" height="1258"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N0N-Ny-Aeg" userLabel="CloseScreenshareView">
                             <rect key="frame" x="980" y="12" width="32" height="32"/>
@@ -257,7 +257,7 @@
                     </subviews>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fSY-ZT-xIC" userLabel="Sidebar View">
-                    <rect key="frame" x="666" y="8" width="350" height="1350"/>
+                    <rect key="frame" x="666" y="32" width="350" height="1306"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="350" id="8kc-f3-P81"/>

--- a/NextcloudTalk/NCZoomableView.swift
+++ b/NextcloudTalk/NCZoomableView.swift
@@ -94,12 +94,12 @@ import Foundation
 
         if recognizer.state == .ended {
             let bounds = self.contentView.bounds
-            let videoSize = self.contentViewSize
             let zoomedSize = recognizer.view!.frame.size
 
-            let remoteVideoFrame = AVMakeRect(aspectRatio: videoSize, insideRect: bounds)
+            let aspectRatioContentViewSize = AVMakeRect(aspectRatio: self.contentViewSize, insideRect: bounds).size
 
-            if zoomedSize.width < remoteVideoFrame.size.width || zoomedSize.height < remoteVideoFrame.size.height {
+            // Don't zoom smaller than the original size
+            if zoomedSize.width < aspectRatioContentViewSize.width || zoomedSize.height < aspectRatioContentViewSize.height {
                 UIView.animate(withDuration: 0.3) {
                     self.resizeContentView()
                 }

--- a/NextcloudTalk/NCZoomableView.swift
+++ b/NextcloudTalk/NCZoomableView.swift
@@ -1,0 +1,229 @@
+//
+// Copyright (c) 2023 Marcel Müller <ivan@nextcloud.com>
+//
+// Author Ivan Sein <ivan@nextcloud.com>
+// Author Marcel Müller <marcel.mueller@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+@objc protocol NCZoomableViewDelegate {
+    @objc func resizeContentViewToOriginalSize(_ view: NCZoomableView)
+}
+
+@objcMembers class NCZoomableView: UIView, UIGestureRecognizerDelegate {
+
+    public weak var delegate: NCZoomableViewDelegate?
+
+    var pinchGestureRecognizer: UIPinchGestureRecognizer?
+    var panGestureRecognizer: UIPanGestureRecognizer?
+    var doubleTapGestureRecoginzer: UITapGestureRecognizer?
+
+    private(set) var contentView = UIView()
+    var contentViewSize = CGSize()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        self.addSubview(self.contentView)
+        self.initGestureRecognizers()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+
+        self.addSubview(self.contentView)
+        self.initGestureRecognizers()
+    }
+
+    func initGestureRecognizers() {
+        self.pinchGestureRecognizer = UIPinchGestureRecognizer(target: self, action: #selector(handlePinch(_:)))
+        self.pinchGestureRecognizer?.delegate = self
+        self.contentView.addGestureRecognizer(self.pinchGestureRecognizer!)
+
+        self.panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+        self.panGestureRecognizer?.delegate = self
+        self.contentView.addGestureRecognizer(self.panGestureRecognizer!)
+
+        self.doubleTapGestureRecoginzer = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
+        self.doubleTapGestureRecoginzer?.delegate = self
+        self.doubleTapGestureRecoginzer?.numberOfTapsRequired = 2
+        self.contentView.addGestureRecognizer(self.doubleTapGestureRecoginzer!)
+    }
+
+    public func replaceContentView(_ newView: UIView) {
+        if let pinchGestureRecognizer = self.pinchGestureRecognizer {
+            self.contentView.removeGestureRecognizer(pinchGestureRecognizer)
+        }
+
+        if let panGestureRecognizer = self.panGestureRecognizer {
+            self.contentView.removeGestureRecognizer(panGestureRecognizer)
+        }
+
+        if let doubleTapGestureRecoginzer = self.doubleTapGestureRecoginzer {
+            self.contentView.removeGestureRecognizer(doubleTapGestureRecoginzer)
+        }
+
+        self.contentView.removeFromSuperview()
+        self.contentView = newView
+        self.contentViewSize = newView.frame.size
+        self.addSubview(self.contentView)
+
+        self.initGestureRecognizers()
+        self.resizeContentView()
+    }
+
+    func handlePinch(_ recognizer: UIPinchGestureRecognizer) {
+        self.zoomView(view: self.contentView, toPoint: recognizer.location(in: recognizer.view), usingScale: recognizer.scale)
+        recognizer.scale = 1
+
+        if recognizer.state == .ended {
+            let bounds = self.contentView.bounds
+            let videoSize = self.contentViewSize
+            let zoomedSize = recognizer.view!.frame.size
+
+            let remoteVideoFrame = AVMakeRect(aspectRatio: videoSize, insideRect: bounds)
+
+            if zoomedSize.width < remoteVideoFrame.size.width || zoomedSize.height < remoteVideoFrame.size.height {
+                UIView.animate(withDuration: 0.3) {
+                    self.resizeContentView()
+                }
+            } else {
+                self.adjustViewPosition()
+            }
+
+        }
+    }
+
+    func handlePan(_ recognizer: UIPanGestureRecognizer) {
+        let point = recognizer.translation(in: self.contentView)
+
+        // We need to take the current scaling into account when panning
+        // As we have the same scale factor for X and Y, we can take only one here
+        let scaleFactor = self.contentView.transform.a
+
+        self.contentView.center = CGPoint(x: self.contentView.center.x + point.x * scaleFactor, y: self.contentView.center.y + point.y * scaleFactor)
+        recognizer.setTranslation(.zero, in: self.contentView)
+
+        if recognizer.state == .ended {
+            self.adjustViewPosition()
+        }
+    }
+
+    func handleDoubleTap(_ recognizer: UITapGestureRecognizer) {
+        if recognizer.state == .recognized {
+            // We need to take the current scaling into account when panning
+            // As we have the same scale factor for X and Y, we can take only one here
+            let scaleFactor = self.contentView.transform.a
+
+            UIView.animate(withDuration: 0.3) {
+                if scaleFactor > 1 {
+                    // Set screenView's original size
+                    self.resizeContentView()
+                } else {
+                    // Zoom 3x screenView into the tap point
+                    self.zoomView(view: recognizer.view!, toPoint: recognizer.location(in: recognizer.view!), usingScale: 3)
+                }
+            }
+
+            self.adjustViewPosition()
+        }
+    }
+
+    func zoomView(view: UIView, toPoint point: CGPoint, usingScale scale: CGFloat) {
+        let bounds = view.bounds
+
+        var resultPoint = point
+        resultPoint.x -= bounds.midX
+        resultPoint.y -= bounds.midY
+
+        var transform = view.transform
+        transform = CGAffineTransformTranslate(transform, resultPoint.x, resultPoint.y)
+        transform = CGAffineTransformScale(transform, scale, scale)
+        transform = CGAffineTransformTranslate(transform, -resultPoint.x, -resultPoint.y)
+        view.transform = transform
+    }
+
+    func adjustViewPosition() {
+        let parentSize = self.frame.size
+        let size = self.contentView.frame.size
+        var position = self.contentView.frame.origin
+
+        let viewLeft = position.x
+        let viewRight = position.x + size.width
+        let viewTop = position.y
+        let viewBottom = position.y + size.height
+
+        // Left align screenView if it has been moved to the center (and it is wide enough)
+        if viewLeft > 0, size.width >= parentSize.width {
+            position = CGPoint(x: 0, y: position.y)
+        }
+
+        // Top align screenView if it has been moved to the center (and it is tall enough)
+        if viewTop > 0, size.height >= parentSize.height {
+            position = CGPoint(x: position.x, y: 0)
+        }
+
+        // Right align screenView if it has been moved to the center (and it is wide enough)
+        if viewRight < parentSize.width, size.width >= parentSize.width {
+            position = CGPoint(x: parentSize.width - size.width, y: position.y)
+        }
+
+        // Bottom align screenView if it has been moved to the center (and it is tall enough)
+        if viewBottom < parentSize.height, size.height >= parentSize.height {
+            position = CGPoint(x: position.x, y: parentSize.height - size.height)
+        }
+
+        // Align screenView vertically
+        if size.width <= parentSize.width {
+            position = CGPoint(x: parentSize.width / 2 - size.width / 2, y: position.y)
+        }
+
+        // Align screenView horizontally
+        if size.height <= parentSize.height {
+            position = CGPoint(x: position.x, y: parentSize.height / 2 - size.height / 2)
+        }
+
+        var frame = self.contentView.frame
+        frame.origin.x = position.x
+        frame.origin.y = position.y
+
+        UIView.animate(withDuration: 0.3) {
+            self.contentView.frame = frame
+        }
+    }
+
+    public func resizeContentView() {
+        self.contentView.transform = .identity
+
+        let bounds = self.bounds
+        let contentSize = self.contentViewSize
+
+        if contentSize.width > 0, contentSize.height > 0 {
+            let aspectFrame = AVMakeRect(aspectRatio: contentSize, insideRect: bounds)
+            self.contentView.frame = aspectFrame
+            self.contentView.center = CGPoint(x: bounds.midX, y: bounds.midY)
+        } else {
+            self.contentView.frame = bounds
+        }
+    }
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
+    }
+}

--- a/NextcloudTalk/VLCKitVideoViewController.xib
+++ b/NextcloudTalk/VLCKitVideoViewController.xib
@@ -17,7 +17,7 @@
                 <outlet property="positionSlider" destination="YOo-ek-LBP" id="Nz2-je-Ipm"/>
                 <outlet property="shareButton" destination="s5N-YD-tyg" id="Q0l-YZ-QaM"/>
                 <outlet property="totalTimeLabel" destination="tnZ-oA-kNS" id="I5E-Ci-QMO"/>
-                <outlet property="videoView" destination="NXo-gc-zjF" id="oyt-6D-BkG"/>
+                <outlet property="videoViewContainer" destination="NXo-gc-zjF" id="oyt-6D-BkG"/>
                 <outlet property="view" destination="iN0-l3-epB" id="uwm-Nh-hWT"/>
             </connections>
         </placeholder>
@@ -26,7 +26,7 @@
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NXo-gc-zjF" userLabel="VideoView">
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NXo-gc-zjF" userLabel="VideoView" customClass="NCZoomableView" customModule="NextcloudTalk" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="59" width="393" height="759"/>
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>


### PR DESCRIPTION
* Move zooming and panning to a dedicated view to be reusable
* Use the newly created view also in our VLC view to make it zoomable

Note: Since we can't detect the "real area" VLC draws onto, it's not possible to adjust our view to the size of the drawable at the moment (see https://code.videolan.org/videolan/VLCKit/-/issues/467).