### PR TITLE
Do not show destructive actions in room info view while in a call

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -2149,6 +2149,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
 - (void)chatTitleViewTapped:(NCChatTitleView *)titleView
 {
     RoomInfoTableViewController *roomInfoVC = [[RoomInfoTableViewController alloc] initForRoom:_room];
+    roomInfoVC.hideDestructiveActions = YES;
 
     roomInfoVC.modalPresentationStyle = UIModalPresentationPageSheet;
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:roomInfoVC];

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -4197,6 +4197,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 - (void)chatTitleViewTapped:(NCChatTitleView *)titleView
 {
     RoomInfoTableViewController *roomInfoVC = [[RoomInfoTableViewController alloc] initForRoom:_room fromChatViewController:self];
+    roomInfoVC.hideDestructiveActions = _presentedInCall;
     NCSplitViewController *splitViewController = [NCUserInterfaceController sharedInstance].mainViewController;
 
     if (splitViewController != nil && !splitViewController.isCollapsed) {

--- a/NextcloudTalk/RoomInfoTableViewController.h
+++ b/NextcloudTalk/RoomInfoTableViewController.h
@@ -26,6 +26,8 @@
 
 @interface RoomInfoTableViewController : UITableViewController
 
+@property (nonatomic, assign) BOOL hideDestructiveActions;
+
 - (instancetype)initForRoom:(NCRoom *)room;
 - (instancetype)initForRoom:(NCRoom *)room fromChatViewController:(NCChatViewController *)chatViewController;
 

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -335,8 +335,7 @@ typedef enum FileAction {
     // Participants section
     [sections addObject:[NSNumber numberWithInt:kRoomInfoSectionParticipants]];
     // Destructive actions section
-    if (!_chatViewController || !_chatViewController.presentedInCall) {
-        // Do not show destructive actions when chat is presented during a call
+    if (!_hideDestructiveActions) {
         [sections addObject:[NSNumber numberWithInt:kRoomInfoSectionDestructive]];
     }
     return [NSArray arrayWithArray:sections];


### PR DESCRIPTION
Destructive actions were shown when opening room info view from call view's title view.