### PR TITLE
Fix editing info in chat cells

### DIFF
--- a/NextcloudTalk/ChatMessageTableViewCell.m
+++ b/NextcloudTalk/ChatMessageTableViewCell.m
@@ -284,7 +284,7 @@
     if (message.lastEditActorDisplayName || message.lastEditTimestamp > 0) {
         NSString *editedString;
 
-        if ([message.lastEditActorId isEqualToString:activeAccount.userId] && [message.lastEditActorType isEqualToString:@"users"]) {
+        if ([message.lastEditActorId isEqualToString:message.actorId] && [message.lastEditActorType isEqualToString:@"users"]) {
             editedString = NSLocalizedString(@"edited", "A message was edited");
             editedString = [NSString stringWithFormat:@" (%@)", editedString];
         } else {

--- a/NextcloudTalk/FileMessageTableViewCell.m
+++ b/NextcloudTalk/FileMessageTableViewCell.m
@@ -215,7 +215,7 @@
     if (message.lastEditActorDisplayName || message.lastEditTimestamp > 0) {
         NSString *editedString;
 
-        if ([message.lastEditActorId isEqualToString:activeAccount.userId] && [message.lastEditActorType isEqualToString:@"users"]) {
+        if ([message.lastEditActorId isEqualToString:message.actorId] && [message.lastEditActorType isEqualToString:@"users"]) {
             editedString = NSLocalizedString(@"edited", "A message was edited");
             editedString = [NSString stringWithFormat:@" (%@)", editedString];
         } else {


### PR DESCRIPTION
I wrongly checked against the active account userId, but we need to check if the actor which edited a message is the same as the actor which wrote a message.