### PR TITLE
Store the height of the preview file in the database

### DIFF
--- a/NextcloudTalk/NCChatMessage.h
+++ b/NextcloudTalk/NCChatMessage.h
@@ -116,5 +116,6 @@ typedef void (^GetReferenceDataCompletionBlock)(NCChatMessage *message, NSDictio
 - (BOOL)containsURL;
 - (void)getReferenceDataWithCompletionBlock:(GetReferenceDataCompletionBlock)block;
 - (BOOL)isSameMessage:(NCChatMessage *)message;
+- (void)setPreviewImageHeight:(CGFloat)height;
 
 @end

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -3979,7 +3979,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     
     BOOL isAtBottom = [self shouldScrollOnNewMessages];
 
-    message.file.previewImageHeight = height;
+    [message setPreviewImageHeight:height];
 
     [CATransaction begin];
     [CATransaction setCompletionBlock:^{

--- a/NextcloudTalk/NCMessageFileParameter.m
+++ b/NextcloudTalk/NCMessageFileParameter.m
@@ -32,6 +32,7 @@
         self.mimetype = [parameterDict objectForKey:@"mimetype"];
         self.size = [[parameterDict objectForKey:@"size"] integerValue];
         self.previewAvailable = [[parameterDict objectForKey:@"preview-available"] boolValue];
+        self.previewImageHeight = [[parameterDict objectForKey:@"preview-image-height"] intValue];
     }
     
     return self;


### PR DESCRIPTION
When we receive a preview of a file, we currently store the height in the fileParameter object, so scrolling is smooth when the image appears again. But this does not survive leaving and joining the conversation again. So now we store the height in the database and know the preview height each time when we enter a conversation.