### PR TITLE
Prevent the completion handler of checkNotificationExistance called multiple times

### DIFF
--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -437,14 +437,14 @@ NSString * const NCNotificationActionReplyToChat                    = @"REPLY_CH
                 dispatch_group_leave(notificationsGroup);
             }];
         }];
-
-        dispatch_group_notify(notificationsGroup, dispatch_get_main_queue(), ^{
-            // Notify backgroundFetch that we're finished
-            if (block) {
-                block(nil);
-            }
-        });
     }
+
+    dispatch_group_notify(notificationsGroup, dispatch_get_main_queue(), ^{
+        // Notify backgroundFetch that we're finished
+        if (block) {
+            block(nil);
+        }
+    });
 }
 
 #pragma mark - UNUserNotificationCenter delegate


### PR DESCRIPTION
The execution of the completionBlock was actually done inside of the accounts for-loop and could lead to multiple executions of the block. This results in a crash, because we have unbalanced enter-leave-calls.