### PR TITLE
Fix race condition when receiving messages in the background

### DIFF
--- a/NextcloudTalk/NCChatController.h
+++ b/NextcloudTalk/NCChatController.h
@@ -40,10 +40,12 @@ extern NSString * const NCChatControllerDidReceiveUpdateMessageNotification;
 extern NSString * const NCChatControllerDidReceiveHistoryClearedNotification;
 extern NSString * const NCChatControllerDidReceiveCallStartedMessageNotification;
 extern NSString * const NCChatControllerDidReceiveCallEndedMessageNotification;
+extern NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotification;
 
 @interface NCChatController : NSObject
 
 @property (nonatomic, strong) NCRoom *room;
+@property (nonatomic, assign) BOOL hasReceivedMessagesFromServer;
 
 - (instancetype)initForRoom:(NCRoom *)room;
 - (void)sendChatMessage:(NSString *)message replyTo:(NSInteger)replyTo referenceId:(NSString *)referenceId silently:(BOOL)silently;

--- a/NextcloudTalk/NCChatViewController.h
+++ b/NextcloudTalk/NCChatViewController.h
@@ -23,6 +23,7 @@
 #import "SLKTextViewController.h"
 
 #import "NCRoom.h"
+#import "NCChatController.h"
 
 extern NSString * const NCChatViewControllerReplyPrivatelyNotification;
 extern NSString * const NCChatViewControllerForwardNotification;
@@ -31,6 +32,7 @@ extern NSString * const NCChatViewControllerTalkToUserNotification;
 @interface NCChatViewController : SLKTextViewController
 
 @property (nonatomic, strong) NCRoom *room;
+@property (nonatomic, strong) NCChatController *chatController;
 @property (nonatomic, assign) BOOL presentedInCall;
 @property (nonatomic, assign) NSInteger highlightMessageId;
 

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -479,7 +479,14 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
                 dispatch_group_enter(chatUpdateGroup);
 
                 NSLog(@"Updating room %@", room.internalId);
-                NCChatController *chatController = [[NCChatController alloc] initForRoom:room];
+                NCChatController *chatController;
+
+                if (self.chatViewController && self.chatViewController.chatController && [self.chatViewController.room.internalId isEqualToString:room.internalId]) {
+                    // If there's already a chatController for this room, don't create a new one
+                    chatController = self.chatViewController.chatController;
+                } else {
+                    chatController = [[NCChatController alloc] initForRoom:room];
+                }
 
                 [chatController updateHistoryInBackgroundWithCompletionBlock:^(NSError *error) {
                     NSLog(@"Finished updating room %@", room.internalId);


### PR DESCRIPTION
Fixes #1176 

When there's an active chatViewController, we suddenly did have multiple chatController for the same conversation. This lead to a race condition on who is responsible for actually updating the messages. Now we restructured things a bit and make sure that we only ever have one chatController for a conversation.