### PR TITLE
Add markdown property to NCChatMessage

### DIFF
--- a/NextcloudTalk/NCChatMessage.h
+++ b/NextcloudTalk/NCChatMessage.h
@@ -87,6 +87,7 @@ typedef void (^GetReferenceDataCompletionBlock)(NCChatMessage *message, NSDictio
 @property (nonatomic, assign) BOOL collapsedIncludesActorSelf;
 @property (nonatomic, assign) BOOL collapsedIncludesUserSelf;
 @property (nonatomic, assign) BOOL isCollapsed;
+@property (nonatomic, assign) BOOL isMarkdownMessage;
 
 + (instancetype)messageWithDictionary:(NSDictionary *)messageDict;
 + (instancetype)messageWithDictionary:(NSDictionary *)messageDict andAccountId:(NSString *)accountId;

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -80,6 +80,7 @@ NSString * const kSharedItemTypeRecording   = @"recording";
     message.referenceId = [messageDict objectForKey:@"referenceId"];
     message.messageType = [messageDict objectForKey:@"messageType"];
     message.expirationTimestamp = [[messageDict objectForKey:@"expirationTimestamp"] integerValue];
+    message.isMarkdownMessage = [[messageDict objectForKey:@"markdown"] boolValue];
     
     id actorDisplayName = [messageDict objectForKey:@"actorDisplayName"];
     if (!actorDisplayName) {
@@ -169,6 +170,7 @@ NSString * const kSharedItemTypeRecording   = @"recording";
     managedChatMessage.messageType = chatMessage.messageType;
     managedChatMessage.reactionsJSONString = chatMessage.reactionsJSONString;
     managedChatMessage.expirationTimestamp = chatMessage.expirationTimestamp;
+    managedChatMessage.isMarkdownMessage = chatMessage.isMarkdownMessage;
     
     if (!isRoomLastMessage) {
         managedChatMessage.reactionsSelfJSONString = chatMessage.reactionsSelfJSONString;
@@ -215,6 +217,7 @@ NSString * const kSharedItemTypeRecording   = @"recording";
     messageCopy.isDeleting = _isDeleting;
     messageCopy.isOfflineMessage = _isOfflineMessage;
     messageCopy.isSilent = _isSilent;
+    messageCopy.isMarkdownMessage = _isMarkdownMessage;
     
     return messageCopy;
 }
@@ -508,6 +511,10 @@ NSString * const kSharedItemTypeRecording   = @"recording";
         return nil;
     }
 
+    if (!_isMarkdownMessage) {
+        return parsedMessage;
+    }
+
     return [SwiftMarkdownObjCBridge parseMarkdownWithMarkdownString:parsedMessage];
 }
 
@@ -522,6 +529,10 @@ NSString * const kSharedItemTypeRecording   = @"recording";
 
     if (!parsedMessage) {
         return nil;
+    }
+
+    if (!_isMarkdownMessage) {
+        return parsedMessage;
     }
 
     return [SwiftMarkdownObjCBridge parseMarkdownWithMarkdownString:parsedMessage];

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -33,7 +33,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 53;
+uint64_t const kTalkDatabaseSchemaVersion           = 54;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";


### PR DESCRIPTION
Fixes #1299 

Render markdown only if we receive the `markdown` property for the message.