### PR TITLE
Reset avatar image when cell is prepared for reuse

### DIFF
--- a/NextcloudTalk/CallParticipantViewCell.m
+++ b/NextcloudTalk/CallParticipantViewCell.m
@@ -76,9 +76,12 @@ CGFloat const kCallParticipantCellMinHeight = 128;
 - (void)prepareForReuse
 {
     [super prepareForReuse];
+
     [_peerAvatarImageView cancelCurrentRequest];
-    _displayName = nil;
+    _peerAvatarImageView.image = nil;
     _peerAvatarImageView.alpha = 1;
+
+    _displayName = nil;
     _peerNameLabel.text = nil;
     [_videoView removeFromSuperview];
     _videoView = nil;


### PR DESCRIPTION
Ref #1242 
Not only do we need to cancel the request, but we also need to reset the image to not show an already loaded avatar.