### PR TITLE
Add note when typing indicators are not supported

### DIFF
--- a/NextcloudTalk/SettingsTableViewController.swift
+++ b/NextcloudTalk/SettingsTableViewController.swift
@@ -830,7 +830,7 @@ extension SettingsTableViewController {
             readStatusSwitch.isOn = !serverCapabilities.readStatusPrivacy
 
         case AccountSettingsOptions.kAccountSettingsTypingPrivacy.rawValue:
-            cell = tableView.dequeueReusableCell(withIdentifier: typingIndicatorCellIdentifier) ?? UITableViewCell(style: .default, reuseIdentifier: typingIndicatorCellIdentifier)
+            cell = tableView.dequeueReusableCell(withIdentifier: typingIndicatorCellIdentifier) ?? UITableViewCell(style: .subtitle, reuseIdentifier: typingIndicatorCellIdentifier)
             cell.textLabel?.text = NSLocalizedString("Typing indicator", comment: "")
             cell.selectionStyle = .none
             cell.imageView?.image = UIImage(systemName: "rectangle.and.pencil.and.ellipsis")
@@ -840,6 +840,15 @@ extension SettingsTableViewController {
             let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
             let serverCapabilities = NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: activeAccount.accountId)
             typingIndicatorSwitch.isOn = !serverCapabilities.typingPrivacy
+
+            let externalSignalingController = NCSettingsController.sharedInstance().externalSignalingController(forAccountId: activeAccount.accountId)
+            let externalSignalingServerUsed = externalSignalingController?.isEnabled() ?? false
+
+            if !externalSignalingServerUsed {
+                cell.detailTextLabel?.text = NSLocalizedString("Typing indicators are only available when using a high performance backend (HPB)", comment: "")
+            } else {
+                cell.detailTextLabel?.text = nil
+            }
 
         case AccountSettingsOptions.kAccountSettingsContactsSync.rawValue:
             cell = tableView.dequeueReusableCell(withIdentifier: contactsSyncCellIdentifier) ?? UITableViewCell(style: .subtitle, reuseIdentifier: contactsSyncCellIdentifier)

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -1529,6 +1529,9 @@
 "Typing indicator" = "Typing indicator";
 
 /* No comment provided by engineer. */
+"Typing indicators are only available when using a high performance backend (HPB)" = "Typing indicators are only available when using a high performance backend (HPB)";
+
+/* No comment provided by engineer. */
 "Unable to load file" = "Unable to load file";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
Missing task from #1249 

Text aligned with android https://github.com/nextcloud/talk-android/blob/master/app/src/main/res/values/strings.xml#L156

![image](https://github.com/nextcloud/talk-ios/assets/1580193/56b2e003-e8b4-4dcf-b9b7-3290231f2223)
