### PR TITLE
Correctly read "firstNewMessagesAfterHistory" as bool

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -2590,7 +2590,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
             return;
         }
 
-        BOOL firstNewMessagesAfterHistory = [notification.userInfo objectForKey:@"firstNewMessagesAfterHistory"];
+        BOOL firstNewMessagesAfterHistory = [[notification.userInfo objectForKey:@"firstNewMessagesAfterHistory"] boolValue];
         
         NSMutableArray *messages = [notification.userInfo objectForKey:@"messages"];
         if (messages.count > 0) {


### PR DESCRIPTION
Fix #1194 