### PR TITLE
Correctly render temporary messages when markdown is supported

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -1073,6 +1073,7 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     temporaryMessage.parentId = parentMessage.internalId;
     temporaryMessage.messageParametersJSONString = messageParameters;
     temporaryMessage.isSilent = silently;
+    temporaryMessage.isMarkdownMessage = [[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityMarkdownMessages];
 
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm transactionWithBlock:^{

--- a/NextcloudTalk/NCDatabaseManager.h
+++ b/NextcloudTalk/NCDatabaseManager.h
@@ -77,6 +77,7 @@ extern NSString * const kCapabilityConversationAvatars;
 extern NSString * const kCapabilityTypingIndicators;
 extern NSString * const kCapabilityPublishingPermissions;
 extern NSString * const kCapabilityRemindMeLater;
+extern NSString * const kCapabilityMarkdownMessages;
 
 extern NSString * const kNotificationsCapabilityExists;
 

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -81,6 +81,7 @@ NSString * const kCapabilityConversationAvatars     = @"avatar";
 NSString * const kCapabilityTypingIndicators        = @"typing-privacy";
 NSString * const kCapabilityPublishingPermissions   = @"publishing-permissions";
 NSString * const kCapabilityRemindMeLater           = @"remind-me-later";
+NSString * const kCapabilityMarkdownMessages        = @"markdown-messages";
 
 NSString * const kNotificationsCapabilityExists     = @"exists";
 


### PR DESCRIPTION
Since we introduced the `markdown` property to the messages on the server, we render all temporary messages without markdown. Now we have a capability to check if the server supports markdown, so we can now correctly render the temporary messages as well.

Server PR for reference: https://github.com/nextcloud/spreed/pull/10364