### PR TITLE
Fix grouped reply messages

### DIFF
--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -2697,7 +2697,7 @@ import QuickLook
 
         var height = ceil(bodyBounds.height)
 
-        if message.isGroupMessage || message.isSystemMessage() {
+        if (message.isGroupMessage && message.parent() == nil) || message.isSystemMessage() {
             height += 10 // 2*left(5)
 
             if height < kGroupedChatMessageCellMinimumHeight {

--- a/NextcloudTalkTests/Unit/UnitChatCellTest.swift
+++ b/NextcloudTalkTests/Unit/UnitChatCellTest.swift
@@ -77,6 +77,24 @@ final class UnitChatCellTest: TestBaseRealm {
         XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 70.0)
     }
 
+    func testGroupedCellWithQuoteHeight() throws {
+        // Add an existing message to the database
+        let existingMessage = NCChatMessage()
+        existingMessage.messageId = 1
+        existingMessage.internalId = "internal-1"
+        existingMessage.message = "existing"
+
+        try? realm.transaction {
+            realm.add(existingMessage)
+        }
+
+        // Chat message with a quote
+        testMessage.message = "test"
+        testMessage.parentId = "internal-1"
+        testMessage.isGroupMessage = true
+        XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 135.0)
+    }
+
     func testCellWithUrlHeight() throws {
         // Chat message with URL preview
         testMessage.message = "test - https://nextcloud.com"


### PR DESCRIPTION
Reply messages are never displayed as grouped messages, so we can't assign the same default height as for a grouped message.

**Before:**
![IMG_E0001 1](https://github.com/nextcloud/talk-ios/assets/4638605/5ac39f94-3871-4b78-a85f-c51a80185a22)

**After:**
![IMG_E0002 1](https://github.com/nextcloud/talk-ios/assets/4638605/706016bb-1490-4dbc-953f-da1490dc5751)
