### PR TITLE
Tackle SplitViewController glitches

### DIFF
--- a/NextcloudTalk/NCSplitViewController.swift
+++ b/NextcloudTalk/NCSplitViewController.swift
@@ -179,17 +179,19 @@
     }
 
     func popSecondaryColumnToRootViewController() {
-        if let navController = self.viewController(for: .secondary) as? UINavigationController {
-            if let chatViewController = getActiveChatViewController() {
-                chatViewController.leaveChat()
+        self.internalExecuteAfterTransition {
+            if let navController = self.viewController(for: .secondary) as? UINavigationController {
+                if let chatViewController = self.getActiveChatViewController() {
+                    chatViewController.leaveChat()
+                }
+
+                // No animation -> animated would interfere with room highlighting
+                navController.popToRootViewController(animated: false)
+
+                // Make sure the chatViewController gets properly deallocated
+                self.setViewController(self.placeholderViewController, for: .secondary)
+                navController.setViewControllers([self.placeholderViewController], animated: false)
             }
-
-            // No animation -> animated would interfere with room highlighting
-            navController.popToRootViewController(animated: false)
-
-            // Make sure the chatViewController gets properly deallocated
-            setViewController(placeholderViewController, for: .secondary)
-            navController.setViewControllers([placeholderViewController], animated: false)
         }
     }
 }

--- a/NextcloudTalk/NCSplitViewController.swift
+++ b/NextcloudTalk/NCSplitViewController.swift
@@ -188,9 +188,12 @@
                 // No animation -> animated would interfere with room highlighting
                 navController.popToRootViewController(animated: false)
 
-                // Make sure the chatViewController gets properly deallocated
-                self.setViewController(self.placeholderViewController, for: .secondary)
-                navController.setViewControllers([self.placeholderViewController], animated: false)
+                // We also need to make sure, that the popToRootViewController animation is finished before setting the placeholderVC
+                self.internalExecuteAfterTransition {
+                    // Make sure the chatViewController gets properly deallocated
+                    self.setViewController(self.placeholderViewController, for: .secondary)
+                    navController.setViewControllers([self.placeholderViewController], animated: false)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #992 
Related #958

How to test:
```diff
diff --git a/NextcloudTalk/RoomsTableViewController.m b/NextcloudTalk/RoomsTableViewController.m
index 6a47c6b5..5968734f 100644
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -341,6 +341,11 @@ typedef void (^FetchRoomsCompletionBlock)(BOOL success);
 
 - (IBAction)addButtonPressed:(id)sender
 {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self presentChatForRoomAtIndexPath:[self.tableView.indexPathsForVisibleRows firstObject]];
+        [[NCUserInterfaceController sharedInstance] presentConversationsList];
+    });
+    return;
     NewRoomTableViewController *newRoowVC = [[NewRoomTableViewController alloc] init];
     NCNavigationController *navigationController = [[NCNavigationController alloc] initWithRootViewController:newRoowVC];
     [self presentViewController:navigationController animated:YES completion:nil];
```

Then press the "+" icon in the conversation list.

Expected result:
Entering the first conversation and leaving it again.

Actual result:
<img src="https://user-images.githubusercontent.com/1580193/226122675-d1ca55fb-65f5-4606-ad9d-6d3f29cce72d.png" width="250" />
We end up in this weird glitched state.

I could not detect a regression with this PR (testing on Simulator, iPhone and iPad), but since we are so close to 16, I would suggest not including it and adding to for 16.1 / 16.0.1 for a TestFlight round.
