### PR TITLE
Check camera permission and request access if needed

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1958,7 +1958,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
 - (void)callController:(NCCallController *)callController userPermissionsChanged:(NSInteger)permissions
 {
     [self setAudioMuteButtonEnabled:(permissions & NCPermissionCanPublishAudio)];
-    [self setVideoDisableButtonEnabled:(permissions & NCPermissionCanPublishVideo)];
+    [self setVideoDisableButtonEnabled:((permissions & NCPermissionCanPublishVideo) && [callController isCameraAccessAvailable])];
 }
 
 - (void)callController:(NCCallController *)callController didCreateLocalAudioTrack:(RTCAudioTrack *)audioTrack
@@ -1968,6 +1968,15 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
 
 - (void)callController:(NCCallController *)callController didCreateLocalVideoTrack:(RTCVideoTrack *)videoTrack
 {
+    if (!videoTrack && !self->_isAudioOnly) {
+        // No video track was created, probably because there are no publishing rights or camera access was denied
+        [self setVideoDisableButtonEnabled:NO];
+        [self setVideoDisableButtonActive:NO];
+        _userDisabledVideo = YES;
+
+        return;
+    }
+
     [self setVideoDisableButtonActive:videoTrack.isEnabled];
 
     // We set _userDisabledVideo = YES so the proximity sensor doesn't enable it.

--- a/NextcloudTalk/NCCallController.h
+++ b/NextcloudTalk/NCCallController.h
@@ -94,6 +94,7 @@ typedef void (^GetAudioEnabledStateCompletionBlock)(BOOL isEnabled);
 - (BOOL)isBackgroundBlurEnabled;
 - (void)enableBackgroundBlur:(BOOL)enable;
 - (void)stopCapturing;
+- (BOOL)isCameraAccessAvailable;
 
 - (void)willSwitchToCall:(NSString *)token;
 

--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -476,6 +476,11 @@ static NSString * const kNCScreenTrackKind  = @"screen";
     [self.cameraController enableBackgroundBlurWithEnable:enable];
 }
 
+- (BOOL)isCameraAccessAvailable {
+    AVAuthorizationStatus authStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+    return (authStatus == AVAuthorizationStatusAuthorized);
+}
+
 - (void)stopCapturing
 {
     [self.cameraController stopAVCaptureSession];
@@ -844,7 +849,9 @@ static NSString * const kNCScreenTrackKind  = @"screen";
             [self.delegate callController:self didCreateLocalAudioTrack:nil];
         }
 
-        if (!self->_isAudioOnly && ((self->_userPermissions & NCPermissionCanPublishVideo) != 0 || !self->_serverSupportsConversationPermissions)) {
+        BOOL hasPublishVideoPermission = ((self->_userPermissions & NCPermissionCanPublishVideo) != 0 || !self->_serverSupportsConversationPermissions);
+
+        if (!self->_isAudioOnly && hasPublishVideoPermission && [self isCameraAccessAvailable]) {
             [self createLocalVideoTrack];
         } else {
             [self.delegate callController:self didCreateLocalVideoTrack:nil];


### PR DESCRIPTION
The app crashes when camera access is denied and we try to start/join a video call:
- Disable camera access in the iOS settings
- Try to join a video call
- 💣

Also I noticed that since we switched to `NCCameraController` for camera access, we never request access to the camera anymore (I assume this was done by WebRTC before).

This PR does the following:
- Checks if camera access was granted before trying to access the camera
- If camera access is not available, the camera button in the `CallViewController` is disabled
- When starting a call, we check if camera access was requested, if not, we request it.