### PR TITLE
Adjust share to chat wording

### DIFF
--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -247,7 +247,7 @@
 
     // Recording actions/category
     UNNotificationAction *recordingShareAction = [UNNotificationAction actionWithIdentifier:NCNotificationActionShareRecording
-                                                                                      title:NSLocalizedString(@"Share recording to chat", nil)
+                                                                                      title:NSLocalizedString(@"Share to chat", nil)
                                                                                     options:UNNotificationActionOptionAuthenticationRequired];
 
     UNNotificationAction *recordingDismissAction = [UNNotificationAction actionWithIdentifier:NCNotificationActionDismissRecordingNotification

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -92,9 +92,6 @@
 "Add participants to new group conversation" = "Add participants to new group conversation";
 
 /* No comment provided by engineer. */
-"Add reaction" = "Add reaction";
-
-/* No comment provided by engineer. */
 "Add to favorites" = "Add to favorites";
 
 /* No comment provided by engineer. */
@@ -1379,7 +1376,7 @@
 "Share pin location" = "Share pin location";
 
 /* No comment provided by engineer. */
-"Share recording to chat" = "Share recording to chat";
+"Share to chat" = "Share to chat";
 
 /* No comment provided by engineer. */
 "Share with" = "Share with";


### PR DESCRIPTION
We receive the same notification type for recordings and for transcripts. Since we show the notifications subject/body that is already adjusted according to the type. But for the iOS native notification action we still show "Share recording to chat" in both cases. With this PR we adjust it to "Share to chat" which is valid for both cases.