### PR TITLE
Adjust typing indicators

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -233,6 +233,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveStartedTyping:) name:NCExternalSignalingControllerDidReceiveStartedTypingNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveStoppedTyping:) name:NCExternalSignalingControllerDidReceiveStoppedTypingNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveParticipantJoin:) name:NCExternalSignalingControllerDidReceiveJoinOfParticipant object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveParticipantLeave:) name:NCExternalSignalingControllerDidReceiveLeaveOfParticipant object:nil];
 
         // Notifications when runing on Mac 
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidBecomeActive:) name:@"NSApplicationDidBecomeActiveNotification" object:nil];
@@ -3178,6 +3179,27 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         }
     });
 }
+
+- (void)didReceiveParticipantLeave:(NSNotification *)notification
+{
+    NSString *roomToken = [notification.userInfo objectForKey:@"roomToken"];
+    NSString *sessionId = [notification.userInfo objectForKey:@"sessionId"];
+    NSString *userId = [notification.userInfo objectForKey:@"userId"];
+
+    if (![roomToken isEqualToString:_room.token] || !sessionId) {
+        return;
+    }
+
+    // For guests we use the sessionId as identifiert, for users we use the userId
+    NSString *userIdentifier = sessionId;
+
+    if (userId && ![userId isEqualToString:@""]) {
+        userIdentifier = userId;
+    }
+
+    [self removeTypingIndicatorWithUserIdentifier:userIdentifier];
+}
+
 
 
 #pragma mark - Lobby functions

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -596,7 +596,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 
     // In case we're typing when we leave the chat, make sure we notify everyone
     // The 'stopTyping' method makes sure to only send signaling messages when we were typing before
-    [self stopTyping];
+    [self stopTyping:NO];
     
     // If this chat view controller is for the same room as the one owned by the rooms manager
     // then we should not try to leave the chat. Since we will leave the chat when the
@@ -660,7 +660,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     [self savePendingMessage];
     [_chatController stopChatController];
     [_messageExpirationTimer invalidate];
-    [self stopTyping];
+    [self stopTyping:NO];
     [[NCRoomsManager sharedInstance] leaveChatInRoom:_room.token];
 }
 
@@ -1280,7 +1280,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     [_replyMessageView dismiss];
     [super didPressRightButton:self];
     [self clearPendingMessage];
-    [self stopTyping];
+    [self stopTyping:YES];
 }
 
 - (BOOL)canPressRightButton
@@ -1729,10 +1729,6 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 
 #pragma mark UITextViewDelegate
 
-- (void)textViewDidEndEditing:(UITextView *)textView {
-    [self stopTyping];
-}
-
 - (void)textViewDidChange:(UITextView *)textView {
     [self startTyping];
 }
@@ -1826,7 +1822,17 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     [self setStopTypingTimer];
 }
 
-- (void)stopTyping
+- (void)stopTyping:(BOOL)force
+{
+    if (_isTyping || force) {
+        _isTyping = NO;
+        [self sendStoppedTypingMessageToAll];
+        [self invalidateStopTypingTimer];
+        [self invalidateTypingTimer];
+    }
+}
+
+- (void)stopTypingDetected
 {
     if (_isTyping) {
         _isTyping = NO;
@@ -1862,7 +1868,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 - (void)setStopTypingTimer
 {
     [self invalidateStopTypingTimer];
-    _stopTypingTimer = [NSTimer scheduledTimerWithTimeInterval:5.0 target:self selector:@selector(stopTyping) userInfo:nil repeats:NO];
+    _stopTypingTimer = [NSTimer scheduledTimerWithTimeInterval:5.0 target:self selector:@selector(stopTypingDetected) userInfo:nil repeats:NO];
 }
 
 - (void)invalidateStopTypingTimer

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -3116,8 +3116,13 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     NSString *userId = [notification.userInfo objectForKey:@"userId"];
     NSString *sessionId = [notification.userInfo objectForKey:@"sessionId"];
     
-    if (![roomToken isEqualToString:_room.token] || !displayName || (!userId && !sessionId)) {
+    if (![roomToken isEqualToString:_room.token] || (!userId && !sessionId)) {
         return;
+    }
+
+    // Waiting for https://github.com/nextcloud/spreed/issues/9726 to receive the correct displayname for guests
+    if (!displayName) {
+        displayName = NSLocalizedString(@"Guest", nil);
     }
 
     // Don't show a typing indicator for ourselves or if typing indicator setting is disabled

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1846,20 +1846,20 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 }
 
 
-- (void)addTypingIndicatorWithUserId:(NSString *)userId withDisplayName:(NSString *)displayName
+- (void)addTypingIndicatorWithUserIdentifier:(NSString *)userIdentifier withDisplayName:(NSString *)displayName
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         TypingIndicatorView *view = (TypingIndicatorView *)self.textInputbar.typingView;
-        [view addTypingWithUserId:userId displayName:displayName];
+        [view addTypingWithUserIdentifier:userIdentifier displayName:displayName];
     });
 
 }
 
