### PR TITLE
Correctly show file captions with urls

### DIFF
--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -2716,7 +2716,8 @@ import QuickLook
             height += 40 // reactionsView(40)
         }
 
-        if message.containsURL() {
+        // File cells currently can't show the reference view
+        if message.containsURL(), message.file() ==  nil {
             height += 105
         }
 

--- a/NextcloudTalk/FileMessageTableViewCell.m
+++ b/NextcloudTalk/FileMessageTableViewCell.m
@@ -240,6 +240,12 @@
     self.messageId = message.messageId;
     self.message = message;
 
+    if ([message.message isEqualToString:@"{file}"]) {
+        self.bodyTextView.dataDetectorTypes = UIDataDetectorTypeNone;
+    } else {
+        self.bodyTextView.dataDetectorTypes = UIDataDetectorTypeAll;
+    }
+
     NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:message.timestamp];
     self.dateLabel.text = [NCUtils getTimeFromDate:date];
     

--- a/NextcloudTalkTests/Unit/UnitChatCellTest.swift
+++ b/NextcloudTalkTests/Unit/UnitChatCellTest.swift
@@ -27,6 +27,30 @@ final class UnitChatCellTest: TestBaseRealm {
     var baseController: BaseChatViewController!
     var testMessage: NCChatMessage!
 
+    let fileMessageParameters = """
+{
+    "actor": {
+        "type": "user",
+        "id": "admin",
+        "name": "admin"
+    },
+    "file": {
+        "type": "file",
+        "id": "9",
+        "name": "photo-1517603250781-c4eac1449a80.jpeg",
+        "size": 444676,
+        "path": "Media/photo-1517603250781-c4eac1449a80.jpeg",
+        "link": "https://nextcloud-mm.local/index.php/f/9",
+        "etag": "60fb4ececc370787b1cdc5623ff4a189",
+        "permissions": 27,
+        "mimetype": "image/jpeg",
+        "preview-available": "yes",
+        "width": 1491,
+        "height": 837
+    }
+}
+"""
+
     override func setUpWithError() throws {
         try super.setUpWithError()
 
@@ -154,35 +178,31 @@ final class UnitChatCellTest: TestBaseRealm {
     }
 
     func testCellWithFileHeight() {
-        testMessage.messageParametersJSONString = """
-{
-    "actor": {
-        "type": "user",
-        "id": "admin",
-        "name": "admin"
-    },
-    "file": {
-        "type": "file",
-        "id": "9",
-        "name": "photo-1517603250781-c4eac1449a80.jpeg",
-        "size": 444676,
-        "path": "Media/photo-1517603250781-c4eac1449a80.jpeg",
-        "link": "https://nextcloud-mm.local/index.php/f/9",
-        "etag": "60fb4ececc370787b1cdc5623ff4a189",
-        "permissions": 27,
-        "mimetype": "image/jpeg",
-        "preview-available": "yes",
-        "width": 1491,
-        "height": 837
-    }
-}
-"""
-
+        // Test without file caption
+        testMessage.messageParametersJSONString = fileMessageParameters
         testMessage.message = "{file}"
         XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 190.0)
+    }
 
+    func testCellWithFileCaptionHeight() {
+        testMessage.messageParametersJSONString = fileMessageParameters
         testMessage.message = "File caption..."
         XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 210.0)
+    }
+
+    func testCellWithFileCaptionUrlHeight() {
+        updateCapabilities { cap in
+            cap.referenceApiSupported = true
+        }
+
+        testMessage.messageParametersJSONString = fileMessageParameters
+        testMessage.message = "File caption... https://nextcloud.com"
+        XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 210.0)
+    }
+
+    func testCellWithFileAndQuoteHeight() {
+        testMessage.messageParametersJSONString = fileMessageParameters
+        testMessage.message = "File caption..."
 
         // Add an existing message to the database
         let existingMessage = NCChatMessage()


### PR DESCRIPTION

Before:
* No URL detection
* Space at the bottom, but no reference view

<img width="340" alt="image" src="https://github.com/nextcloud/talk-ios/assets/1580193/aa89336f-0da8-46e7-9938-ab759a055c0a">


After:
<img width="336" alt="image" src="https://github.com/nextcloud/talk-ios/assets/1580193/0f2b94fc-2966-4815-a502-7f8c83f9a9ff">
