### PR TITLE
Fix position of message expiration selector on iPads

### DIFF
--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -433,6 +433,17 @@ typedef enum FileAction {
     return [NSArray arrayWithArray:actions];
 }
 
+- (NSIndexPath *)getIndexPathForConversationAction:(ConversationAction)action
+{
+    NSInteger section = [self getSectionForRoomInfoSection:kRoomInfoSectionConversation];
+    NSIndexPath *actionIndexPath = [NSIndexPath indexPathForRow:0 inSection:section];
+    NSInteger actionRow = [[self getConversationActions] indexOfObject:[NSNumber numberWithInt:action]];
+    if(NSNotFound != actionRow) {
+        actionIndexPath = [NSIndexPath indexPathForRow:actionRow inSection:section];
+    }
+    return actionIndexPath;
+}
+
 - (NSArray *)getWebinarActions
 {
     NSMutableArray *actions = [[NSMutableArray alloc] init];
@@ -688,8 +699,8 @@ typedef enum FileAction {
     
     // Presentation on iPads
     optionsActionSheet.popoverPresentationController.sourceView = self.tableView;
-    optionsActionSheet.popoverPresentationController.sourceRect = [self.tableView rectForRowAtIndexPath:[self getIndexPathForNotificationAction:kNotificationActionChatNotifications]];
-    
+    optionsActionSheet.popoverPresentationController.sourceRect = [self.tableView rectForRowAtIndexPath:[self getIndexPathForConversationAction:kConversationActionMessageExpiration]];
+
     [self presentViewController:optionsActionSheet animated:YES completion:nil];
 }
 


### PR DESCRIPTION
Noticed while checking #1378 

Before:

![image](https://github.com/nextcloud/talk-ios/assets/1580193/a38b26b8-61cb-4cf6-99d0-54a8e67a55bb)


After: 

![image](https://github.com/nextcloud/talk-ios/assets/1580193/eb6e2e1c-63ee-4023-ba40-10684ec93271)
