### PR TITLE
Specify an indicator font used for correctly sizing list indents

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -3521,7 +3521,7 @@
 			repositoryURL = "https://github.com/nextcloud-deps/CDMarkdownKit.git";
 			requirement = {
 				kind = revision;
-				revision = f83c43ba66a1bf451359155c3d621cadca6efbfb;
+				revision = 818927d8bcbcc70e2395232f9b733cfc40e8f0bd;
 			};
 		};
 		1F0ECBFB2A73F21A00921E90 /* XCRemoteSwiftPackageReference "realm-swift" */ = {

--- a/NextcloudTalk/SwiftMarkdownObjCBridge.swift
+++ b/NextcloudTalk/SwiftMarkdownObjCBridge.swift
@@ -41,9 +41,12 @@ import UIKit
 
         markdownParser.image.enabled = false
 
-        // Don't update the font when we have a listing/quote, just the paragraph style
+        // Don't update the font when we have a listing/quote (to not override any mentions), just the paragraph style
         markdownParser.list.font = nil
         markdownParser.list.color = nil
+
+        // To correctly position list elements, we need to tell CDMarkdownKit the font to use for sizing
+        markdownParser.list.indicatorFont = .systemFont(ofSize: 16)
 
         markdownParser.quote.font = nil
         markdownParser.quote.color = nil


### PR DESCRIPTION
See:
- https://github.com/nextcloud-deps/CDMarkdownKit/pull/16

- [x] Bump lib