### PR TITLE
Check exists endpoint for notifications

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -418,6 +418,18 @@
         dispatch_group_leave(backgroundRefreshGroup);
     }];
 
+    // Check if the shown notifications are still available on the server
+    dispatch_group_enter(backgroundRefreshGroup);
+    [[NCNotificationController sharedInstance] checkNotificationExistanceWithCompletionBlock:^(NSError *error) {
+        [NCUtils log:@"CompletionHandler checkNotificationExistance"];
+
+        if (error) {
+            errorOccurred = YES;
+        }
+
+        dispatch_group_leave(backgroundRefreshGroup);
+    }];
+
     /* Disable checking for new messages for now, until we can prevent them from showing twice
     dispatch_group_enter(backgroundRefreshGroup);
     [[NCNotificationController sharedInstance] checkForNewNotificationsWithCompletionBlock:^(NSError *error) {

--- a/NextcloudTalk/DiagnosticsTableViewController.swift
+++ b/NextcloudTalk/DiagnosticsTableViewController.swift
@@ -507,7 +507,7 @@ class DiagnosticsTableViewController: UITableViewController {
 
         case ServerSections.kServerSectionNotificationsAppEnabled.rawValue:
             cell.textLabel?.text = NSLocalizedString("Notifications app enabled?", comment: "")
-            cell.detailTextLabel?.text = readableBool(for: serverCapabilities.notificationsAppEnabled)
+            cell.detailTextLabel?.text = readableBool(for: serverCapabilities.notificationsCapabilities.count > 0)
 
         case ServerSections.kServerSectionReachable.rawValue:
             cell.textLabel?.text = NSLocalizedString("Reachable?", comment: "")

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -105,9 +105,11 @@ typedef void (^GetUserStatusCompletionBlock)(NSDictionary *userStatus, NSError *
 typedef void (^SetUserStatusCompletionBlock)(NSError *error);
 
 typedef void (^GetServerCapabilitiesCompletionBlock)(NSDictionary *serverCapabilities, NSError *error);
+
 typedef void (^GetServerNotificationCompletionBlock)(NSDictionary *notification, NSError *error, NSInteger statusCode);
 typedef void (^GetServerNotificationsCompletionBlock)(NSArray *notifications, NSString *ETag, NSString *userStatus, NSError *error);
 typedef void (^ExecuteNotificationActionCompletionBlock)(NSError *error);
+typedef void (^CheckNotificationExistanceBlock)(NSArray *notificationIds, NSError *error);
 
 typedef void (^SubscribeToNextcloudServerCompletionBlock)(NSDictionary *responseDict, NSError *error);
 typedef void (^UnsubscribeToNextcloudServerCompletionBlock)(NSError *error);
@@ -274,6 +276,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 - (NSURLSessionDataTask *)getServerNotification:(NSInteger)notificationId forAccount:(TalkAccount *)account withCompletionBlock:(GetServerNotificationCompletionBlock)block;
 - (NSURLSessionDataTask *)getServerNotificationsForAccount:(TalkAccount *)account withLastETag:(NSString *)lastETag withCompletionBlock:(GetServerNotificationsCompletionBlock)block;
 - (void)executeNotificationAction:(NCNotificationAction *)action forAccount:(TalkAccount *)account withCompletionBlock:(ExecuteNotificationActionCompletionBlock)block;
+- (NSURLSessionDataTask *)checkNotificationExistance:(NSArray *)notificationIds forAccount:(TalkAccount *)account withCompletionBlock:(CheckNotificationExistanceBlock)block;
 
 // Push Notifications
 - (NSURLSessionDataTask *)subscribeAccount:(TalkAccount *)account withPublicKey:(NSData *)publicKey toNextcloudServerWithCompletionBlock:(SubscribeToNextcloudServerCompletionBlock)block;

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -2713,6 +2713,31 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     }
 }
 
+- (NSURLSessionDataTask *)checkNotificationExistance:(NSArray *)notificationIds forAccount:(TalkAccount *)account withCompletionBlock:(CheckNotificationExistanceBlock)block
+{
+    NSString *URLString = [NSString stringWithFormat:@"%@/ocs/v2.php/apps/notifications/api/v2/notifications/exists", account.server];
+
+    NSDictionary *parameters = @{
+        @"ids" : notificationIds,
+    };
+
+    NCAPISessionManager *apiSessionManager = [_apiSessionManagers objectForKey:account.accountId];
+    NSURLSessionDataTask *task = [apiSessionManager POST:URLString parameters:parameters progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+        NSArray *responseArray = [[responseObject objectForKey:@"ocs"] objectForKey:@"data"];
+        if (block) {
+            block(responseArray, nil);
+        }
+    } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
+        NSInteger statusCode = [self getResponseStatusCode:task.response];
+        [self checkResponseStatusCode:statusCode forAccount:account];
+        if (block) {
+            block(nil, error);
+        }
+    }];
+
+    return task;
+}
+
 
 #pragma mark - Push Notifications
 

--- a/NextcloudTalk/NCDatabaseManager.h
+++ b/NextcloudTalk/NCDatabaseManager.h
@@ -75,6 +75,8 @@ extern NSString * const kCapabilitySingleConvStatus;
 extern NSString * const kCapabilityChatKeepNotifications;
 extern NSString * const kCapabilityConversationAvatars;
 
+extern NSString * const kNotificationsCapabilityExists;
+
 extern NSString * const kMinimumRequiredTalkCapability;
 
 @interface NCDatabaseManager : NSObject
@@ -104,6 +106,7 @@ extern NSString * const kMinimumRequiredTalkCapability;
 - (void)setServerCapabilities:(NSDictionary *)serverCapabilities forAccountId:(NSString *)accountId;
 - (BOOL)serverHasTalkCapability:(NSString *)capability;
 - (BOOL)serverHasTalkCapability:(NSString *)capability forAccountId:(NSString *)accountId;
+- (BOOL)serverHasNotificationsCapability:(NSString *)capability forAccountId:(NSString *)accountId;
 - (void)setExternalSignalingServerVersion:(NSString *)version forAccountId:(NSString *)accountId;
 
 @end

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -33,7 +33,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 50;
+uint64_t const kTalkDatabaseSchemaVersion           = 51;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";
@@ -78,6 +78,8 @@ NSString * const kCapabilityRecordingV1             = @"recording-v1";
 NSString * const kCapabilitySingleConvStatus        = @"single-conversation-status";
 NSString * const kCapabilityChatKeepNotifications   = @"chat-keep-notifications";
 NSString * const kCapabilityConversationAvatars     = @"avatar";
+
+NSString * const kNotificationsCapabilityExists     = @"exists";
 
 NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages; // Talk 4.0 is the minimum required version
 
@@ -384,7 +386,7 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
     capabilities.talkVersion = [talkCaps objectForKey:@"version"];
     capabilities.guestsAppEnabled = [[guestsCaps objectForKey:@"enabled"] boolValue];
     capabilities.referenceApiSupported = [[coreCaps objectForKey:@"reference-api"] boolValue];
-    capabilities.notificationsAppEnabled = ([notificationsCaps objectForKey:@"ocs-endpoints"] != nil);
+    capabilities.notificationsCapabilities = [notificationsCaps objectForKey:@"ocs-endpoints"];
 
     NSDictionary *talkConfig = [talkCaps objectForKey:@"config"];
     NSDictionary *callConfig = [talkConfig objectForKey:@"call"];
@@ -440,6 +442,19 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
     }
     return NO;
 }
+
+- (BOOL)serverHasNotificationsCapability:(NSString *)capability forAccountId:(NSString *)accountId
+{
+    ServerCapabilities *serverCapabilities  = [self serverCapabilitiesForAccountId:accountId];
+    if (serverCapabilities) {
+        NSArray *notificationsFeatures = [serverCapabilities.notificationsCapabilities valueForKey:@"self"];
+        if ([notificationsFeatures containsObject:capability]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
 
 - (void)setExternalSignalingServerVersion:(NSString *)version forAccountId:(NSString *)accountId
 {

--- a/NextcloudTalk/NCNotificationController.h
+++ b/NextcloudTalk/NCNotificationController.h
@@ -32,6 +32,7 @@ extern NSString * const NCNotificationActionDismissRecordingNotification;
 extern NSString * const NCNotificationActionReplyToChat;
 
 typedef void (^CheckForNewNotificationsCompletionBlock)(NSError *error);
+typedef void (^CheckNotificationExistanceCompletionBlock)(NSError *error);
 
 typedef enum {
     kNCLocalNotificationTypeMissedCall = 1,
@@ -53,5 +54,6 @@ typedef enum {
 - (void)showIncomingCallForOldAccount;
 - (void)removeAllNotificationsForAccountId:(NSString *)accountId;
 - (void)checkForNewNotificationsWithCompletionBlock:(CheckForNewNotificationsCompletionBlock)block;
+- (void)checkNotificationExistanceWithCompletionBlock:(CheckNotificationExistanceCompletionBlock)block;
 
 @end

--- a/NextcloudTalk/ServerCapabilities.h
+++ b/NextcloudTalk/ServerCapabilities.h
@@ -63,8 +63,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSString *externalSignalingServerVersion;
 @property BOOL guestsAppEnabled;
 @property BOOL referenceApiSupported;
-@property BOOL notificationsAppEnabled;
 @property BOOL recordingEnabled;
+@property RLMArray<RLMString> *notificationsCapabilities;
 
 @end
 


### PR DESCRIPTION
Implemented the client part of https://github.com/nextcloud/notifications/pull/1509
When we do a background fetch we send the current shown notification ids to the server and in return we get a list of notification ids which are actually on the server. So we remove any notification that we did not back from the server.

This should help a lot with notifications were we did not a silent push to remove it.