### PR TITLE
Fix CI after talk moved to main branch

### DIFF
--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -32,15 +32,16 @@ jobs:
     strategy:
       matrix:
         # Test with stable23 as well to find regressions in older versions
-        test-branches: ['stable23', 'stable27', 'master']
+        configs: [
+          { talkbranch: 'stable23', serverbranch: 'stable23', phpversion: '8.0' },
+          { talkbranch: 'stable27', serverbranch: 'stable27', phpversion: '8.2' },
+          { talkbranch: 'main', serverbranch: 'master', phpversion: '8.2' }
+        ]
 
     env:
       WORKSPACE: NextcloudTalk.xcworkspace
       DESTINATION: platform=iOS Simulator,name=iPhone 14,OS=16.2
       SCHEME: NextcloudTalk
-      TEST_BRANCH: ${{ matrix.test-branches }}
-      CONTAINER_NAME: nextcloud_test
-      SERVER_PORT: 8080
 
     steps:
     - name: Checkout app
@@ -55,11 +56,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pods-
 
-    - name: Set up php 8.2
+    - name: Set up php ${{ matrix.configs.phpversion }}
       uses: shivammathur/setup-php@c5fc0d8281aba02c7fda07d3a70cc5371548067d # v2
-      if: matrix.test-branches != 'stable23'
       with:
-        php-version: 8.2
+        php-version: ${{ matrix.configs.phpversion }}
         # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
         extensions: apcu, bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql
         coverage: none
@@ -69,34 +69,20 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set up php 8.0
-      uses: shivammathur/setup-php@c5fc0d8281aba02c7fda07d3a70cc5371548067d # v2
-      if: matrix.test-branches == 'stable23'
-      with:
-        php-version: 8.0
-        # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
-        extensions: apcu, bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql
-        coverage: none
-        ini-file: development
-        # Temporary workaround for missing pcntl_* in PHP 8.3: ini-values: apc.enable_cli=on
-        ini-values: apc.enable_cli=on, disable_functions=
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}           
-
     - name: Checkout server
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
         submodules: true
         repository: nextcloud/server
         path: server
-        ref: ${{ matrix.test-branches }}
+        ref: ${{ matrix.configs.serverbranch }}
 
     - name: Checkout Talk
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
         repository: nextcloud/spreed
         path: server/apps/spreed
-        ref: ${{ matrix.test-branches }}
+        ref: ${{ matrix.configs.talkbranch }}
 
     - name: Set up production dependencies
       working-directory: server/apps/spreed
@@ -130,5 +116,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ !cancelled() }}
       with:
-        name: testResults-${{ matrix.test-branches }}.xcresult
+        name: testResults-${{ matrix.configs.talkbranch }}.xcresult
         path: "testResult.xcresult"


### PR DESCRIPTION
After talk moved to main branch, we need to adjust our tests. I made the test matrix a bit clearer, so we can easily adjust server branch, talk branch and used php version.