### PR TITLE
Fix multi-account notification existance check

### DIFF
--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -416,7 +416,7 @@ NSString * const NCNotificationActionReplyToChat                    = @"REPLY_CH
                 NSInteger notificationId = [[notificationRequest.content.userInfo objectForKey:@"notificationId"] integerValue];
 
                 if (![notificationAccountId isEqualToString:account.accountId]) {
-                    return;
+                    continue;
                 }
 
                 [notificationIdsOnDevice addObject:@(notificationId)];
@@ -440,7 +440,10 @@ NSString * const NCNotificationActionReplyToChat                    = @"REPLY_CH
                     [notificationIdsOnDevice removeObject:notificationId];
                 }
 
-                [self removeNotificationWithNotificationIds:notificationIdsOnDevice forAccountId:account.accountId];
+                // In case there are still notifications on the device (that are not on the server anymore) remove them
+                if ([notificationIdsOnDevice count] > 0) {
+                    [self removeNotificationWithNotificationIds:notificationIdsOnDevice forAccountId:account.accountId];
+                }
 
                 dispatch_group_leave(notificationsGroup);
             }];


### PR DESCRIPTION
Since this is a "normal" loop, we need to `continue` instead of `returning`. Also we don't need to check the notifications if there are non on the device left according to our calculation.

This happens only in multi-account scenarios and explains why the background refresh sometimes gets cancelled, as we never leave the `dispatch_group` and we never finalize the background refresh itself.