### PR TITLE
Fix reloading of non-loaded messages when grouping

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -3784,14 +3784,13 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
         }
     }
 
-    // Reload collapsedBy message if it's already laoded in the chat
-    NSMutableArray *reloadIndexPaths = [NSMutableArray new];
+    // Reload collapsedBy message if it's already loaded in the chat
     NSIndexPath *indexPath = [self indexPathForMessageWithMessageId:collapseByMessage.messageId];
-    if (indexPath) {
-        [reloadIndexPaths addObject:indexPath];
 
+    // Make sure the cells are really loaded into the tableView before trying to reload them
+    if (indexPath && indexPath.section < self.tableView.numberOfSections && indexPath.row < [self.tableView numberOfRowsInSection:indexPath.section]) {
         [self.tableView beginUpdates];
-        [self.tableView reloadRowsAtIndexPaths:reloadIndexPaths withRowAnimation:UITableViewRowAnimationNone];
+        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
         [self.tableView endUpdates];
     }
 }


### PR DESCRIPTION
When we receive new messages, these messages are added to the dictionary before being loaded into the tableView, but since we check the grouping in between adding to the dictionary and loading into the view, we crash when we try to reload those non-loaded messages.
Therefore we need to check if the messages are currently loaded before trying to perform a reload. When they're not loaded, they will be loaded in the batch update after all new messages are processed, so visually everything works as expected.

How to test:
- iPhone1 in conversation "A"
- iPhone1 moved to background
- iPhone2 adds multiple users to conversation "A"
- iPhone1 come back from background -> crash