### PR TITLE
Remove public access to data channels

### DIFF
--- a/NextcloudTalk/NCPeerConnection.h
+++ b/NextcloudTalk/NCPeerConnection.h
@@ -85,8 +85,6 @@
 - (void)drainRemoteCandidates;
 - (void)close;
 - (RTCPeerConnection *)getPeerConnection;
-- (RTCDataChannel *)getLocalDataChannel;
-- (RTCDataChannel *)getRemoteDataChannel;
 - (RTCMediaStream *)getRemoteStream;
 - (BOOL)hasRemoteStream;
 


### PR DESCRIPTION
Not used anywhere outside of the `NCPeerConnection`, so no need to expose it.