### PR TITLE
Fix send button when sharing text

### DIFF
--- a/ShareExtension/ShareConfirmationViewController.swift
+++ b/ShareExtension/ShareConfirmationViewController.swift
@@ -291,6 +291,11 @@ import AVFoundation
             self.itemToolbar.isHidden = true
             self.shareTextView.isHidden = false
             self.shareTextView.text = sharedText
+
+            // When an item of type "public.url" or "public.plain-text" is shared,
+            // we switch to text-sharing after viewWillAppear, so we need to add the sendButton here as well
+            self.navigationItem.rightBarButtonItem = self.sendButton
+            self.navigationItem.rightBarButtonItem?.tintColor = NCAppBranding.themeTextColor()
         }
     }
 


### PR DESCRIPTION
When sharing a URL or text from another app, it is shared as an `item`. After checking the type of that `item` we switch to text-sharing, but this happens after we already checked that we are sharing an `item`, which by default shows a text input when `media-caption` capability is there. So there's no way to actually send the text.