### PR TITLE
Fix appStateHasChanged in SettingsTableViewController

### DIFF
--- a/NextcloudTalk/SettingsTableViewController.swift
+++ b/NextcloudTalk/SettingsTableViewController.swift
@@ -248,7 +248,8 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
 
     @objc func appStateHasChanged(notification: NSNotification) {
         let appState = notification.userInfo?["appState"]
-        if let appState = appState as? AppState {
+        if let rawAppState = appState as? UInt32 {
+            let appState = AppState(rawValue: rawAppState)
             self.adaptInterfaceForAppState(appState: appState)
         }
     }


### PR DESCRIPTION
Fixes #1326 

We can't directly convert a `typedef enum` from ObjC to the bridged Swift enum. Therefore the `if let` construct fails and we never update the UI after the app state was changed.