### PR TITLE
Add test for chatviewcontroller deallocation

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -172,6 +172,8 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(audioSessionDidChangeRoutingInformation:) name:AudioSessionDidChangeRoutingInformationNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
+
+    [NCUserInterfaceController sharedInstance].numberOfAllocatedCallViewControllers += 1;
     
     return self;
 }
@@ -346,6 +348,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
 - (void)dealloc
 {
     NSLog(@"CallViewController dealloc");
+    [NCUserInterfaceController sharedInstance].numberOfAllocatedCallViewControllers -= 1;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/NextcloudTalk/ChatMessageTableViewCell.m
+++ b/NextcloudTalk/ChatMessageTableViewCell.m
@@ -427,12 +427,14 @@
         [checkView setImage:[UIImage imageNamed:@"check"]];
         checkView.image = [checkView.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
         [checkView setTintColor:[UIColor lightGrayColor]];
+        [checkView setAccessibilityValue:@"MessageSent"];
         [self.statusView addSubview:checkView];
     } else if (state == ChatMessageDeliveryStateRead) {
         UIImageView *checkAllView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 20, 20)];
         [checkAllView setImage:[UIImage imageNamed:@"check-all"]];
         checkAllView.image = [checkAllView.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
         [checkAllView setTintColor:[UIColor lightGrayColor]];
+        [checkAllView setAccessibilityValue:@"MessageSent"];
         [self.statusView addSubview:checkAllView];
     }
 }

--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -241,6 +241,8 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         // Notifications when runing on Mac 
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidBecomeActive:) name:@"NSApplicationDidBecomeActiveNotification" object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appWillResignActive:) name:@"NSApplicationDidResignActiveNotification" object:nil];
+
+        [NCUserInterfaceController sharedInstance].numberOfAllocatedChatViewControllers += 1;
     }
     
     return self;
@@ -249,6 +251,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [NCUserInterfaceController sharedInstance].numberOfAllocatedChatViewControllers -= 1;
     NSLog(@"Dealloc NCChatViewController");
 }
 

--- a/NextcloudTalk/NCUserInterfaceController.h
+++ b/NextcloudTalk/NCUserInterfaceController.h
@@ -38,6 +38,8 @@ typedef void (^PresentCallControllerCompletionBlock)(void);
 
 @property (nonatomic, strong) NCSplitViewController *mainViewController;
 @property (nonatomic, strong) RoomsTableViewController *roomsTableViewController;
+@property (nonatomic, assign) NSInteger numberOfAllocatedChatViewControllers;
+@property (nonatomic, assign) NSInteger numberOfAllocatedCallViewControllers;
 
 + (instancetype)sharedInstance;
 - (void)presentConversationsList;

--- a/NextcloudTalkUITests/NextcloudTalkUITests.swift
+++ b/NextcloudTalkUITests/NextcloudTalkUITests.swift
@@ -191,7 +191,7 @@ final class NextcloudTalkUITests: XCTestCase {
         sendMessageButton.tap()
 
         // Wait for temporary message to be replaced
-        sleep(5)
+        XCTAssert(app.images["MessageSent"].waitForExistence(timeout: timeoutShort))
 
         // Open context menu
         let tables = app.tables

--- a/NextcloudTalkUITests/NextcloudTalkUITests.swift
+++ b/NextcloudTalkUITests/NextcloudTalkUITests.swift
@@ -177,6 +177,9 @@ final class NextcloudTalkUITests: XCTestCase {
         app.typeText(newConversationName)
         app.navigationBars["New group conversation"].buttons["Create"].tap()
 
+        // Check if we have one chat view controller allocated
+        XCTAssert(app.staticTexts["ChatVC: 1 / CallVC: 0"].waitForExistence(timeout: timeoutShort))
+
         // Send a test message
         let testMessage = "TestMessage"
         let toolbar = app.toolbars["Toolbar"]


### PR DESCRIPTION
Based on and test for https://github.com/nextcloud/talk-ios/pull/1323

To track (de-)allocations we add a `UILabel` to the main view controller when we are in a test environment (added as a startup parameter to the app). The label will be updated continuously with the number of allocated chat/call view controllers. 

The test works like this:
* Create a new group conversation
* Send a message
* Open context menu for the new message
* Add a reaction (mainly to close the contextmenu again)
* Go back to the main view controller
* Check that we are back at "0" allocated chat view controllers

Before #1323 this test fails, after #1323 the test succeeds.