### PR TITLE
Don't show a context menu for a deleted message

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -4638,7 +4638,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     NSDate *sectionDate = [_dateSections objectAtIndex:indexPath.section];
     NCChatMessage *message = [[_messages objectForKey:sectionDate] objectAtIndex:indexPath.row];
     
-    if (message.isSystemMessage || message.messageId == kUnreadMessagesSeparatorIdentifier) {
+    if (message.isSystemMessage || message.isDeletedMessage || message.messageId == kUnreadMessagesSeparatorIdentifier) {
         return nil;
     }
         
@@ -4682,7 +4682,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     }
 
     // Remind me later
-    if (!message.sendingFailed && !message.isOfflineMessage && !message.isDeletedMessage && [[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityRemindMeLater]) {
+    if (!message.sendingFailed && !message.isOfflineMessage && [[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityRemindMeLater]) {
         UIImage *remindMeLaterImage = [UIImage systemImageNamed:@"alarm"];
 
         __weak typeof(self) weakSelf = self;
@@ -4749,7 +4749,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     [actions addObject:copyAction];
     
     // Translate
-    if (!message.isDeletedMessage && !_offlineMode && [[NCSettingsController sharedInstance] availableTranslations].count > 0) {
+    if (!_offlineMode && [[NCSettingsController sharedInstance] availableTranslations].count > 0) {
         UIImage *translateImage = [UIImage systemImageNamed:@"character.book.closed"];
         UIAction *translateAction = [UIAction actionWithTitle:NSLocalizedString(@"Translate", nil) image:translateImage identifier:nil handler:^(UIAction *action){
 


### PR DESCRIPTION
I see no reason why we should show a contextmenu (having a "copy" option) for a deleted message.