### PR TITLE
Check for visibility of the cell before trying to scroll to the bottom

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1183,9 +1183,15 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         
         dispatch_async(dispatch_get_main_queue(), ^{
             // Make sure we're really at the bottom after updating a message
-            if (isAtBottom) {
-                [self.tableView slk_scrollToBottomAnimated:NO];
-                [self updateToolbar:NO];
+            NSIndexPath *newIndexPath = [self indexPathForMessageWithMessageId:messageId];
+
+            if (isAtBottom && newIndexPath) {
+                NSArray* visibleCellsIPs = [self.tableView indexPathsForVisibleRows];
+
+                if ([visibleCellsIPs containsObject:newIndexPath]) {
+                    [self.tableView slk_scrollToBottomAnimated:NO];
+                    [self updateToolbar:NO];
+                }
             }
         });
     });


### PR DESCRIPTION
In case we received a update message, we did not check if that message is actually in the visible area before trying to scroll to the bottom.