### PR TITLE
Message editing

### DIFF
--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -1106,6 +1106,7 @@ import QuickLook
         super.didCancelTextEditing(sender)
         self.autoCompletionView.tableHeaderView = nil
         self.replyMessageView?.dismiss()
+        self.mentionsDict.removeAll()
         self.editingMessage = nil
         self.restorePendingMessage()
     }
@@ -1114,6 +1115,7 @@ import QuickLook
         super.didCommitTextEditing(sender)
         self.autoCompletionView.tableHeaderView = nil
         self.replyMessageView?.dismiss()
+        self.mentionsDict.removeAll()
         self.editingMessage = nil
         self.restorePendingMessage()
     }

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -1029,13 +1029,16 @@ import QuickLook
                    let value = value as? [String: String] {
 
                     guard let parameter = NCMessageParameter(dictionary: value),
-                          let paramaterDisplayName = parameter.name
+                          let paramaterDisplayName = parameter.name,
+                          let parameterId = parameter.parameterId
                     else { continue }
 
                     // For mentions the displayName is in the parameter "name", in our mentionsDict we use
                     // "mentionsDisplayName" for the displayName with the prefix "@", so we need to construct
-                    // that manually here, so mentions are correctly removed while editing
+                    // that manually here, so mentions are correctly removed while editing.
+                    // The same needs to happen for "mentionId" -> userId with a prefixed "@"
                     parameter.mentionDisplayName = "@\(paramaterDisplayName)"
+                    parameter.mentionId = "@\(parameterId)"
                     self.mentionsDict[key] = parameter
                 }
             }

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -2877,6 +2877,11 @@ import QuickLook
     }
 
     public func savePendingMessage() {
+        if self.textInputbar.isEditing {
+            // We don't want to save a message that we are editing
+            return
+        }
+
         self.room.pendingMessage = self.textView.text
         NCRoomsManager.sharedInstance().updatePendingMessage(self.room.pendingMessage, for: self.room)
     }

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -64,6 +64,7 @@ import QuickLook
     internal var interactingMessage: NCChatMessage?
     internal var lastMessageBeforeInteraction: IndexPath?
     internal var contextMenuActionBlock: (() -> Void)?
+    internal var editingMessage: NCChatMessage?
 
     internal lazy var emojiTextField: EmojiTextField = {
         let emojiTextField = EmojiTextField()
@@ -582,7 +583,7 @@ import QuickLook
 
             let isAtBottom = self.shouldScrollOnNewMessages()
             let keyDate = self.dateSections[indexPath.section]
-            updatedMessage.isGroupMessage = message.isGroupMessage && message.actorType != "bots"
+            updatedMessage.isGroupMessage = message.isGroupMessage && message.actorType != "bots" && updatedMessage.lastEditTimestamp == 0
             self.messages[keyDate]?[indexPath.row] = updatedMessage
 
             // Check if there are any messages that reference our message as a parent -> these need to be reloaded as well
@@ -847,24 +848,28 @@ import QuickLook
         }
     }
 
+    func showReplyView(for message: NCChatMessage) {
+        let isAtBottom = self.shouldScrollOnNewMessages()
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+
+        if let replyProxyView = self.replyProxyView as? ReplyMessageView {
+            self.replyMessageView = replyProxyView
+
+            replyProxyView.presentReply(with: message, withUserId: activeAccount.userId)
+            self.presentKeyboard(true)
+
+            // Make sure we're really at the bottom after showing the replyMessageView
+            if isAtBottom {
+                self.tableView?.slk_scrollToBottom(animated: false)
+                self.updateToolbar(animated: false)
+            }
+        }
+    }
+
     func didPressReply(for message: NCChatMessage) {
         // Make sure we get a smooth animation after dismissing the context menu
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            let isAtBottom = self.shouldScrollOnNewMessages()
-            let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-
-            if let replyProxyView = self.replyProxyView as? ReplyMessageView {
-                self.replyMessageView = replyProxyView
-
-                replyProxyView.presentReply(with: message, withUserId: activeAccount.userId)
-                self.presentKeyboard(true)
-
-                // Make sure we're really at the bottom after showing the replyMessageView
-                if isAtBottom {
-                    self.tableView?.slk_scrollToBottom(animated: false)
-                    self.updateToolbar(animated: false)
-                }
-            }
+            self.showReplyView(for: message)
         }
     }
 
@@ -979,6 +984,73 @@ import QuickLook
         downloader.downloadFile(fromMessage: message.file())
     }
 
