### PR TITLE
Remove docker workaround

### DIFF
--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -44,12 +44,6 @@ jobs:
     
     - name: Install docker
       run: |
-
-        # Workaround for https://github.com/actions/runner-images/issues/8104
-        brew remove --ignore-dependencies qemu
-        curl -o ./qemu.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/dc0669eca9479e9eeb495397ba3a7480aaa45c2e/Formula/qemu.rb
-        brew install ./qemu.rb
-
         brew install docker
         colima start
 


### PR DESCRIPTION
Looks like we don't need to workaround anymore. In some runs it even failed, so removing.