### PR TITLE
User status SwiftUI fixes

### DIFF
--- a/NextcloudTalk/SettingsTableViewController.swift
+++ b/NextcloudTalk/SettingsTableViewController.swift
@@ -58,7 +58,7 @@ enum AboutSection: Int {
     case kAboutSectionNumber
 }
 
-class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
+class SettingsTableViewController: UITableViewController, UITextFieldDelegate, UserStatusViewDelegate {
     let kPhoneTextFieldTag = 99
     let kUserSettingsCellIdentifier = "UserSettingsCellIdentifier"
     let kUserSettingsTableCellNibName = "UserSettingsTableViewCell"
@@ -317,15 +317,20 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
         let userProfileVC = UserProfileTableViewController(withAccount: activeAccount)
         self.navigationController?.pushViewController(userProfileVC, animated: true)
     }
-    
+
     // MARK: User Status (SwiftUI)
 
     func presentUserStatusOptions() {
         if let activeUserStatus = activeUserStatus {
-            let userStatusView = UserStatusSwiftUIView(userStatus: activeUserStatus)
+            var userStatusView = UserStatusSwiftUIView(userStatus: activeUserStatus)
+            userStatusView.delegate = self
             let hostingController = UIHostingController(rootView: userStatusView)
             self.present(hostingController, animated: true)
         }
+    }
+
+    func userStatusViewDidDisappear() {
+        self.getActiveUserStatus()
     }
 
     // MARK: User phone number

--- a/NextcloudTalk/SettingsTableViewController.swift
+++ b/NextcloudTalk/SettingsTableViewController.swift
@@ -733,7 +733,6 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate {
             } else {
                 cell.textLabel?.text = NSLocalizedString("Fetching status …", comment: "")
             }
-            cell.accessoryType = .disclosureIndicator
             return cell
         case SettingsSection.kSettingsSectionAccountSettings.rawValue:
             cell = userSettingsCell(for: indexPath)

--- a/NextcloudTalk/UserStatusMessageSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusMessageSwiftUIView.swift
@@ -155,6 +155,8 @@ struct UserStatusMessageSwiftUIView: View {
                         }
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(uiColor: .systemGroupedBackground))
         .navigationBarTitle(Text(NSLocalizedString("Status message", comment: "")), displayMode: .inline)
         .navigationBarHidden(false)
         .onAppear {

--- a/NextcloudTalk/UserStatusMessageSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusMessageSwiftUIView.swift
@@ -137,8 +137,9 @@ struct UserStatusMessageSwiftUIView: View {
                                                 action: setActiveUserStatus,
                                                 style: .primary, height: 40,
                                                 disabled: Binding.constant(selectedMessage.isEmpty))
+                                .padding(.bottom, 16)
                             }
-                        }else {
+                        } else {
                             HStack(spacing: 10) {
                                 Spacer()
                                 NCButtonSwiftUI(title: NSLocalizedString("Clear status message",
@@ -146,10 +147,12 @@ struct UserStatusMessageSwiftUIView: View {
                                                 action: clearActiveUserStatus,
                                                 style: .tertiary, height: 40,
                                                 disabled: Binding.constant(selectedMessage.isEmpty))
+                                .padding(.bottom, 16)
                                 NCButtonSwiftUI(title: NSLocalizedString("Set status message", comment: ""),
                                                 action: setActiveUserStatus,
                                                 style: .primary, height: 40,
                                                 disabled: Binding.constant(selectedMessage.isEmpty))
+                                .padding(.bottom, 16)
                                 Spacer()
                             }
                         }

--- a/NextcloudTalk/UserStatusSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusSwiftUIView.swift
@@ -23,7 +23,7 @@ import UIKit
 import SwiftUI
 import SwiftUIIntrospect
 
-protocol UserStatusViewDelegate{
+protocol UserStatusViewDelegate: AnyObject {
     func userStatusViewDidDisappear()
 }
 
@@ -37,7 +37,7 @@ struct UserStatusSwiftUIView: View {
         _userStatus = State(initialValue: userStatus)
     }
 
-    var delegate: UserStatusViewDelegate?
+    weak var delegate: UserStatusViewDelegate?
 
     var body: some View {
         NavigationView {

--- a/NextcloudTalk/UserStatusSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusSwiftUIView.swift
@@ -81,6 +81,7 @@ struct UserStatusSwiftUIView: View {
             appearance.configureWithOpaqueBackground()
             appearance.backgroundColor = NCAppBranding.themeColor()
             appearance.titleTextAttributes = [.foregroundColor: NCAppBranding.themeTextColor()]
+            navController.navigationBar.tintColor = NCAppBranding.themeTextColor()
             navController.navigationBar.standardAppearance = appearance
             navController.navigationBar.compactAppearance = appearance
             navController.navigationBar.scrollEdgeAppearance = appearance

--- a/NextcloudTalk/UserStatusSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusSwiftUIView.swift
@@ -23,6 +23,10 @@ import UIKit
 import SwiftUI
 import SwiftUIIntrospect
 
+protocol UserStatusViewDelegate{
+    func userStatusViewDidDisappear()
+}
+
 struct UserStatusSwiftUIView: View {
 
     @Environment(\.dismiss) var dismiss
@@ -32,6 +36,8 @@ struct UserStatusSwiftUIView: View {
     init(userStatus: NCUserStatus) {
         _userStatus = State(initialValue: userStatus)
     }
+
+    var delegate: UserStatusViewDelegate?
 
     var body: some View {
         NavigationView {
@@ -89,6 +95,10 @@ struct UserStatusSwiftUIView: View {
                 changed = false
             }
         }
+        .onDisappear {
+            delegate?.userStatusViewDidDisappear()
+        }
+
     }
 
     func getUserStatus() {

--- a/NextcloudTalk/UserStatusSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusSwiftUIView.swift
@@ -85,6 +85,7 @@ struct UserStatusSwiftUIView: View {
             navController.navigationBar.compactAppearance = appearance
             navController.navigationBar.scrollEdgeAppearance = appearance
         }
+        .navigationViewStyle(StackNavigationViewStyle())
         .tint(Color(NCAppBranding.themeTextColor()))
         .onAppear {
             getUserStatus()


### PR DESCRIPTION
Follow up of #1332 

- [x] Remove disclosure indicator in settings view for user status option since we are not presenting it as a modal
- [x] Update settings view when dismissing user status view.
- [x] Do not use default navigation style (SplitViewStyle on iPads).
- [x] Use same background colors for buttons as for tableview in UserStatusMessage view.
- [x] Add some padding to buttons in UserStatusMessage view.