### PR TITLE
Make the call buttons 44px wide

### DIFF
--- a/NextcloudTalk/NCChatViewController.m
+++ b/NextcloudTalk/NCChatViewController.m
@@ -786,8 +786,8 @@ NSString * const NCChatViewControllerTalkToUserNotification = @"NCChatViewContro
     UIImage *videoCallImage = [UIImage systemImageNamed:@"video" withConfiguration:symbolConfiguration];
     UIImage *voiceCallImage = [UIImage systemImageNamed:@"phone" withConfiguration:symbolConfiguration];
     
-    CGFloat buttonWidth = 24.0;
-    CGFloat buttonPadding = 30.0;
+    CGFloat buttonWidth = 44.0;
+    CGFloat buttonPadding = 16.0;
     
     _videoCallButton = [[BarButtonItemWithActivity alloc] initWithWidth:buttonWidth withImage:videoCallImage];
     [_videoCallButton.innerButton addTarget:self action:@selector(videoCallButtonPressed:) forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
Not sure why we had 24 before, but in recent iOS versions you can observe a little "jump" of the title when pressing the video call button. Also the minimum size for a button should be 44px.