### PR TITLE
Keep a strong reference of firstUnreadMessage

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -139,7 +139,7 @@ NSString * const kActionTypeTranscribeVoiceMessage   = @"transcribe-voice-messag
 @property (nonatomic, strong) NCChatMessage *unreadMessagesSeparator;
 @property (nonatomic, assign) NSInteger chatViewPresentedTimestamp;
 @property (nonatomic, strong) UIActivityIndicatorView *loadingHistoryView;
-@property (nonatomic, assign) NCChatMessage *firstUnreadMessage;
+@property (nonatomic, strong) NCChatMessage *firstUnreadMessage;
 @property (nonatomic, strong) UIButton *unreadMessageButton;
 @property (nonatomic, strong) NSTimer *lobbyCheckTimer;
 @property (nonatomic, strong) ReplyMessageView *replyMessageView;


### PR DESCRIPTION
Currently no strong reference to `firstUnreadMessage` is kept, which can lead to a crash:
<img width="621" alt="image" src="https://github.com/nextcloud/talk-ios/assets/1580193/81dcf1aa-ecbb-483d-ace1-f7c423e0ec13">
