### PR TITLE
Default font and color is still needed for markdown

### DIFF
--- a/NextcloudTalk/SwiftMarkdownObjCBridge.swift
+++ b/NextcloudTalk/SwiftMarkdownObjCBridge.swift
@@ -26,7 +26,7 @@ import UIKit
 @objcMembers class SwiftMarkdownObjCBridge: NSObject {
 
     static func parseMarkdown(markdownString: NSAttributedString) -> NSMutableAttributedString {
-        let markdownParser = CDMarkdownParser()
+        let markdownParser = CDMarkdownParser(font: .systemFont(ofSize: 16), fontColor: NCAppBranding.chatForegroundColor())
         markdownParser.code.backgroundColor = .secondarySystemBackground
         markdownParser.code.font =  CDFont.monospacedSystemFont(ofSize: 16, weight: .regular)
 


### PR DESCRIPTION
Since the elements itself overwrite font and color, this is still needed.