### PR TITLE
Potentially fix intent crash

### DIFF
--- a/NextcloudTalk/NCIntentController.m
+++ b/NextcloudTalk/NCIntentController.m
@@ -119,7 +119,8 @@
                 image = [[AvatarManager shared] createRenderedImageWithImage:image];
             }
 
-            [sendMessageIntent setImage:[INImage imageWithUIImage:image] forParameterNamed:@"speakableGroupName"];
+            INImage *intentImage = [INImage imageWithUIImage:image];
+            [sendMessageIntent setImage:intentImage forParameterNamed:@"speakableGroupName"];
             [self donateMessageSentIntent:sendMessageIntent];
         }
     }];

--- a/ShareExtension/ShareConfirmationViewController.m
+++ b/ShareExtension/ShareConfirmationViewController.m
@@ -372,11 +372,11 @@
 {
     [[NCAPIController sharedInstance] sendChatMessage:self.shareTextView.text toRoom:_room.token displayName:nil replyTo:-1 referenceId:nil silently:NO forAccount:_account withCompletionBlock:^(NSError *error) {
         if (error) {
-            [self.delegate shareConfirmationViewControllerDidFailed:self];
             NSLog(@"Failed to send shared item");
+            [self.delegate shareConfirmationViewControllerDidFailed:self];
         } else {
-            [self.delegate shareConfirmationViewControllerDidFinish:self];
             [[NCIntentController sharedInstance] donateSendMessageIntentForRoom:self->_room];
+            [self.delegate shareConfirmationViewControllerDidFinish:self];
         }
         [self stopAnimatingSharingIndicator];
     }];


### PR DESCRIPTION
We got a few reports about a crash in `donateSendMessage` from TestFlight. I am not sure how this can happen and I am unable to reproduce locally. Two things

1. Split the image part to 2 lines, so we know which call fails if it fails in the future
2. Make sure to do the donation before dismissing the share view (should probably have a completion block, but as a first step this makes sense)