### PR TITLE
Fix reuse of date label when searching

### DIFF
--- a/NextcloudTalk/RoomSearchTableViewController.m
+++ b/NextcloudTalk/RoomSearchTableViewController.m
@@ -253,6 +253,10 @@ typedef enum RoomSearchSection {
         cell = [[RoomTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:kRoomCellIdentifier];
     }
 
+    // Clear possible content not removed by cell reuse
+    cell.dateLabel.text = @"";
+    [cell setUnreadMessages:0 mentioned:NO groupMentioned:NO];
+
     cell.titleLabel.text = user.name;
     cell.titleOnly = YES;
     [cell.roomImage setUserAvatarFor:user.userId with:self.traitCollection.userInterfaceStyle];


### PR DESCRIPTION
Fixes the date label showing content for user cells:

<img width="330" alt="image" src="https://github.com/nextcloud/talk-ios/assets/1580193/a4dbd054-a465-4c78-ab95-bde6fd49840f">

Same as 
https://github.com/nextcloud/talk-ios/blob/fab806637c850c8c5dcc4d7235619eeac2962758/NextcloudTalk/RoomSearchTableViewController.m#L224-L226