### PR TITLE
Remove session of leaving participant from _participantMap

### DIFF
--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -528,6 +528,8 @@ NSString * const NCExternalSignalingControllerDidReceiveStoppedTypingNotificatio
         for (NSString *sessionId in leftSessions) {
             NSString *userId = [self getUserIdFromSessionId:sessionId];
 
+            [_participantsMap removeObjectForKey:sessionId];
+
             if ([sessionId isEqualToString:_sessionId] || [userId isEqualToString:_userId]) {
                 // Ignore own session
                 continue;


### PR DESCRIPTION
How to test:

iOS 1, user1:
* Be in room1

iOS 2, user2:
* Start to type and continue to type

iOS 1, user1:
* See that `user2` is writing
* Leave room and join `room2`

Without this PR:
* Wait for a bit and then see `Guest is typing`

With this PR:
* Nothing happens

