### PR TITLE
Fix unread marker shown when initial history contains new update messages

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -2477,9 +2477,18 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         NSMutableArray *messages = [notification.userInfo objectForKey:@"messages"];
         if (messages.count > 0) {
             NSIndexPath *indexPathUnreadMessageSeparator;
-            int lastMessageIndex = (int)[messages count] - 1;
-            NCChatMessage *lastMessage = [messages objectAtIndex:lastMessageIndex];
-            
+            NCChatMessage *lastMessage = nil;
+
+            // Find the last message we received, which is not an update message
+            for (NSInteger messageIndex = ([messages count] - 1); messageIndex >= 0; messageIndex--) {
+                NCChatMessage *tempMessage = messages[messageIndex];
+
+                if (tempMessage && ![tempMessage isUpdateMessage]) {
+                    lastMessage = tempMessage;
+                    break;
+                }
+            }
+
             [self appendMessages:messages inDictionary:self->_messages];
             
             if (lastMessage && lastMessage.messageId > self->_lastReadMessage) {


### PR DESCRIPTION
In `didReceiveInitialChatHistory` we assume that the last message we have is a visible message. This is not true in all cases, which then leads to the unread marker being shown at the bottom with no messages beneath it.