### PR TITLE
Correctly color talk logo in reference provider

### DIFF
--- a/NextcloudTalk/ReferenceTalkView.swift
+++ b/NextcloudTalk/ReferenceTalkView.swift
@@ -97,7 +97,7 @@ import SwiftyAttributes
                 self.referenceTypeIcon.layer.cornerRadius = self.referenceTypeIcon.frame.height / 2
             } else {
                 self.referenceTypeIcon.layer.cornerRadius = 0
-                self.referenceTypeIcon.image = UIImage(named: "talk-20")
+                self.referenceTypeIcon.image = UIImage(named: "talk-20")?.withTintColor(.systemGray, renderingMode: .alwaysOriginal)
             }
         }
     }


### PR DESCRIPTION
Before the logo was always rendered white, which is invisible in light mode.