### PR TITLE
Don't create subviews on invisible system message cells

### DIFF
--- a/NextcloudTalk/SystemMessageTableViewCell.m
+++ b/NextcloudTalk/SystemMessageTableViewCell.m
@@ -25,6 +25,10 @@
 #import "NCAppBranding.h"
 #import "NCUtils.h"
 
+@interface SystemMessageTableViewCell () <UITextFieldDelegate>
+@property (nonatomic, assign) BOOL didCreateSubviews;
+@end
+
 @implementation SystemMessageTableViewCell
 
 - (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier
@@ -33,8 +37,6 @@
     if (self) {
         self.selectionStyle = UITableViewCellSelectionStyleNone;
         self.backgroundColor = [NCAppBranding backgroundColor];
-        
-        [self configureSubviews];
     }
     return self;
 }
@@ -44,11 +46,11 @@
     if ([self.reuseIdentifier isEqualToString:InvisibleSystemMessageCellIdentifier]) {
         return;
     }
-    
+
     [self.contentView addSubview:self.dateLabel];
     [self.contentView addSubview:self.bodyTextView];
     [self.contentView addSubview:self.collapseButton];
-    
+
     NSDictionary *views = @{@"dateLabel": self.dateLabel,
                             @"bodyTextView": self.bodyTextView,
                             @"collapseButton" : self.collapseButton
@@ -62,12 +64,18 @@
     
     [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-avatarGap-[bodyTextView]-[dateLabel(>=dateLabelWidth)]-right-|" options:0 metrics:metrics views:views]];
     [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-left-[collapseButton(40)]-left-[bodyTextView]-[dateLabel(>=dateLabelWidth)]-right-|" options:NSLayoutFormatAlignAllCenterY metrics:metrics views:views]];
-    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-left-[bodyTextView(>=0@999)]-left-|" options:0 metrics:metrics views:views]];
+    [self.bodyTextView.centerYAnchor constraintEqualToAnchor:self.contentView.centerYAnchor].active = YES;
+
+    self.didCreateSubviews = YES;
 }
 
 - (void)prepareForReuse
 {
     [super prepareForReuse];
+
+    if (!self.didCreateSubviews) {
+        [self configureSubviews];
+    }
     
     self.selectionStyle = UITableViewCellSelectionStyleNone;
     self.backgroundColor = [NCAppBranding backgroundColor];
@@ -132,6 +140,17 @@
 
 - (void)setupForMessage:(NCChatMessage *)message
 {
+    self.collapseButton.hidden = (message.isCollapsed || message.collapsedMessages.count == 0);
+
+    // If the message is not visible, we don't need to setup this cell
+    if (message.isCollapsed && message.collapsedBy) {
+        return;
+    }
+
+    if (!self.didCreateSubviews) {
+        [self configureSubviews];
+    }
+    
     self.bodyTextView.attributedText = message.systemMessageFormat;
     self.messageId = message.messageId;
     self.message = message;
@@ -139,12 +158,6 @@
     if (!message.isGroupMessage && !(message.isCollapsed && message.collapsedBy > 0)) {
         NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:message.timestamp];
         self.dateLabel.text = [NCUtils getTimeFromDate:date];
-    }
-
-    if (!message.isCollapsed && message.collapsedMessages.count > 0) {
-        self.collapseButton.hidden = NO;
-    } else {
-        self.collapseButton.hidden = YES;
     }
 
     if (!message.isCollapsed && (message.collapsedBy > 0 || message.collapsedMessages.count > 0)) {


### PR DESCRIPTION
It only makes sense to add views to the SystemMessageTableViewCell if we are actually trying to show something. If not, it's just a waste of performance.
This can happen in 2 cases right now:
* Many reactions being added to messages (each reaction creates a invisible system message)
* Many collapsed system messages (even if they are not shown)