### PR TITLE
Setup spell checker for localizable file

### DIFF
--- a/.github/workflows/localizable.yml
+++ b/.github/workflows/localizable.yml
@@ -38,9 +38,18 @@ jobs:
       run: |
         git diff
 
+    - name: Install dependencies
+      run: |
+        pip3 install pyspelling
+
+    - name: Spell check
+      run: |
+        python3 -m pyspelling
+
     - name: Verify Changed files
       uses: tj-actions/verify-changed-files@v16
       id: verify-changed-files
+      if: always()
       with:
         fail-if-changed: true
         files: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ NextcloudTalk.xcworkspace/xcshareddata
 ThirdParty/WebRTC.xcframework
 .DS_Store
 testResult.xcresult
+dictionary.dic

--- a/.pyspelling.wordlist.txt
+++ b/.pyspelling.wordlist.txt
@@ -1,0 +1,13 @@
+AirPlay
+Cancelled
+HPB
+Matterbridge
+Nextcloud
+Repo
+backend
+formattedPhoneNumber
+https
+ld
+listable
+lu
+decrypted

--- a/.pyspelling.yml
+++ b/.pyspelling.yml
@@ -1,0 +1,10 @@
+matrix:
+- name: English localizable file
+  aspell:
+    lang: en
+    d: en_US
+  dictionary:
+    wordlists:
+      - .pyspelling.wordlist.txt
+  sources:
+  - NextcloudTalk/en.lproj/Localizable.strings 

--- a/NextcloudTalk/CallKitManager.m
+++ b/NextcloudTalk/CallKitManager.m
@@ -258,7 +258,7 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
 - (void)reportIncomingCallForOldAccount
 {
     CXCallUpdate *update = [self defaultCallUpdate];
-    update.localizedCallerName = NSLocalizedString(@"Old account", @"Will be used as the caller name when a voip notification can't be decrypted");
+    update.localizedCallerName = NSLocalizedString(@"Old account", @"Will be used as the caller name when a VoIP notification can't be decrypted");
 
     NSUUID *callUUID = [NSUUID new];
     CallKitCall *call = [[CallKitCall alloc] init];

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -1189,7 +1189,7 @@
 /* No comment provided by engineer. */
 "OK" = "OK";
 
-/* Will be used as the caller name when a voip notification can't be decrypted */
+/* Will be used as the caller name when a VoIP notification can't be decrypted */
 "Old account" = "Old account";
 
 /* No comment provided by engineer. */
@@ -1624,7 +1624,7 @@
 /* No comment provided by engineer. */
 "To resolve this issue, use the web interface and go to \"Settings -> Security\"." = "To resolve this issue, use the web interface and go to \"Settings -> Security\".";
 
-/* TRANSLATORS this is for sending something 'to' a user. Eg. 'To: John Doe' */
+/* TRANSLATORS this is for sending something 'to' a user. E.g. 'To: John Doe' */
 "To:" = "To:";
 
 /* No comment provided by engineer. */

--- a/ShareExtension/ShareConfirmationViewController.m
+++ b/ShareExtension/ShareConfirmationViewController.m
@@ -123,7 +123,7 @@
     NSDictionary *subAttribute = @{NSFontAttributeName:[UIFont boldSystemFontOfSize:15],
                                    NSForegroundColorAttributeName:[UIColor tertiaryLabelColor]};
     
-    NSString *localizedToString = NSLocalizedString(@"To:", @"TRANSLATORS this is for sending something 'to' a user. Eg. 'To: John Doe'");
+    NSString *localizedToString = NSLocalizedString(@"To:", @"TRANSLATORS this is for sending something 'to' a user. E.g. 'To: John Doe'");
     NSMutableAttributedString *toString = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@ %@", localizedToString, _room.displayName] attributes:attributes];
     [toString addAttributes:subAttribute range:NSMakeRange(0, [localizedToString length])];
     self.toLabel.attributedText = toString;


### PR DESCRIPTION
Add spell check to localizable CI. Added it there to always check with the latest localizable file (otherwise the run would first fail for not correctly updating the localizable file and then for spell checking).

Test of failure: https://github.com/nextcloud/talk-ios/actions/runs/6657060665/job/18090981017?pr=1403