### PR TITLE
Remove fade animation when setting titleView

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -726,7 +726,6 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     self.titleView.frame = CGRectMake(0, 0, MAXFLOAT, 30);
     self.titleView.delegate = self;
     self.titleView.titleTextView.accessibilityHint = NSLocalizedString(@"Double tap to go to conversation information", nil);
-    self.titleView.alpha = 0;
 
     if (self.navigationController.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact) {
         self.titleView.showSubtitle = NO;
@@ -735,10 +734,6 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     [self.titleView updateForRoom:_room];
 
     self.navigationItem.titleView = _titleView;
-
-    [UIView animateWithDuration:0.8 animations:^{
-            self.titleView.alpha = 1;
-    }];
 }
 
 - (void)configureActionItems


### PR DESCRIPTION
Reverts #1140 
@SystemKeeper as discussed, #1140 added a strange animation on iOS 15 devices.
