### PR TITLE
Fix retain cycle from scrollToBottomButton

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -394,8 +394,9 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     _chatViewPresentedTimestamp = [[NSDate date] timeIntervalSince1970];
     _lastReadMessage = _room.lastReadMessage;
 
+    __weak typeof(self) weakSelf = self;
     _scrollToBottomButton = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, 44, 44) primaryAction:[UIAction actionWithHandler:^(__kindof UIAction * _Nonnull action) {
-        [self.tableView slk_scrollToBottomAnimated:YES];
+        [weakSelf.tableView slk_scrollToBottomAnimated:YES];
     }]];
 
     _scrollToBottomButton.backgroundColor = [UIColor secondarySystemBackgroundColor];


### PR DESCRIPTION
I noticed that the log `Dealloc NCChatViewController` was missing after dismissing a `NCChatViewController`. After doing a bisect this lead to #1127. The button itself is retained strong from the `NCChatViewController` but the `NCChatViewController` itself is captured strong inside of the buttons action.
This PR fixes the retain cycle and the `NCChatViewController` is deallocated correctly again.