### PR TITLE
Only clear participant map on room messages when the room changed

### DIFF
--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -446,8 +446,14 @@ NSString * const NCExternalSignalingControllerDidReceiveStoppedTypingNotificatio
 
 - (void)roomMessageReceived:(NSDictionary *)messageDict
 {
-    _participantsMap = [NSMutableDictionary new];
-    _currentRoom = [[messageDict objectForKey:@"room"] objectForKey:@"roomid"];
+    NSString *newRoomId = [[messageDict objectForKey:@"room"] objectForKey:@"roomid"];
+
+    // Only reset the participant map when the room actually changed
+    // Otherwise we would loose participant information for example when a recording is started
+    if (![_currentRoom isEqualToString:newRoomId]) {
+        _participantsMap = [NSMutableDictionary new];
+        _currentRoom = newRoomId;
+    }
     
     NSString *messageId = [messageDict objectForKey:@"id"];
     [self executeCompletionBlockForMessageId:messageId withStatus:SendMessageSuccess];


### PR DESCRIPTION
Currently when we receive a room signaling message, we always clear the participant map. When we are in a conversation/call and someone starts a call recording, a room message is send as well, leading to the removal of all known participants. We now only clear the participant map if the room really changed.

How to test:
* Add a `[self.collectionView reloadData]` call to one of the call view buttons
* Start and join a call with talk-ios and web
* Notice that participants are correctly shown
* Start a recording in Web
* Reload the data

Without this PR: Every participant is rendered as a guest
With this PR: Nothing changes