### PR TITLE
Fix crash on iOS 17 when avatar was not downloaded before

### DIFF
--- a/NextcloudTalk/NCCameraController.swift
+++ b/NextcloudTalk/NCCameraController.swift
@@ -220,9 +220,9 @@ class NCCameraController: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate
             self.session?.sessionPreset = .inputPriority
 
             if self.usingFrontCamera {
-                self.session?.addInput(getFrontCameraInput())
+                self.session?.addInput(self.getFrontCameraInput())
             } else {
-                self.session?.addInput(getBackCameraInput())
+                self.session?.addInput(self.getBackCameraInput())
             }
 
             let output = AVCaptureVideoDataOutput()

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -439,21 +439,24 @@ typedef enum RoomsFilter {
     for (TalkAccount *account in [[NCDatabaseManager sharedInstance] allAccounts]) {
         NSString *accountName = account.userDisplayName;
         UIImage *accountImage = [[NCAPIController sharedInstance] userProfileImageForAccount:account withStyle:self.traitCollection.userInterfaceStyle];
-        accountImage = [NCUtils roundedImageFromImage:accountImage];
 
-        // Draw a red circle to the image in case we have unread notifications for that account
-        if (account.unreadNotification) {
-            UIGraphicsBeginImageContextWithOptions(CGSizeMake(82, 82), NO, 3);
-            CGContextRef context = UIGraphicsGetCurrentContext();
-            [accountImage drawInRect:CGRectMake(0, 4, 78, 78)];
-            CGContextSaveGState(context);
+        if (accountImage) {
+            accountImage = [NCUtils roundedImageFromImage:accountImage];
 
-            CGContextSetFillColorWithColor(context, [UIColor systemRedColor].CGColor);
-            CGContextFillEllipseInRect(context, CGRectMake(52, 0, 30, 30));
+            // Draw a red circle to the image in case we have unread notifications for that account
+            if (account.unreadNotification) {
+                UIGraphicsBeginImageContextWithOptions(CGSizeMake(82, 82), NO, 3);
+                CGContextRef context = UIGraphicsGetCurrentContext();
+                [accountImage drawInRect:CGRectMake(0, 4, 78, 78)];
+                CGContextSaveGState(context);
 
-            accountImage = UIGraphicsGetImageFromCurrentImageContext();
+                CGContextSetFillColorWithColor(context, [UIColor systemRedColor].CGColor);
+                CGContextFillEllipseInRect(context, CGRectMake(52, 0, 30, 30));
 
-            UIGraphicsEndImageContext();
+                accountImage = UIGraphicsGetImageFromCurrentImageContext();
+
+                UIGraphicsEndImageContext();
+            }
         }
 
         UIAction *switchAccountAction = [UIAction actionWithTitle:accountName image:accountImage identifier:nil handler:^(UIAction *action) {


### PR DESCRIPTION
When we create the UIMenu and don't have an avatar downloaded, it will crash on iOS 17, whereas it worked on iOS 16.

Best checked as https://github.com/nextcloud/talk-ios/pull/1375/commits/ab4594e677e984e70556c6c3f317328242e0a804?diff=unified&w=1