### PR TITLE
Capabilities cache

### DIFF
--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -33,7 +33,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 56;
+uint64_t const kTalkDatabaseSchemaVersion           = 204;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";
@@ -93,6 +93,12 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
 
 @end
 
+@interface NCDatabaseManager ()
+
+@property (nonatomic, strong) NSCache<NSString *, ServerCapabilities*> *capabilitiesCache;
+
+@end
+
 @implementation NCDatabaseManager
 
 + (NCDatabaseManager *)sharedInstance
@@ -139,6 +145,8 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
         [[NSFileManager defaultManager] removeItemAtURL:dbCopyURL error:nil];
         [[NSFileManager defaultManager] copyItemAtURL:databaseURL toURL:dbCopyURL error:nil];
 #endif
+        
+        self.capabilitiesCache = [[NSCache alloc] init];
     }
     
     return self;
@@ -348,10 +356,19 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
 
 - (ServerCapabilities *)serverCapabilitiesForAccountId:(NSString *)accountId
 {
+    ServerCapabilities *cachedCapabilities = [self.capabilitiesCache objectForKey:accountId];
+
+    if (cachedCapabilities) {
+        return cachedCapabilities;
+    }
+
     NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@", accountId];
     ServerCapabilities *managedServerCapabilities = [ServerCapabilities objectsWithPredicate:query].firstObject;
     if (managedServerCapabilities) {
-        return [[ServerCapabilities alloc] initWithValue:managedServerCapabilities];
+        ServerCapabilities *unmanagedServerCapabilities = [[ServerCapabilities alloc] initWithValue:managedServerCapabilities];
+        [self.capabilitiesCache setObject:unmanagedServerCapabilities forKey:accountId];
+
+        return unmanagedServerCapabilities;
     }
     return nil;
 }
@@ -462,6 +479,9 @@ NSString * const kMinimumRequiredTalkCapability     = kCapabilitySystemMessages;
     [realm transactionWithBlock:^{
         [realm addOrUpdateObject:capabilities];
     }];
+
+    ServerCapabilities *unmanagedServerCapabilities = [[ServerCapabilities alloc] initWithValue:capabilities];
+    [self.capabilitiesCache setObject:unmanagedServerCapabilities forKey:accountId];
 }
 
 - (BOOL)serverHasTalkCapability:(NSString *)capability

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -33,7 +33,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 204;
+uint64_t const kTalkDatabaseSchemaVersion           = 56;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";

--- a/NextcloudTalk/NCSplitViewPlaceholderViewController.swift
+++ b/NextcloudTalk/NCSplitViewPlaceholderViewController.swift
@@ -37,6 +37,7 @@ import UIKit
         adjustTheming()
 
         NotificationCenter.default.addObserver(self, selector: #selector(self.appStateChanged(notification:)), name: NSNotification.Name.NCAppStateHasChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.serverCapabilitiesUpdated(notification:)), name: NSNotification.Name.NCServerCapabilitiesUpdated, object: nil)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -60,6 +61,10 @@ import UIKit
     }
 
     func appStateChanged(notification: Notification) {
+        adjustTheming()
+    }
+
+    func serverCapabilitiesUpdated(notification: Notification) {
         adjustTheming()
     }
 }


### PR DESCRIPTION
We are quite heavily relying on the server capabilities and query these often. When starting the app in simulator, I see already around 100 queries just to that. So in my opinion it makes sense to cache the capabilities at runtime.

I think we should also consider this for the active `TalkAccount`, but this needs to be done a bite more carefully.