### PR TITLE
Check existence of selectedPredifinedStatus

### DIFF
--- a/NextcloudTalk/UserStatusMessageSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusMessageSwiftUIView.swift
@@ -224,8 +224,8 @@ struct UserStatusMessageSwiftUIView: View {
     }
 
     func setActiveUserStatus() {
-        if !customStatusSelected {
-            NextcloudKit.shared.setCustomMessagePredefined(messageId: selectedPredifinedStatus!.id!, clearAt: selectedClearAt) { _, error in
+        if !customStatusSelected, let selectedPredifinedStatus {
+            NextcloudKit.shared.setCustomMessagePredefined(messageId: selectedPredifinedStatus.id!, clearAt: selectedClearAt) { _, error in
                 if error.errorCode == 0 {
                     dismiss()
                     changed.toggle()


### PR DESCRIPTION
Fixes a crash seen on TestFlight.

Steps to reproduce:
- Set a custom user status
- Open `UserStatusMessageSwiftUIView` again
- Without changing anything, press `Set status message`
- 💣

Reason is that `selectedPredifinedStatus` is force un-wrapped and it is `nil` in that case.