### PR TITLE
Fix timer userinfo access

### DIFF
--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -1101,11 +1101,11 @@ static NSString * const kNCScreenTrackKind  = @"screen";
 
 - (void)requestNewOffer:(NSTimer *)timer
 {
-    [[WebRTCCommon shared] dispatch:^{
-        NSString *sessionId = [timer.userInfo objectForKey:@"sessionId"];
-        NSString *roomType = [timer.userInfo objectForKey:@"roomType"];
-        NSInteger timeout = [[timer.userInfo objectForKey:@"timeout"] integerValue];
+    NSString *sessionId = [timer.userInfo objectForKey:@"sessionId"];
+    NSString *roomType = [timer.userInfo objectForKey:@"roomType"];
+    NSInteger timeout = [[timer.userInfo objectForKey:@"timeout"] integerValue];
 
+    [[WebRTCCommon shared] dispatch:^{
         if ([[NSDate date] timeIntervalSince1970] < timeout) {
             NSLog(@"Re-requesting an offer to session: %@", sessionId);
             [self->_externalSignalingController requestOfferForSessionId:sessionId andRoomType:roomType];


### PR DESCRIPTION
Access to the userinfo dictionary is not thread safe and should be done on the main thread:

<img width="1157" alt="Bildschirmfoto 2024-02-10 um 16 46 00" src="https://github.com/nextcloud/talk-ios/assets/1580193/bb9eca27-458a-4169-8147-8bc2d7501599">
