### PR TITLE
Get last real message when checking for new messages after background

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -985,6 +985,25 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     return nil;
 }
 
+- (NCChatMessage *)getLastRealMessage
+{
+    for (NSInteger sectionIndex = (self->_dateSections.count - 1); sectionIndex >= 0; sectionIndex--) {
+        NSDate *dateSection = [self->_dateSections objectAtIndex:sectionIndex];
+        NSMutableArray *messagesInSection = [self->_messages objectForKey:dateSection];
+
+        for (NSInteger messageIndex = (messagesInSection.count - 1); messageIndex >= 0; messageIndex--) {
+            NCChatMessage *chatMessage = [messagesInSection objectAtIndex:messageIndex];
+
+            // Ignore temporary messages
+            if (chatMessage && chatMessage.messageId > 0) {
+                return chatMessage;
+            }
+        }
+    }
+
+    return nil;
+}
+
 - (NCChatMessage *)getFirstRealMessage
 {
     for (int section = 0; section < [_dateSections count]; section++) {
@@ -3515,7 +3534,9 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 
 - (void)checkForNewStoredMessages
 {
-    NCChatMessage *lastMessage = [[self->_messages objectForKey:[self->_dateSections lastObject]] lastObject];
+    // Get the last "real" message. For temporary messages the messageId would be 0
+    // which would load all stored messages of the current conversation
+    NCChatMessage *lastMessage = [self getLastRealMessage];
 
     if (lastMessage) {
         [self.chatController checkForNewMessagesFromMessageId:lastMessage.messageId];


### PR DESCRIPTION
After moving to the foreground, we check if new messages were stored while we were inactive. To do so, we use the last known message id and check if newer messages are available. This works fine, if the last message is not a temporary message. In that case the `messageId` would be 0 which would result in loading all messages that were stored for that conversation. Before using batch update (#1238) this would lead to a slow application and sometimes a crash because the main thread was blocked for too long. Now with batch update the app crashes because we try to reload cells, which are not there.
To solve this issue, we skip temporary messages and only use the last "real" message to do the check.