### PR TITLE
Add background processing

### DIFF
--- a/NextcloudTalk/Info.plist
+++ b/NextcloudTalk/Info.plist
@@ -6,6 +6,7 @@
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER).refresh</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).processing</string>
 	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>


### PR DESCRIPTION
While the app refresh is based on the usage of the app, background processing on the other hand should be independent of the usage. Let's try to add background processing additionally for removing already read notifications.