### PR TITLE
Markdown performance

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -3197,7 +3197,7 @@
 			repositoryURL = "https://github.com/nextcloud-deps/CDMarkdownKit.git";
 			requirement = {
 				kind = revision;
-				revision = a46582f9ec7ff58852231555f53cd267313d20cc;
+				revision = 6c175aade4227d5b04b93356f8df5bfd7b08f8c8;
 			};
 		};
 		1F0ECBFB2A73F21A00921E90 /* XCRemoteSwiftPackageReference "realm-swift" */ = {

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1343,7 +1343,13 @@ typedef enum RoomsFilter {
     // Set last activity
     if (room.lastMessage) {
         cell.titleOnly = NO;
-        cell.subtitleLabel.text = room.lastMessageString;
+
+        // Only use the first 80 characters of the message, so we don't need to calculate the label size for the whole message
+        NSString *lastRoomMessage = room.lastMessageString;
+        NSRange stringRange = {0, MIN([lastRoomMessage length], 80)};
+
+        stringRange = [lastRoomMessage rangeOfComposedCharacterSequencesForRange:stringRange];
+        cell.subtitleLabel.text = [lastRoomMessage substringWithRange:stringRange];
     } else {
         cell.titleOnly = YES;
     }

--- a/NextcloudTalk/SwiftMarkdownObjCBridge.swift
+++ b/NextcloudTalk/SwiftMarkdownObjCBridge.swift
@@ -37,6 +37,7 @@ import UIKit
         markdownParser.squashNewlines = false
         markdownParser.overwriteExistingStyle = false
         markdownParser.trimLeadingWhitespaces = false
+        markdownParser.automaticLinkDetectionEnabled = false
 
         markdownParser.image.enabled = false
 


### PR DESCRIPTION
Before:
![Bildschirmfoto 2023-11-11 um 16 03 43](https://github.com/nextcloud/talk-ios/assets/1580193/d5dc5367-e33d-41de-9328-68808d3d656c)

After:
![Bildschirmfoto 2023-11-11 um 16 06 06](https://github.com/nextcloud/talk-ios/assets/1580193/a0d2d738-1814-423b-a1fa-50845ff7785b)

Needs bump after https://github.com/nextcloud-deps/CDMarkdownKit/pull/13

I am a bit unsure about the automatic link detection. I can see no difference in my tests, all links worked fine since they are already parsed via the UITextView, just something to keep an eye on. Enabling it has a huge performance impact on the rendering.