### PR TITLE
Fix screensharing disappearing issue

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -2460,9 +2460,6 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
                 [[[peer getRemoteStream].videoTracks firstObject] removeRenderer:videoRenderer];
             }];
 
-            // Screen renderers
-            [self removeScreensharingOfPeer:peer];
-
             NSIndexPath *indexPath = [self indexPathForPeerIdentifier:peer.peerIdentifier];
 
             // Make sure we remove every index path only once

--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -663,7 +663,11 @@ static NSString * const kNCScreenTrackKind  = @"screen";
 
     for (NCPeerConnection *peerConnectionWrapper in [_connectionsDict allValues]) {
         if (!peerConnectionWrapper.isMCUPublisherPeer) {
-            [self.delegate callController:self peerLeft:peerConnectionWrapper];
+            if ([peerConnectionWrapper.roomType isEqualToString:kRoomTypeVideo]) {
+                [self.delegate callController:self peerLeft:peerConnectionWrapper];
+            } else if ([peerConnectionWrapper.roomType isEqualToString:kRoomTypeScreen]) {
+                [self.delegate callController:self didReceiveUnshareScreenFromPeer:peerConnectionWrapper];
+            }
         }
 
         peerConnectionWrapper.delegate = nil;


### PR DESCRIPTION
How to test:

1. Start a call with user A and start screensharing
2. Join call with user B using the iOS app

Without this PR:
User B joins the call and most of the time the screensharing appears just for a second and then vanishes.

With this PR:
User B joins the call and can see User A screen share.

Fix  #1466