### PR TITLE
Run on draft PRs and don't fail fast

### DIFF
--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -27,9 +27,9 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: macos-latest
-    if: github.event.pull_request.draft == false
 
     strategy:
+      fail-fast: false
       matrix:
         # Test with stable23 as well to find regressions in older versions
         configs: [


### PR DESCRIPTION
* I think we should also run on draft PRs. It does not make sense to manually move to "Ready-for-review" and then back to Draft just for the workflows to run (also this does not work without another push right now, because the type "ready_to_review" is not checked by default, see https://github.com/orgs/community/discussions/25722#discussioncomment-3248917)
* "fail-fast" should be disabled. We currently run 4 test scenarios (23, 27, 28, main), when one of these scenarios fail, all others are cancelled as well. When there's a specific issue in only one of the scenarios, the others should still continue to run.