### PR TITLE
Fix avatar image size rendering

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -2944,7 +2944,7 @@
 			repositoryURL = "https://github.com/SDWebImage/SDWebImage.git";
 			requirement = {
 				kind = exactVersion;
-				version = 5.15.6;
+				version = 5.15.7;
 			};
 		};
 		1F45A11F2A01D8BA005FE87D /* XCRemoteSwiftPackageReference "SDWebImageSVGKitPlugin" */ = {

--- a/NextcloudTalk/AvatarManager.swift
+++ b/NextcloudTalk/AvatarManager.swift
@@ -97,7 +97,7 @@ import SDWebImage
     // MARK: - Utils
 
     public func createRenderedImage(image: UIImage) -> UIImage? {
-        return self.createRenderedImage(image: image, width: 512, height: 512)
+        return self.createRenderedImage(image: image, width: 120, height: 120)
     }
 
     private func createRenderedImage(image: UIImage, width: Int, height: Int) -> UIImage? {

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -2228,7 +2228,7 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     SDWebImageOptions options = SDWebImageRetryFailed | SDWebImageRefreshCached;
     SDWebImageDownloaderRequestModifier *requestModifier = [self getRequestModifierForAccount:account];
 
-    // Make sure we get at least a 512x512 image when retrieving an SVG with SVGKit
+    // Make sure we get at least a 120x120 image when retrieving an SVG with SVGKit
     SDWebImageContext *context = @{
         SDWebImageContextDownloadRequestModifier : requestModifier,
         SDWebImageContextImageThumbnailPixelSize : @(CGSizeMake(120, 120))

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -2231,7 +2231,7 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     // Make sure we get at least a 512x512 image when retrieving an SVG with SVGKit
     SDWebImageContext *context = @{
         SDWebImageContextDownloadRequestModifier : requestModifier,
-        SDWebImageContextImageThumbnailPixelSize : @(CGSizeMake(512, 512))
+        SDWebImageContextImageThumbnailPixelSize : @(CGSizeMake(120, 120))
     };
     
     return [[SDWebImageManager sharedManager] loadImageWithURL:url options:options context:context progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {

--- a/NotificationServiceExtension/NotificationService.m
+++ b/NotificationServiceExtension/NotificationService.m
@@ -32,6 +32,8 @@
 #import "NCPushNotification.h"
 #import "NCPushNotificationsUtils.h"
 
+#import <SDWebImage/SDWebImage.h>
+
 @interface NotificationService ()
 
 @property (nonatomic, strong) void (^contentHandler)(UNNotificationContent *contentToDeliver);
@@ -88,6 +90,9 @@
         // At the very minimum we need to update the version with an empty block to indicate that the schema has been upgraded (automatically) by Realm
     };
     [RLMRealmConfiguration setDefaultConfiguration:configuration];
+
+    // We don't want to use a memory cache in NSE, because we only have a total of 24MB before we get killed by the OS
+    SDImageCache.sharedImageCache.config.shouldCacheImagesInMemory = NO;
     
     BOOL foundDecryptableMessage = NO;
     


### PR DESCRIPTION
Fixes #1223 

We set the size to 512x512 for rendered avatars. But in reality, that is without taking the screen scaling into account. On device with a scale factor of 3 this results in a rendered image of 3 * 512 * 512 which is problematic for NSE with its memory constraints. 

Also rendering through SVGKit actually leaks memory if not done on the main thread (which is done by default, when reading the cache from disk). So actually the PR at https://github.com/nextcloud/talk-ios/pull/1221 solves this memory leak, because we now do it on the main thread as well. I'll add a note to this PR in code.