### PR TITLE
Improve shared item list

### DIFF
--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -216,31 +216,10 @@ import QuickLook
 
         self.appendMessages(messages: messages)
 
-        guard let tableView = self.tableView
-        else { return }
-
-        tableView.performBatchUpdates({
-            tableView.reloadData()
+        self.tableView?.performBatchUpdates({
+            self.tableView?.reloadData()
         }, completion: { _ in
-            guard highlightMessageId > 0,
-                  let (indexPath, message) = self.indexPathAndMessage(forMessageId: highlightMessageId)
-            else { return }
-
-            self.highlightMessage(at: indexPath, with: .none)
-
-            let messageHeight = self.getCellHeight(for: message)
-            let rect = tableView.rectForRow(at: indexPath)
-
-            // ContentOffset when the cell is at the top of the tableView
-            let contentOffsetTop = rect.origin.y - tableView.safeAreaInsets.top
-
-            // ContentOffset when the cell is at the middle of the tableView
-            let contentOffsetMiddle = contentOffsetTop - tableView.frame.height / 2 + messageHeight / 2
-
-            // Fallback to the top offset in case the top of the cell would be scrolled outside of the view
-            let newContentOffset = min(contentOffsetTop, contentOffsetMiddle)
-
-            tableView.contentOffset.y = newContentOffset
+            self.highlightMessageWithContentOffset(messageId: highlightMessageId)
         })
     }
 
@@ -3027,6 +3006,34 @@ import QuickLook
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             self.tableView?.deselectRow(at: indexPath, animated: true)
         }
