### PR TITLE
Test with 23

### DIFF
--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/**'
       - NextcloudTalk.xcodeproj/**
       - NextcloudTalk/**
+      - NextcloudTalkUITests/**
       - NotificationServiceExtension/**
       - ShareExtension/**
 

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -43,7 +43,14 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
-    
+
+    - uses: actions/cache@v3
+      with:
+        path: Pods
+        key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-pods-
+
     - name: Install docker
       run: |
         brew install docker

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -26,7 +26,8 @@ jobs:
 
     strategy:
       matrix:
-        test-branches: ['stable27', 'master']
+        # Test with stable23 as well to find regressions in older versions
+        test-branches: ['stable23', 'stable27', 'master']
 
     env:
       WORKSPACE: NextcloudTalk.xcworkspace

--- a/NextcloudTalkUITests/NextcloudTalkUITests.swift
+++ b/NextcloudTalkUITests/NextcloudTalkUITests.swift
@@ -200,8 +200,16 @@ final class NextcloudTalkUITests: XCTestCase {
         message.press(forDuration: 2.0)
 
         // Add a reaction to close the context menu
-        XCTAssert(app.staticTexts["👍"].waitForExistence(timeout: timeoutShort))
-        app.staticTexts["👍"].tap()
+        let reactionExists = app.staticTexts["👍"].waitForExistence(timeout: timeoutShort)
+
+        if reactionExists {
+            app.staticTexts["👍"].tap()
+        } else {
+            // In case we are testing against a nextcloud version that does not support reactions (<= NC 23)
+            // we simply tap the "Reply" button from the context menu
+            XCTAssert(app.buttons["Reply"].waitForExistence(timeout: timeoutShort))
+            app.buttons["Reply"].tap()
+        }
 
         // Go back to the main view controller
         let chatNavBar = app.navigationBars["NCChatView"]


### PR DESCRIPTION
The run on 23 without the patch for the participantFlags fails as expected: https://github.com/nextcloud/talk-ios/actions/runs/6273738989/job/17037766340
So I would suggest we add 23 to our test matrix to catch any issues with older versions