+    func didPressEdit(for message: NCChatMessage) {
+        self.savePendingMessage()
+
+        let warningString = NSLocalizedString("Adding a mention will only notify users that did not read the message yet", comment: "")
+        let warningView = UIView()
+        let warningLabel = UILabel()
+
+        warningView.addSubview(warningLabel)
+        warningLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            warningLabel.leftAnchor.constraint(equalTo: warningView.safeAreaLayoutGuide.leftAnchor, constant: 8),
+            warningLabel.rightAnchor.constraint(equalTo: warningView.safeAreaLayoutGuide.rightAnchor, constant: -8),
+            warningLabel.topAnchor.constraint(equalTo: warningView.safeAreaLayoutGuide.topAnchor, constant: 4),
+            warningLabel.bottomAnchor.constraint(equalTo: warningView.safeAreaLayoutGuide.bottomAnchor)
+        ])
+
+        let attributedWarningString = warningString.withFont(.systemFont(ofSize: 14)).withTextColor(.secondaryLabel)
+
+        warningLabel.attributedText = attributedWarningString
+        warningLabel.numberOfLines = 0
+
+        // Calculate the height needed to completely show the text
+        let maxWidth = self.autoCompletionView.frame.width - autoCompletionView.safeAreaInsets.left - autoCompletionView.safeAreaInsets.right - 16
+        let contraintRect = CGSize(width: maxWidth, height: .greatestFiniteMagnitude)
+        let size = attributedWarningString.boundingRect(with: contraintRect, options: .usesLineFragmentOrigin, context: nil)
+
+        // Update the frame for the new height and include the top padding
+        warningView.frame = .init(x: 0, y: 0, width: size.width, height: ceil(size.height) + 4)
+        self.autoCompletionView.tableHeaderView = warningView
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            // Show the message to edit in the reply view
+            self.showReplyView(for: message)
+            self.replyMessageView!.hideCloseButton()
+
+            self.mentionsDict = [:]
+
+            // Try to reconstruct the mentionsDict
+            for (key, value) in message.messageParameters() {
+                if let key = key as? String,
+                   key.hasPrefix("mention-"),
+                   let value = value as? [String: String] {
+
+                    guard let parameter = NCMessageParameter(dictionary: value),
+                          let paramaterDisplayName = parameter.name
+                    else { continue }
+
+                    // For mentions the displayName is in the parameter "name", in our mentionsDict we use
+                    // "mentionsDisplayName" for the displayName with the prefix "@", so we need to construct
+                    // that manually here, so mentions are correctly removed while editing
+                    parameter.mentionDisplayName = "@\(paramaterDisplayName)"
+                    self.mentionsDict[key] = parameter
+                }
+            }
+
+            self.editingMessage = message
+
+            // For files without a caption we start with an empty text instead of "{file}"
+            if message.message == "{file}", message.file() != nil {
+                self.editText("")
+            } else {
+                self.editText(message.parsedMessage().string)
+            }
+        }
+    }
+
     func didPressDelete(for message: NCChatMessage) {
         if message.sendingFailed, message.isOfflineMessage {
             self.removePermanentlyTemporaryMessage(temporaryMessage: message)
@@ -1026,6 +1098,24 @@ import QuickLook
         if let file = message.file() {
             NCUtils.openFileInNextcloudAppOrBrowser(path: file.path, withFileLink: file.link)
         }
+    }
+
+    // MARK: - Editing support
+
+    public override func didCancelTextEditing(_ sender: Any) {
+        super.didCancelTextEditing(sender)
+        self.autoCompletionView.tableHeaderView = nil
+        self.replyMessageView?.dismiss()
+        self.editingMessage = nil
+        self.restorePendingMessage()
+    }
+
+    public override func didCommitTextEditing(_ sender: Any) {
+        super.didCommitTextEditing(sender)
+        self.autoCompletionView.tableHeaderView = nil
+        self.replyMessageView?.dismiss()
+        self.editingMessage = nil
+        self.restorePendingMessage()
     }
 
     // MARK: - UITextField delegate
@@ -1305,7 +1395,7 @@ import QuickLook
         }
     }
 
-    // MARK: UIDocumentPickerViewController Delegate
+    // MARK: - UIDocumentPickerViewController Delegate
 
     public func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
         let (shareConfirmationVC, navigationController) = self.createShareConfirmationViewController()
