### PR TITLE
Fix user reconnected grouped system messages

### DIFF
--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -2105,7 +2105,7 @@ import QuickLook
                 }
             }
         } else if newMessage.actorId == lastMessage.actorId {
-            if ["call_joined", "call_left"].contains(newMessage.systemMessage) {
+            if lastMessage.systemMessage == "call_left", newMessage.systemMessage == "call_joined" {
                 self.collapseSystemMessage(newMessage, withMessage: lastMessage, withAction: "call_reconnected")
             }
         }


### PR DESCRIPTION
Before:
User joins the call and then leaves the call.
Both system messages were grouped as "reconnected"

With this PR:
Only when the user leaves the call and then joins again, both system messages are grouped as "reconnected"