### PR TITLE
Disabling "Save Status" Button until changes

### DIFF
--- a/NextcloudTalk/NCButton.swift
+++ b/NextcloudTalk/NCButton.swift
@@ -41,7 +41,7 @@ struct NCButtonSwiftUI: View {
         Button(action: action, label: {
                 Text(title)
                     .bold()
-                    .foregroundColor(titleColorForStyle(style: style).opacity(disabled ? 0.75 : 1))
+                    .foregroundColor(titleColorForStyle(style: style).opacity(disabled ? 0.5 : 1))
                     .padding(.vertical, 4)
                     .padding(.horizontal, 40)
                     .frame(height: height)

--- a/NextcloudTalk/UserStatusMessageSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusMessageSwiftUIView.swift
@@ -37,6 +37,7 @@ struct UserStatusMessageSwiftUIView: View {
     @State private var selectedMessage: String = ""
     @State private var selectedClearAt: Double = 0
     @State private var selectedClearAtString: String = ""
+    @State private var changedSmth: Bool = false
 
     @State private var isLoading: Bool = true
     @FocusState private var textFieldIsFocused: Bool
@@ -66,6 +67,7 @@ struct UserStatusMessageSwiftUIView: View {
                                 .frame(maxWidth: 23)
                                 .opacity(selectedIcon.isEmpty ? 0.5 : 1.0)
                                 .onChange(of: selectedIcon) { newString in
+                                    changedSmth = true
                                     customStatusSelected = !changedStatusFromPredefined
                                     changedStatusFromPredefined = false
                                     if newString.count > 1 {
@@ -77,6 +79,7 @@ struct UserStatusMessageSwiftUIView: View {
                             Divider()
                             TextField(NSLocalizedString("What is your status?", comment: ""), text: $selectedMessage)
                                 .onChange(of: selectedMessage) { _ in
+                                    changedSmth = true
                                     customStatusSelected = !changedStatusFromPredefined
                                     changedStatusFromPredefined = false
                                 }
@@ -132,11 +135,11 @@ struct UserStatusMessageSwiftUIView: View {
                                                                          comment: ""),
                                                 action: clearActiveUserStatus,
                                                 style: .tertiary, height: 40,
-                                                disabled: Binding.constant(selectedMessage.isEmpty))
+                                                disabled: Binding.constant(selectedMessage.isEmpty  && selectedIcon.isEmpty))
                                 NCButtonSwiftUI(title: NSLocalizedString("Set status message", comment: ""),
                                                 action: setActiveUserStatus,
                                                 style: .primary, height: 40,
-                                                disabled: Binding.constant(selectedMessage.isEmpty))
+                                                disabled: Binding.constant(selectedMessage.isEmpty  || changedSmth == false))
                                 .padding(.bottom, 16)
                             }
                         } else {
@@ -146,12 +149,12 @@ struct UserStatusMessageSwiftUIView: View {
                                                                          comment: ""),
                                                 action: clearActiveUserStatus,
                                                 style: .tertiary, height: 40,
-                                                disabled: Binding.constant(selectedMessage.isEmpty))
+                                                disabled: Binding.constant(selectedMessage.isEmpty && selectedIcon.isEmpty))
                                 .padding(.bottom, 16)
                                 NCButtonSwiftUI(title: NSLocalizedString("Set status message", comment: ""),
                                                 action: setActiveUserStatus,
                                                 style: .primary, height: 40,
-                                                disabled: Binding.constant(selectedMessage.isEmpty))
+                                                disabled: Binding.constant(selectedMessage.isEmpty || changedSmth == false))
                                 .padding(.bottom, 16)
                                 Spacer()
                             }


### PR DESCRIPTION
As requested the "Set status message" Button is now grayed out until the user changes ether the emoji or the text.
 
# Unchanged custom status:
![Simulator Screenshot - iPhone 15 - 2024-01-06 at 21 28 45](https://github.com/nextcloud/talk-ios/assets/106263486/430ed9d9-81a3-4185-af74-7cfd02c772c4)

# Changed custom status:
![Simulator Screenshot - iPhone 15 - 2024-01-06 at 21 28 51](https://github.com/nextcloud/talk-ios/assets/106263486/8ef7d3aa-c3f3-4106-a655-69d132da69c2)