@@ -1913,7 +2003,8 @@ import QuickLook
                         // The newly received message either already exists or its temporary counterpart exists -> update
                         // If the user type a command the newMessage.actorType will be "bots", then we should not group those messages
                         // even if the original message was grouped.
-                        newMessage.isGroupMessage = currentMessage.isGroupMessage && newMessage.actorType != "bots"
+                        // Edited messages should not be grouped to make it clear, that the message was edited
+                        newMessage.isGroupMessage = currentMessage.isGroupMessage && newMessage.actorType != "bots" && newMessage.lastEditTimestamp == 0
                         dictionary[keyDate]?[messageIndex] = newMessage
                         messageUpdated = true
                         break
@@ -1981,6 +2072,7 @@ import QuickLook
         let sameActor = newMessage.actorId == lastMessage.actorId
         let sameType = newMessage.isSystemMessage() == lastMessage.isSystemMessage()
         let timeDiff = (newMessage.timestamp - lastMessage.timestamp) < kChatMessageGroupTimeDifference
+        let notEdited = newMessage.lastEditTimestamp == 0
 
         // Try to collapse system messages if the new message is not already collapsing some messages
         // Disable swiftlint -> not supported on Realm object
@@ -1989,7 +2081,7 @@ import QuickLook
             self.tryToGroupSystemMessage(newMessage: newMessage, withMessage: lastMessage)
         }
 
-        return sameActor && sameType && timeDiff
+        return sameActor && sameType && timeDiff && notEdited
     }
 
     func tryToGroupSystemMessage(newMessage: NCChatMessage, withMessage lastMessage: NCChatMessage) {
@@ -3223,6 +3315,10 @@ import QuickLook
     }
 
     public func cellWantsToReply(to message: NCChatMessage!) {
+        if self.textInputbar.isEditing {
+            return
+        }
+
         self.didPressReply(for: message)
     }
 

--- a/NextcloudTalk/ChatMessageTableViewCell.m
+++ b/NextcloudTalk/ChatMessageTableViewCell.m
@@ -279,7 +279,24 @@
 
 - (void)setupForMessage:(NCChatMessage *)message withLastCommonReadMessage:(NSInteger)lastCommonRead
 {
-    self.titleLabel.text = message.actorDisplayName;
+    if (message.lastEditActorDisplayName || message.lastEditTimestamp > 0) {
+        NSTextAttachment *attachment = [[NSTextAttachment alloc] init];
+        attachment.image = [[UIImage systemImageNamed:@"pencil"] imageWithTintColor:[UIColor secondaryLabelColor]];
+        [attachment setBounds:CGRectMake(0, -2, 16, 16)];
+
+        NSAttributedString *attachmentString = [NSAttributedString attributedStringWithAttachment:attachment];
+        NSMutableAttributedString *attachmentMutableString = [[NSMutableAttributedString alloc] initWithAttributedString:attachmentString];
+
+        NSMutableAttributedString *actorDisplayNameString = [[NSMutableAttributedString alloc] initWithString:message.actorDisplayName];
+        NSMutableAttributedString *spaceString = [[NSMutableAttributedString alloc] initWithString:@" "];
+        [actorDisplayNameString appendAttributedString:spaceString];
+        [actorDisplayNameString appendAttributedString:attachmentMutableString];
+
+        self.titleLabel.attributedText = actorDisplayNameString;
+    } else {
+        self.titleLabel.text = message.actorDisplayName;
+    }
+
     self.bodyTextView.attributedText = message.parsedMarkdownForChat;
     self.messageId = message.messageId;
     self.message = message;

--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -1489,6 +1489,16 @@ import UIKit
         let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
         let hasChatPermissions = !NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityChatPermission) || (self.room.permissions & NCPermission.chat.rawValue) != 0
 
