### PR TITLE
Fix clearing of messages

### DIFF
--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -85,12 +85,10 @@ import QuickLook
 
     internal lazy var chatBackgroundView: PlaceholderView = {
         let chatBackgroundView = PlaceholderView()
-        chatBackgroundView.isHidden = true
+        chatBackgroundView.placeholderView.isHidden = true
         chatBackgroundView.loadingView.startAnimating()
         chatBackgroundView.placeholderTextView.text = NSLocalizedString("No messages yet, start the conversation!", comment: "")
         chatBackgroundView.setImage(UIImage(named: "chat-placeholder"))
-
-        self.tableView?.backgroundView = chatBackgroundView
 
         return chatBackgroundView
     }()

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -654,6 +654,16 @@ NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotification     
             if (messages.count > 0) {
                 [self storeMessages:messages];
                 [self checkForNewMessagesFromMessageId:messageId];
+
+                for (NSDictionary *messageDict in messages) {
+                    NCChatMessage *message = [NCChatMessage messageWithDictionary:messageDict andAccountId:self->_account.accountId];
+
+                    // When we receive a "history_cleared" message, we don't continue here, as otherwise
+                    // we would request new message, but instead, we need to request the inital history again
+                    if ([message.systemMessage isEqualToString:@"history_cleared"]) {
+                        return;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Fix #1388 
Regression from #1178 

In the PR above the `return` statement was moved to a separate function, therefore we did not stop in the completion block anymore and requested new messages directly afterwards. This stopped our call the get the initial chat history and we only tried to get new messages. We fetched the "You cleared..." message, but would not create the corresponding chat block, resulting in an infinite fetching of new messages.