### PR TITLE
Explicitly set contentMode for userAvatar

### DIFF
--- a/NextcloudTalk/AvatarImageView.swift
+++ b/NextcloudTalk/AvatarImageView.swift
@@ -82,6 +82,7 @@ import SDWebImage
             }
 
             self.image = image
+            self.contentMode = .scaleToFill
         }
     }
 }


### PR DESCRIPTION
This fixes the avatars on ReactionSummaryView being zoomed by accident