+        // Show edit information
+        if let lastEditActorDisplayName = message.lastEditActorDisplayName, message.lastEditTimestamp > 0 {
+            let timestampDate = Date(timeIntervalSince1970: TimeInterval(message.lastEditTimestamp))
+
+            let editInfo = UIAction(title: NSLocalizedString("Edited by", comment: "") + " " + lastEditActorDisplayName, attributes: [.disabled], handler: {_ in })
+            editInfo.subtitle = NCUtils.readableTimeOrDate(fromDate: timestampDate)
+
+            actions.append(UIMenu(options: [.displayInline], children: [editInfo]))
+        }
+
         // Reply option
         if self.isMessageReplyable(message: message), hasChatPermissions {
             actions.append(UIAction(title: NSLocalizedString("Reply", comment: ""), image: .init(systemName: "arrowshape.turn.up.left")) { _ in

--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -1277,7 +1277,12 @@ import UIKit
     public override func didCommitTextEditing(_ sender: Any) {
         if let editingMessage {
             let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-            NCAPIController.sharedInstance().editChatMessage(inRoom: editingMessage.token, withMessageId: editingMessage.messageId, withMessage: self.textView.text, for: activeAccount) { messageDict, error, _ in
+
+            let messageParametersJSONString = NCMessageParameter.messageParametersJSONString(from: self.mentionsDict) ?? ""
+            editingMessage.message = self.replaceMentionsDisplayNamesWithMentionsKeysInMessage(message: self.textView.text, parameters: messageParametersJSONString)
+            editingMessage.messageParametersJSONString = messageParametersJSONString
+
+            NCAPIController.sharedInstance().editChatMessage(inRoom: editingMessage.token, withMessageId: editingMessage.messageId, withMessage: editingMessage.sendingMessage(), for: activeAccount) { messageDict, error, _ in
                 if error != nil {
                     NotificationPresenter.shared().present(text: NSLocalizedString("Error occurred while editing a message", comment: ""), dismissAfterDelay: 5.0, includedStyle: .error)
                     return

--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -494,6 +494,11 @@ import UIKit
     public override func canPressRightButton() -> Bool {
         let canPress = super.canPressRightButton()
 
+        if self.textInputbar.isEditing {
+            // When we're editing, we can use the default implementation, as we don't want to save an empty message
+            return canPress
+        }
+
         // If in offline mode, we don't want to show the voice button
         if !offlineMode, !canPress && !presentedInCall && NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityVoiceMessage) {
             self.showVoiceMessageRecordButton()

--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -1493,7 +1493,7 @@ import UIKit
         if let lastEditActorDisplayName = message.lastEditActorDisplayName, message.lastEditTimestamp > 0 {
             let timestampDate = Date(timeIntervalSince1970: TimeInterval(message.lastEditTimestamp))
 
-            let editInfo = UIAction(title: NSLocalizedString("Edited by", comment: "") + " " + lastEditActorDisplayName, attributes: [.disabled], handler: {_ in })
+            let editInfo = UIAction(title: NSLocalizedString("Edited by", comment: "A message was edited by ...") + " " + lastEditActorDisplayName, attributes: [.disabled], handler: {_ in })
             editInfo.subtitle = NCUtils.readableTimeOrDate(fromDate: timestampDate)
 
             actions.append(UIMenu(options: [.displayInline], children: [editInfo]))

--- a/NextcloudTalk/FileMessageTableViewCell.m
+++ b/NextcloudTalk/FileMessageTableViewCell.m
@@ -210,7 +210,32 @@
 
 - (void)setupForMessage:(NCChatMessage *)message withLastCommonReadMessage:(NSInteger)lastCommonRead
 {
-    self.titleLabel.text = message.actorDisplayName;
+    TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+
+    if (message.lastEditActorDisplayName || message.lastEditTimestamp > 0) {
+        NSString *editedString;
+
+        if ([message.lastEditActorId isEqualToString:activeAccount.userId] && [message.lastEditActorType isEqualToString:@"users"]) {
+            editedString = NSLocalizedString(@"edited", "A message was edited");
+            editedString = [NSString stringWithFormat:@" (%@)", editedString];
+        } else {
+            editedString = NSLocalizedString(@"edited by", "A message was edited by ...");
+            editedString = [NSString stringWithFormat:@" (%@ %@)", editedString, message.lastEditActorDisplayName];
+        }
+
+        NSMutableAttributedString *editedAttributedString = [[NSMutableAttributedString alloc] initWithString:editedString];
+        NSRange rangeEditedString = NSMakeRange(0, [editedAttributedString length]);
+        [editedAttributedString addAttribute:NSFontAttributeName value:[UIFont systemFontOfSize:14] range:rangeEditedString];
+        [editedAttributedString addAttribute:NSForegroundColorAttributeName value:[UIColor tertiaryLabelColor] range:rangeEditedString];
+
+        NSMutableAttributedString *actorDisplayNameString = [[NSMutableAttributedString alloc] initWithString:message.actorDisplayName];
+        [actorDisplayNameString appendAttributedString:editedAttributedString];
+
+        self.titleLabel.attributedText = actorDisplayNameString;
+    } else {
+        self.titleLabel.text = message.actorDisplayName;
+    }
+
     self.bodyTextView.attributedText = message.parsedMarkdownForChat;
     self.messageId = message.messageId;
     self.message = message;
@@ -218,7 +243,6 @@
     NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:message.timestamp];
     self.dateLabel.text = [NCUtils getTimeFromDate:date];
     
-    TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
     [self.avatarButton setUserAvatarFor:message.actorId with:self.traitCollection.userInterfaceStyle using:activeAccount];
 
     _avatarButton.menu = [super getDeferredUserMenuForMessage:message];

--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -155,9 +155,7 @@ import UIKit
         // We can't use UIColor with systemBlueColor directly, because it will switch to indigo. So make sure we actually get a blue tint here
         self.textView.tintColor = UIColor(cgColor: UIColor.systemBlue.cgColor)
 
-        if let pendingMessage = self.room.pendingMessage {
-            self.setChatMessage(pendingMessage)
-        }
+        self.restorePendingMessage()
 
         self.rightButton.setTitle("", for: .normal)
         self.rightButton.setImage(UIImage(systemName: "paperplane"), for: .normal)
@@ -364,6 +362,12 @@ import UIKit
     public func setChatMessage(_ chatMessage: String) {
         DispatchQueue.main.async {
             self.textView.text = chatMessage
+        }
+    }
+
+    public func restorePendingMessage() {
+        if let pendingMessage = self.room.pendingMessage {
+            self.setChatMessage(pendingMessage)
         }
     }
 

--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -205,7 +205,7 @@ import UIKit
     }
 
     public override func heightForAutoCompletionView() -> CGFloat {
-        return kAutoCompletionCellHeight * CGFloat(self.autocompletionUsers.count)
+        return kAutoCompletionCellHeight * CGFloat(self.autocompletionUsers.count) + (self.autoCompletionView.tableHeaderView?.frame.height ?? 0)
     }
 
     func showSuggestions(for string: String) {

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -70,6 +70,7 @@ typedef void (^GetChatMessagesCompletionBlock)(NSArray *messages, NSInteger last
 typedef void (^SendChatMessagesCompletionBlock)(NSError *error);
 typedef void (^GetMentionSuggestionsCompletionBlock)(NSArray *mentions, NSError *error);
 typedef void (^DeleteChatMessageCompletionBlock)(NSDictionary *messageDict, NSError *error, NSInteger statusCode);
+typedef void (^EditChatMessageCompletionBlock)(NSDictionary *messageDict, NSError *error, NSInteger statusCode);
 typedef void (^ClearChatHistoryCompletionBlock)(NSDictionary *messageDict, NSError *error, NSInteger statusCode);
 typedef void (^GetSharedItemsOverviewCompletionBlock)(NSDictionary *sharedItemsOverview, NSError *error, NSInteger statusCode);
 typedef void (^GetSharedItemsCompletionBlock)(NSArray *sharedItems, NSInteger lastKnownMessage, NSError *error, NSInteger statusCode);
@@ -221,6 +222,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 - (NSURLSessionDataTask *)sendChatMessage:(NSString *)message toRoom:(NSString *)token displayName:(NSString *)displayName replyTo:(NSInteger)replyTo referenceId:(NSString *)referenceId silently:(BOOL)silently forAccount:(TalkAccount *)account withCompletionBlock:(SendChatMessagesCompletionBlock)block;
 - (NSURLSessionDataTask *)getMentionSuggestionsInRoom:(NSString *)token forString:(NSString *)string forAccount:(TalkAccount *)account withCompletionBlock:(GetMentionSuggestionsCompletionBlock)block;
 - (NSURLSessionDataTask *)deleteChatMessageInRoom:(NSString *)token withMessageId:(NSInteger)messageId forAccount:(TalkAccount *)account withCompletionBlock:(DeleteChatMessageCompletionBlock)block;
+- (NSURLSessionDataTask *)editChatMessageInRoom:(NSString *)token withMessageId:(NSInteger)messageId withMessage:(NSString *)message forAccount:(TalkAccount *)account withCompletionBlock:(EditChatMessageCompletionBlock)block;
 - (NSURLSessionDataTask *)shareRichObject:(NSDictionary *)richObject inRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(SendChatMessagesCompletionBlock)block;
 - (NSURLSessionDataTask *)clearChatHistoryInRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(ClearChatHistoryCompletionBlock)block;
 - (NSURLSessionDataTask *)setChatReadMarker:(NSInteger)lastReadMessage inRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(SendChatMessagesCompletionBlock)block;

--- a/NextcloudTalk/NCChatMessage.h
+++ b/NextcloudTalk/NCChatMessage.h
@@ -106,6 +106,7 @@ typedef void (^GetReferenceDataCompletionBlock)(NCChatMessage *message, NSDictio
 - (BOOL)isCommandMessage;
 - (BOOL)isMessageFromUser:(NSString *)userId;
 - (BOOL)isDeletableForAccount:(TalkAccount *)account inRoom:(NCRoom *)room;
+- (BOOL)isEditableForAccount:(TalkAccount *)account inRoom:(NCRoom *)room;
 - (BOOL)isObjectShare;
 - (NSDictionary *)richObjectFromObjectShare;
 - (NCMessageFileParameter *)file;

--- a/NextcloudTalk/NCChatMessage.h
+++ b/NextcloudTalk/NCChatMessage.h
@@ -89,6 +89,10 @@ typedef void (^GetReferenceDataCompletionBlock)(NCChatMessage *message, NSDictio
 @property (nonatomic, assign) BOOL collapsedIncludesUserSelf;
 @property (nonatomic, assign) BOOL isCollapsed;
 @property (nonatomic, assign) BOOL isMarkdownMessage;
+@property (nonatomic, strong, nullable) NSString *lastEditActorType;
+@property (nonatomic, strong, nullable) NSString *lastEditActorId;
+@property (nonatomic, strong, nullable) NSString *lastEditActorDisplayName;
+@property (nonatomic, assign) NSInteger lastEditTimestamp;
 
 + (instancetype)messageWithDictionary:(NSDictionary *)messageDict;
 + (instancetype)messageWithDictionary:(NSDictionary *)messageDict andAccountId:(NSString *)accountId;

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -257,7 +257,8 @@ NSString * const kSharedItemTypeRecording   = @"recording";
             [self.systemMessage isEqualToString:@"reaction"] ||
             [self.systemMessage isEqualToString:@"reaction_revoked"] ||
             [self.systemMessage isEqualToString:@"reaction_deleted"] ||
-            [self.systemMessage isEqualToString:@"poll_voted"];
+            [self.systemMessage isEqualToString:@"poll_voted"] ||
+            [self.systemMessage isEqualToString:@"message_edited"];
 }
 
 - (BOOL)isDeletedMessage

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -297,9 +297,8 @@ NSString * const kSharedItemTypeRecording   = @"recording";
         && (room.participantType == kNCParticipantTypeOwner
             || room.participantType == kNCParticipantTypeModerator));
 
-    // With "edit-messages" capability, the time limit on deletion was removed
-    BOOL serverAllowsMessageEditing = [[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityEditMessages forAccountId:account.accountId];;
-    BOOL deletionAllowedByTime = (self.timestamp >= sixHoursAgoTimestamp || serverAllowsMessageEditing);
+    BOOL noTimeLimitForMessageDeletion = [[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityDeleteMessagesUnlimited forAccountId:account.accountId];
+    BOOL deletionAllowedByTime = (self.timestamp >= sixHoursAgoTimestamp || noTimeLimitForMessageDeletion);
 
     return serverCanDeleteMessage && userCanDeleteMessage && deletionAllowedByTime && !self.isDeleting;
 }

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -307,9 +307,8 @@ NSString * const kSharedItemTypeRecording   = @"recording";
 {
     NSInteger twentyFourHoursAgoTimestamp = [[NSDate date] timeIntervalSince1970] - (24 * 3600);
 
-    // TODO: Test with file captions, once implemented on the backend
     BOOL serverCanEditMessage = [[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityEditMessages forAccountId:account.accountId];
-    serverCanEditMessage = serverCanEditMessage && [self.messageType isEqualToString:kMessageTypeComment] && !self.file && ![self isObjectShare];
+    serverCanEditMessage = serverCanEditMessage && [self.messageType isEqualToString:kMessageTypeComment] && ![self isObjectShare];
 
     BOOL userCanEditMessage = [self isMessageFromUser:account.userId]
     || (room.type != kNCRoomTypeOneToOne

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -81,7 +81,11 @@ NSString * const kSharedItemTypeRecording   = @"recording";
     message.messageType = [messageDict objectForKey:@"messageType"];
     message.expirationTimestamp = [[messageDict objectForKey:@"expirationTimestamp"] integerValue];
     message.isMarkdownMessage = [[messageDict objectForKey:@"markdown"] boolValue];
-    
+    message.lastEditActorId = [messageDict objectForKey:@"lastEditActorId"];
+    message.lastEditActorType = [messageDict objectForKey:@"lastEditActorType"];
+    message.lastEditActorDisplayName = [messageDict objectForKey:@"lastEditActorDisplayName"];
+    message.lastEditTimestamp = [[messageDict objectForKey:@"lastEditTimestamp"] integerValue];
+
     id actorDisplayName = [messageDict objectForKey:@"actorDisplayName"];
     if (!actorDisplayName) {
         message.actorDisplayName = @"";
@@ -171,7 +175,11 @@ NSString * const kSharedItemTypeRecording   = @"recording";
     managedChatMessage.reactionsJSONString = chatMessage.reactionsJSONString;
     managedChatMessage.expirationTimestamp = chatMessage.expirationTimestamp;
     managedChatMessage.isMarkdownMessage = chatMessage.isMarkdownMessage;
-    
+    managedChatMessage.lastEditActorId = chatMessage.lastEditActorId;
+    managedChatMessage.lastEditActorType = chatMessage.lastEditActorType;
+    managedChatMessage.lastEditActorDisplayName = chatMessage.lastEditActorDisplayName;
+    managedChatMessage.lastEditTimestamp = chatMessage.lastEditTimestamp;
+
     if (!isRoomLastMessage) {
         managedChatMessage.reactionsSelfJSONString = chatMessage.reactionsSelfJSONString;
     }
@@ -218,7 +226,11 @@ NSString * const kSharedItemTypeRecording   = @"recording";
     messageCopy.isOfflineMessage = _isOfflineMessage;
     messageCopy.isSilent = _isSilent;
     messageCopy.isMarkdownMessage = _isMarkdownMessage;
-    
+    messageCopy.lastEditActorId = _lastEditActorId;
+    messageCopy.lastEditActorType = _lastEditActorType;
+    messageCopy.lastEditActorDisplayName = _lastEditActorDisplayName;
+    messageCopy.lastEditTimestamp = _lastEditTimestamp;
+
     return messageCopy;
 }
 

--- a/NextcloudTalk/NCDatabaseManager.h
+++ b/NextcloudTalk/NCDatabaseManager.h
@@ -81,6 +81,7 @@ extern NSString * const kCapabilityMarkdownMessages;
 extern NSString * const kCapabilityNoteToSelf;
 extern NSString * const kCapabilityMediaCaption;
 extern NSString * const kCapabilityEditMessages;
+extern NSString * const kCapabilityDeleteMessagesUnlimited;
 
 extern NSString * const kNotificationsCapabilityExists;
 

--- a/NextcloudTalk/NCDatabaseManager.h
+++ b/NextcloudTalk/NCDatabaseManager.h
@@ -80,6 +80,7 @@ extern NSString * const kCapabilityRemindMeLater;
 extern NSString * const kCapabilityMarkdownMessages;
 extern NSString * const kCapabilityNoteToSelf;
 extern NSString * const kCapabilityMediaCaption;
+extern NSString * const kCapabilityEditMessages;
 
 extern NSString * const kNotificationsCapabilityExists;
 

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -84,6 +84,7 @@ NSString * const kCapabilityRemindMeLater           = @"remind-me-later";
 NSString * const kCapabilityMarkdownMessages        = @"markdown-messages";
 NSString * const kCapabilityNoteToSelf              = @"note-to-self";
 NSString * const kCapabilityMediaCaption            = @"media-caption";
+NSString * const kCapabilityEditMessages            = @"edit-messages";
 
 NSString * const kNotificationsCapabilityExists     = @"exists";
 

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -85,6 +85,7 @@ NSString * const kCapabilityMarkdownMessages        = @"markdown-messages";
 NSString * const kCapabilityNoteToSelf              = @"note-to-self";
 NSString * const kCapabilityMediaCaption            = @"media-caption";
 NSString * const kCapabilityEditMessages            = @"edit-messages";
+NSString * const kCapabilityDeleteMessagesUnlimited = @"delete-messages-unlimited";
 
 NSString * const kNotificationsCapabilityExists     = @"exists";
 

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -33,7 +33,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 56;
+uint64_t const kTalkDatabaseSchemaVersion           = 57;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";

--- a/NextcloudTalk/ReplyMessageView.h
+++ b/NextcloudTalk/ReplyMessageView.h
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)presentReplyViewWithMessage:(NCChatMessage *)message withUserId:(NSString *)userId;
 - (void)dismiss;
+- (void)hideCloseButton;
 
 @end
 

--- a/NextcloudTalk/ReplyMessageView.m
+++ b/NextcloudTalk/ReplyMessageView.m
@@ -33,6 +33,7 @@
 @interface ReplyMessageView ()
 @property (nonatomic, strong) UIView *quoteContainerView;
 @property (nonatomic, strong) UIButton *cancelButton;
+@property (nonatomic, strong) NSArray<NSLayoutConstraint *> *hConstraints;
 @end
 
 @implementation ReplyMessageView
@@ -63,7 +64,8 @@
         @"cancelButton": self.cancelButton
     };
     
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-16-[quoteContainerView]-4-[cancelButton(44)]-4-|" options:0 metrics:nil views:views]];
+    self.hConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-16-[quoteContainerView]-4-[cancelButton(44)]-4-|" options:0 metrics:nil views:views];
+    [self addConstraints:self.hConstraints];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[quotedMessageView(quoteContainerView)]|" options:0 metrics:nil views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[quoteContainerView]|" options:0 metrics:nil views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[cancelButton]|" options:0 metrics:nil views:views]];
@@ -172,8 +174,19 @@
     self.quotedMessageView.messageLabel.text = message.parsedMarkdownForChat.string;
     self.quotedMessageView.highlighted = [message isMessageFromUser:userId];
     [self.quotedMessageView.avatarView setUserAvatarFor:message.actorId with:self.traitCollection.userInterfaceStyle];
-    
+    [self.cancelButton setHidden:NO];
+
+    // Reset button size to 44 in case it was hidden before
+    self.hConstraints[2].constant = 44;
+
     self.visible = YES;
+}
+
+- (void)hideCloseButton
+{
+    [self.cancelButton setHidden:YES];
+    // With 2*4 padding (left and right to the button) we add 8 to have 16 as we have on the left side of the quoteView
+    self.hConstraints[2].constant = 8;
 }
 
 

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -98,6 +98,9 @@
 "Added note to self" = "Added note to self";
 
 /* No comment provided by engineer. */
+"Adding a mention will only notify users that did not read the message yet" = "Adding a mention will only notify users that did not read the message yet";
+
+/* No comment provided by engineer. */
 "Address" = "Address";
 
 /* No comment provided by engineer. */
@@ -778,6 +781,9 @@
 /* No comment provided by engineer. */
 "Duplicate session" = "Duplicate session";
 
+/* Edit a message */
+"Edit" = "Edit";
+
 /* A message was edited */
 "edited" = "edited";
 
@@ -816,6 +822,9 @@
 
 /* No comment provided by engineer. */
 "Error occurred when creating a reminder" = "Error occurred when creating a reminder";
+
+/* No comment provided by engineer. */
+"Error occurred while editing a message" = "Error occurred while editing a message";
 
 /* External signaling used */
 "External" = "External";

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -778,6 +778,15 @@
 /* No comment provided by engineer. */
 "Duplicate session" = "Duplicate session";
 
+/* A message was edited */
+"edited" = "edited";
+
+/* A message was edited by ... */
+"Edited by" = "Edited by";
+
+/* A message was edited by ... */
+"edited by" = "edited by";
+
 /* No comment provided by engineer. */
 "Editing Message" = "Editing Message";
 


### PR DESCRIPTION
Fixes #1452 

Not finished yet.

- [x] Add UI option to edit messages (see https://github.com/nextcloud-deps/SlackTextViewController?tab=readme-ov-file#edit-mode)
- [x] Verify how editing with file caption works
- [x] Distinguish between own edit and moderator edit
- [x] Ungroup messages when edited to show "edited"


<img width="352" alt="Bildschirmfoto 2024-01-24 um 10 06 09" src="https://github.com/nextcloud/talk-ios/assets/1580193/eae44bea-d5c5-4770-aa68-a65edd6a987c">

---

<img width="351" alt="Bildschirmfoto 2024-01-24 um 10 09 04" src="https://github.com/nextcloud/talk-ios/assets/1580193/b74fe9bb-d148-4b81-bde3-d40138eaed3b">

---

<img width="344" alt="Bildschirmfoto 2024-01-24 um 10 06 21" src="https://github.com/nextcloud/talk-ios/assets/1580193/e7167fd2-c6de-442e-97e5-2325c1183156">

---

<img width="345" alt="Bildschirmfoto 2024-01-24 um 10 06 29" src="https://github.com/nextcloud/talk-ios/assets/1580193/046c1540-9eb2-4a5a-9c70-8928da85467f">

---


