### PR TITLE
Improve signaling logging

### DIFF
--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -727,7 +727,7 @@ NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotification     
                 }
             }
 
-            NSLog(@"Could not send chat message. Error: %@", error.description);
+            [NCUtils log:[NSString stringWithFormat:@"Could not send chat message. Error: %@", error.description]];
         } else {
             [[NCIntentController sharedInstance] donateSendMessageIntentForRoom:self->_room];
         }

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -240,6 +240,7 @@ NSString * const NCExternalSignalingControllerDidReceiveStoppedTypingNotificatio
             _pendingMessages = [NSMutableArray new];
         }
 
+        [NCUtils log:@"Trying to send message before we received a hello response -> adding to pendingMessages"];
         [_pendingMessages addObject:wsMessage];
         return;
     }
@@ -296,6 +297,8 @@ NSString * const NCExternalSignalingControllerDidReceiveStoppedTypingNotificatio
                               }
                       };
     }
+
+    [NCUtils log:@"Sending hello message"];
     
     [self sendMessage:helloDict withCompletionBlock:^(NSURLSessionWebSocketTask *task, NCExternalSignalingSendMessageStatus status) {
         if (status == SendMessageSocketError && task == self->_webSocket) {
@@ -308,6 +311,8 @@ NSString * const NCExternalSignalingControllerDidReceiveStoppedTypingNotificatio
 - (void)helloResponseReceived:(NSDictionary *)messageDict
 {
     _helloResponseReceived = YES;
+
+    [NCUtils log:[NSString stringWithFormat:@"Hello received with %ld pending messages", _pendingMessages.count]];
 
     NSString *messageId = [messageDict objectForKey:@"id"];
     [self executeCompletionBlockForMessageId:messageId withStatus:SendMessageSuccess];
@@ -672,7 +677,7 @@ NSString * const NCExternalSignalingControllerDidReceiveStoppedTypingNotificatio
         }
 
 
-        NSLog(@"WebSocket Connected!");
+        [NCUtils log:@"WebSocket Connected!"];
         self->_reconnectInterval = kInitialReconnectInterval;
         [self sendHelloMessage];
     });
@@ -685,7 +690,7 @@ NSString * const NCExternalSignalingControllerDidReceiveStoppedTypingNotificatio
             return;
         }
 
-        NSLog(@"WebSocket didCloseWithCode:%ld reason:%@", (long)closeCode, reason);
+        [NCUtils log:[NSString stringWithFormat:@"WebSocket didCloseWithCode:%ld reason:%@", (long)closeCode, reason]];
         [self reconnect];
     });
 }
@@ -698,7 +703,7 @@ NSString * const NCExternalSignalingControllerDidReceiveStoppedTypingNotificatio
         }
 
         if (error) {
-            NSLog(@"WebSocket session didCompleteWithError: %@", error.description);
+            [NCUtils log:[NSString stringWithFormat:@"WebSocket session didCompleteWithError: %@", error.description]];
             [self reconnect];
         }
     });

--- a/NextcloudTalk/NCUtils.m
+++ b/NextcloudTalk/NCUtils.m
@@ -486,23 +486,12 @@ static NSString *const nextcloudScheme = @"nextcloud:";
         }
 
         dispatch_queue_t currentQueue = dispatch_get_current_queue();
-
-        int applicationState = -1;
-        float backgroundTimeRemaining = -1;
-
-    #ifndef APP_EXTENSION
-        applicationState = (int)[UIApplication sharedApplication].applicationState;
-        backgroundTimeRemaining = [UIApplication sharedApplication].backgroundTimeRemaining;
-    #endif
-
         NSDate *now = [NSDate date];
 
-        NSString *logMessage = [NSString stringWithFormat:@"%@ (%@): %@\nState: %d, Time remaining %f\n\n",
+        NSString *logMessage = [NSString stringWithFormat:@"%@ (%@): %@\n",
                                 [now formattedDateWithFormat:@"y-MM-dd H:mm:ss.SSSS"],
                                 [currentQueue description],
-                                message,
-                                applicationState,
-                                backgroundTimeRemaining
+                                message
         ];
 
 


### PR DESCRIPTION
Attempt to get some more information about #1317 

* Removed calls to `UIApplication` from `NSLog` because that shouldn't be called from a background queue
* Added some more verbose logging to the signaling controller