+    }
+
+    internal func highlightMessageWithContentOffset(messageId: Int) {
+        guard messageId > 0,
+              let tableView = self.tableView,
+              let (indexPath, message) = self.indexPathAndMessage(forMessageId: messageId)
+        else { return }
+
+        self.highlightMessage(at: indexPath, with: .none)
+
+        let messageHeight = self.getCellHeight(for: message)
+        let rect = tableView.rectForRow(at: indexPath)
+
+        // ContentOffset when the cell is at the top of the tableView
+        let contentOffsetTop = rect.origin.y - tableView.safeAreaInsets.top
+
+        // ContentOffset when the cell is at the middle of the tableView
+        let contentOffsetMiddle = contentOffsetTop - tableView.frame.height / 2 + messageHeight / 2
+
+        // Fallback to the top offset in case the top of the cell would be scrolled outside of the view
+        let newContentOffset = min(contentOffsetTop, contentOffsetMiddle)
+
+        tableView.contentOffset.y = newContentOffset
+    }
+
+    public func reloadDataAndHighlightMessage(messageId: Int) {
+        self.tableView?.reloadData()
+        self.highlightMessageWithContentOffset(messageId: messageId)
     }
 
     func showNewMessagesView(until message: NCChatMessage) {

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -3011,19 +3011,18 @@ import QuickLook
     internal func highlightMessageWithContentOffset(messageId: Int) {
         guard messageId > 0,
               let tableView = self.tableView,
-              let (indexPath, message) = self.indexPathAndMessage(forMessageId: messageId)
+              let (indexPath, _) = self.indexPathAndMessage(forMessageId: messageId)
         else { return }
 
         self.highlightMessage(at: indexPath, with: .none)
 
-        let messageHeight = self.getCellHeight(for: message)
         let rect = tableView.rectForRow(at: indexPath)
 
         // ContentOffset when the cell is at the top of the tableView
         let contentOffsetTop = rect.origin.y - tableView.safeAreaInsets.top
 
         // ContentOffset when the cell is at the middle of the tableView
-        let contentOffsetMiddle = contentOffsetTop - tableView.frame.height / 2 + messageHeight / 2
+        let contentOffsetMiddle = contentOffsetTop - tableView.frame.height / 2 + rect.height / 2
 
         // Fallback to the top offset in case the top of the cell would be scrolled outside of the view
         let newContentOffset = min(contentOffsetTop, contentOffsetMiddle)

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -72,6 +72,7 @@ typedef void (^DeleteChatMessageCompletionBlock)(NSDictionary *messageDict, NSEr
 typedef void (^ClearChatHistoryCompletionBlock)(NSDictionary *messageDict, NSError *error, NSInteger statusCode);
 typedef void (^GetSharedItemsOverviewCompletionBlock)(NSDictionary *sharedItemsOverview, NSError *error, NSInteger statusCode);
 typedef void (^GetSharedItemsCompletionBlock)(NSArray *sharedItems, NSInteger lastKnownMessage, NSError *error, NSInteger statusCode);
+typedef void (^GetMessageContextInRoomCompletionBlock)(NSArray *messages, NSError *error, NSInteger statusCode);
 
 typedef void (^GetTranslationsCompletionBlock)(NSArray *languages, BOOL languageDetection, NSError *error, NSInteger statusCode);
 typedef void (^MessageTranslationCompletionBlock)(NSDictionary *translationDict, NSError *error, NSInteger statusCode);
@@ -224,6 +225,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 - (NSURLSessionDataTask *)markChatAsUnreadInRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(SendChatMessagesCompletionBlock)block;
 - (NSURLSessionDataTask *)getSharedItemsOverviewInRoom:(NSString *)token withLimit:(NSInteger)limit forAccount:(TalkAccount *)account withCompletionBlock:(GetSharedItemsOverviewCompletionBlock)block;
 - (NSURLSessionDataTask *)getSharedItemsOfType:(NSString *)objectType fromLastMessageId:(NSInteger)messageId withLimit:(NSInteger)limit inRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(GetSharedItemsCompletionBlock)block;
+- (NSURLSessionDataTask *)getMessageContextInRoom:(NSString *)token forMessageId:(NSInteger)messageId withLimit:(NSInteger)limit forAccount:(TalkAccount *)account withCompletionBlock:(GetMessageContextInRoomCompletionBlock)block;
 
 // Translations
 - (NSURLSessionDataTask *)getAvailableTranslationsForAccount:(TalkAccount *)account withCompletionBlock:(GetTranslationsCompletionBlock)block;

--- a/NextcloudTalk/NCChatController.h
+++ b/NextcloudTalk/NCChatController.h
@@ -26,6 +26,7 @@
 #import "NCChatMessage.h"
 
 typedef void (^UpdateHistoryInBackgroundCompletionBlock)(NSError *error);
+typedef void (^GetMessagesContextCompletionBlock)(NSArray<NCChatMessage *> * _Nullable messages);
 
 @class NCRoom;
 
@@ -65,5 +66,6 @@ extern NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotificati
 - (void)removeExpiredMessages;
 - (BOOL)hasHistoryFromMessageId:(NSInteger)messageId;
 - (void)storeMessages:(NSArray *)messages withRealm:(RLMRealm *)realm;
+- (void)getMessageContextForMessageId:(NSInteger)messageId withLimit:(NSInteger)limit withCompletionBlock:(GetMessagesContextCompletionBlock)block;
 
 @end

--- a/NextcloudTalk/RoomSharedItemsTableViewController.swift
+++ b/NextcloudTalk/RoomSharedItemsTableViewController.swift
@@ -383,7 +383,12 @@ import QuickLook
 
         let message = currentItems[indexPath.row]
 
-        cell.fileNameLabel?.text = message.parsedMessage().string
+        if let file = message.file() {
+            cell.fileNameLabel?.text = file.name
+        } else {
+            cell.fileNameLabel?.text = message.parsedMessage().string
+        }
+
         var infoLabelText = NCUtils.relativeTimeFromDate(date: Date(timeIntervalSince1970: Double(message.timestamp)))
         if !message.actorDisplayName.isEmpty {
             infoLabelText += " ⸱ " + message.actorDisplayName

--- a/NextcloudTalk/RoomSharedItemsTableViewController.swift
+++ b/NextcloudTalk/RoomSharedItemsTableViewController.swift
@@ -73,30 +73,6 @@ import QuickLook
         self.getItemsOverview()
     }
 
-    func presentItemTypeSelector() {
-        let itemTypesActionSheet = UIAlertController(title: NSLocalizedString("Shared items", comment: ""), message: nil, preferredStyle: .actionSheet)
-
-        for itemType in availableItemTypes() {
-            let itemTypeName = nameForItemType(itemType: itemType)
-            let action = UIAlertAction(title: itemTypeName, style: .default) { _ in
-                self.setupViewForItemType(itemType: itemType)
-            }
-
-            if itemType == currentItemType {
-                action.setValue(UIImage(named: "checkmark")?.withRenderingMode(_: .alwaysOriginal), forKey: "image")
-            }
-            itemTypesActionSheet.addAction(action)
-        }
-
-        itemTypesActionSheet.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel, handler: nil))
-
-        // Presentation on iPads
-        itemTypesActionSheet.popoverPresentationController?.sourceView = self.navigationItem.titleView
-        itemTypesActionSheet.popoverPresentationController?.sourceRect = self.navigationItem.titleView?.frame ?? CGRect()
-
-        self.present(itemTypesActionSheet, animated: true, completion: nil)
-    }
-
     func availableItemTypes() -> [String] {
         var availableItemTypes: [String] = []
         for itemType in sharedItemsOverview.keys {
@@ -183,8 +159,25 @@ import QuickLook
         itemTypeSelectorButton.setTitle(buttonTitle, for: .normal)
         itemTypeSelectorButton.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .medium)
         itemTypeSelectorButton.setTitleColor(NCAppBranding.themeTextColor(), for: .normal)
-        itemTypeSelectorButton.addTarget(self, action: #selector(presentItemTypeSelector), for: .touchUpInside)
         self.navigationItem.titleView = itemTypeSelectorButton
+
+        var menuActions: [UIAction] = []
+
+        for itemType in availableItemTypes() {
+            let itemTypeName = nameForItemType(itemType: itemType)
+            let action = UIAction(title: itemTypeName, image: nil) { [unowned self] _ in
+                self.setupViewForItemType(itemType: itemType)
+            }
+
+            if itemType == currentItemType {
+                action.state = .on
+            }
+
+            menuActions.append(action)
+        }
+
+        itemTypeSelectorButton.showsMenuAsPrimaryAction = true
+        itemTypeSelectorButton.menu = UIMenu(children: menuActions)
     }
 
     func showFetchingItemsPlaceholderView() {

--- a/NextcloudTalk/RoomSharedItemsTableViewController.xib
+++ b/NextcloudTalk/RoomSharedItemsTableViewController.xib
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,11 +14,10 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" bouncesZoom="NO" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="i5M-Pr-FkT">
+        <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" bouncesZoom="NO" style="insetGrouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="i5M-Pr-FkT">
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <viewLayoutGuide key="safeArea" id="vLr-E1-eTs"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <connections>
                 <outlet property="dataSource" destination="-1" id="Tng-2m-Rnh"/>
                 <outlet property="delegate" destination="-1" id="9aC-8N-iBw"/>
@@ -27,9 +25,4 @@
             <point key="canvasLocation" x="139" y="98"/>
         </tableView>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>


### PR DESCRIPTION
* Update design to use `insetGrouped`
* Use `UIMenu` instead of `UIAlertController`
* Implemented message context api
* Tap opens preview/object as before
* Long press shows the context of the message and allows to jump right to that message (read only)
* Fixed showing the filename for files with captions

I reworked the positioning of the highlighted cell quite a bite. This one gave me the best results in all cases. Although it is still a bit problematic when the height of the preview is unknown, but the PR https://github.com/nextcloud/spreed/pull/11093 should help with that.


https://github.com/nextcloud/talk-ios/assets/1580193/70f5d378-f61b-434f-ab12-fde13b0aa209

