### PR TITLE
Reduce the general timeout to 25s for requests and 60s for long polling

### DIFF
--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -126,6 +126,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 @interface NCAPIController : NSObject
 
 @property (nonatomic, strong) NSMutableDictionary *apiSessionManagers;
+@property (nonatomic, strong) NSMutableDictionary *longPollingApiSessionManagers;
 @property (nonatomic, strong) AFImageDownloader *imageDownloader;
 @property (nonatomic, strong) AFImageDownloader *imageDownloaderAvatars;
 @property (nonatomic, strong) AFImageDownloader *imageDownloaderNoCache;

--- a/NextcloudTalk/NCPushProxySessionManager.m
+++ b/NextcloudTalk/NCPushProxySessionManager.m
@@ -46,6 +46,10 @@
         
         self.responseSerializer = [[AFHTTPResponseSerializer alloc] init];
         self.requestSerializer = [[AFHTTPRequestSerializer alloc] init];
+
+        // As we can run max. 30s in the background, we need to lower the default timeout from 60s to something < 30s.
+        // Otherwise our app can be killed when trying to register while in the background
+        [self.requestSerializer setTimeoutInterval:25];
         
         AFSecurityPolicy* policy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
         self.securityPolicy = policy;


### PR DESCRIPTION
If we take longer than 30s for a request while in the background, the app gets crashed by the OS. So we introduce a second apiSessionManager just for long polling and reduce the other timeouts to 25s.