-- (void)removeTypingIndicatorWithUserId:(NSString *)userId
+- (void)removeTypingIndicatorWithUserIdentifier:(NSString *)userIdentifier
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         TypingIndicatorView *view = (TypingIndicatorView *)self.textInputbar.typingView;
-        [view removeTypingWithUserId:userId];
+        [view removeTypingWithUserIdentifier:userIdentifier];
     });
 
 }
@@ -3081,8 +3081,9 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     NSString *roomToken = [notification.userInfo objectForKey:@"roomToken"];
     NSString *displayName = [notification.userInfo objectForKey:@"displayName"];
     NSString *userId = [notification.userInfo objectForKey:@"userId"];
+    NSString *sessionId = [notification.userInfo objectForKey:@"sessionId"];
     
-    if (![roomToken isEqualToString:_room.token] || !displayName || !userId) {
+    if (![roomToken isEqualToString:_room.token] || !displayName || (!userId && !sessionId)) {
         return;
     }
 
@@ -3093,15 +3094,23 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         return;
     }
 
-    [self addTypingIndicatorWithUserId:userId withDisplayName:displayName];
+    // For guests we use the sessionId as identifiert, for users we use the userId
+    NSString *userIdentifier = sessionId;
+
+    if (userId && ![userId isEqualToString:@""]) {
+        userIdentifier = userId;
+    }
+
+    [self addTypingIndicatorWithUserIdentifier:userIdentifier withDisplayName:displayName];
 }
 
 - (void)didReceiveStoppedTyping:(NSNotification *)notification
 {
     NSString *roomToken = [notification.userInfo objectForKey:@"roomToken"];
     NSString *userId = [notification.userInfo objectForKey:@"userId"];
+    NSString *sessionId = [notification.userInfo objectForKey:@"sessionId"];
 
-    if (![roomToken isEqualToString:_room.token] || !userId) {
+    if (![roomToken isEqualToString:_room.token] || (!userId && !sessionId)) {
         return;
     }
 
@@ -3112,7 +3121,14 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         return;
     }
 
-    [self removeTypingIndicatorWithUserId:userId];
+    // For guests we use the sessionId as identifiert, for users we use the userId
+    NSString *userIdentifier = sessionId;
+
+    if (userId && ![userId isEqualToString:@""]) {
+        userIdentifier = userId;
+    }
+
+    [self removeTypingIndicatorWithUserIdentifier:userIdentifier];
 }
 
 - (void)didReceiveParticipantJoin:(NSNotification *)notification

--- a/NextcloudTalk/NCExternalSignalingController.h
+++ b/NextcloudTalk/NCExternalSignalingController.h
@@ -29,6 +29,7 @@
 
 extern NSString * const NCExternalSignalingControllerDidUpdateParticipantsNotification;
 extern NSString * const NCExternalSignalingControllerDidReceiveJoinOfParticipant;
+extern NSString * const NCExternalSignalingControllerDidReceiveLeaveOfParticipant;
 extern NSString * const NCExternalSignalingControllerDidReceiveStartedTypingNotification;
 extern NSString * const NCExternalSignalingControllerDidReceiveStoppedTypingNotification;
 

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -608,10 +608,13 @@ NSString * const NCExternalSignalingControllerDidReceiveStoppedTypingNotificatio
         NSString *fromSession = [[messageDict objectForKey:@"sender"] objectForKey:@"sessionid"];
         NSString *fromUser = [[messageDict objectForKey:@"sender"] objectForKey:@"userid"];
 
-        if (_currentRoom && fromSession && fromUser){
+        if (_currentRoom && fromSession){
             [userInfo setObject:_currentRoom forKey:@"roomToken"];
             [userInfo setObject:fromSession forKey:@"sessionId"];
-            [userInfo setObject:fromUser forKey:@"userId"];
+
+            if (fromUser) {
+                [userInfo setObject:fromUser forKey:@"userId"];
+            }
 
             NSString *displayName = [self getDisplayNameFromSessionId:fromSession];
 

--- a/NextcloudTalk/TypingIndicatorView.swift
+++ b/NextcloudTalk/TypingIndicatorView.swift
@@ -69,9 +69,9 @@ import SwiftyAttributes
 
         typingLabel.text = ""
 
-       // removeTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
-     //       self?.checkInactiveTypingUsers()
-     //   })
+        removeTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
+            self?.checkInactiveTypingUsers()
+        })
     }
 
     deinit {


### PR DESCRIPTION
* Continuously send "startedTyping" when we're typing
* Don't send "stoppedTyping" when we stopped typing, only when we leave the room or send a message
* Hide typing indicators after 15s without receiving a signaling message

Fixes #1249 