### PR TITLE
Fix color of send button in ShareConfirmationViewController

### DIFF
--- a/ShareExtension/ShareConfirmationViewController.swift
+++ b/ShareExtension/ShareConfirmationViewController.swift
@@ -351,6 +351,7 @@ import AVFoundation
 
         if !captionAllowed {
             self.navigationItem.rightBarButtonItem = self.sendButton
+            self.navigationItem.rightBarButtonItem?.tintColor = NCAppBranding.themeTextColor()
             self.setTextInputbarHidden(true, animated: false)
         } else {
             let silentSendAction = UIAction(title: NSLocalizedString("Send without notification", comment: ""), image: UIImage(systemName: "bell.slash")) { [unowned self] _ in


### PR DESCRIPTION
Before:
![IMG_3D401642031F-1](https://github.com/nextcloud/talk-ios/assets/1580193/f98bd7fd-2f7a-476f-ae2f-40c2254577d4)

After:
![IMG_E5D93BA9F716-1](https://github.com/nextcloud/talk-ios/assets/1580193/66f2df05-fdac-4fa2-b089-c3328a87a484)