### PR TITLE
Fix recording consent

### DIFF
--- a/NextcloudTalk/NCRoom.m
+++ b/NextcloudTalk/NCRoom.m
@@ -79,7 +79,7 @@ NSString * const NCRoomObjectTypeRoom           = @"room";
     room.callStartTime = [[roomDict objectForKey:@"callStartTime"] integerValue];
     room.avatarVersion = [roomDict objectForKey:@"avatarVersion"];
     room.isCustomAvatar = [roomDict objectForKey:@"isCustomAvatar"];
-    room.recordingConsent = [roomDict objectForKey:@"recordingConsent"];
+    room.recordingConsent = [[roomDict objectForKey:@"recordingConsent"] integerValue];
 
     // Local-only field -> update only if there's actually a value
     if ([roomDict objectForKey:@"pendingMessage"] != nil) {


### PR DESCRIPTION
Otherwise if the server sends the `recordingConsent` property back, we will always ask for consent, even if the value is "0"

For me it's fine like this for now, but we can of course also change the type of `recordingConsent` to int.