### PR TITLE
Unify avatars // Federated avatars

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		1F0A1D442A5F1FA800A25433 /* SwiftMarkdownObjCBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0A1D432A5F1FA800A25433 /* SwiftMarkdownObjCBridge.swift */; };
+		1F0B0A722BA264540073FF8D /* MentionSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0B0A712BA264540073FF8D /* MentionSuggestion.swift */; };
+		1F0B0A732BA265300073FF8D /* MentionSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0B0A712BA264540073FF8D /* MentionSuggestion.swift */; };
+		1F0B0A742BA265310073FF8D /* MentionSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0B0A712BA264540073FF8D /* MentionSuggestion.swift */; };
+		1F0B0A752BA265310073FF8D /* MentionSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0B0A712BA264540073FF8D /* MentionSuggestion.swift */; };
+		1F0B0A772BA26BE10073FF8D /* UnitMentionSuggestionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0B0A762BA26BE10073FF8D /* UnitMentionSuggestionTest.swift */; };
 		1F0ECBF52A68274400921E90 /* CDMarkdownKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1F0ECBF42A68274400921E90 /* CDMarkdownKit */; };
 		1F0ECBF72A68277000921E90 /* CDMarkdownKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1F0ECBF62A68277000921E90 /* CDMarkdownKit */; };
 		1F0ECBF92A68277C00921E90 /* CDMarkdownKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1F0ECBF82A68277C00921E90 /* CDMarkdownKit */; };
@@ -556,6 +561,8 @@
 
 /* Begin PBXFileReference section */
 		1F0A1D432A5F1FA800A25433 /* SwiftMarkdownObjCBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftMarkdownObjCBridge.swift; sourceTree = "<group>"; };
+		1F0B0A712BA264540073FF8D /* MentionSuggestion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MentionSuggestion.swift; sourceTree = "<group>"; };
+		1F0B0A762BA26BE10073FF8D /* UnitMentionSuggestionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitMentionSuggestionTest.swift; sourceTree = "<group>"; };
 		1F11FB7129C07B04001E21E7 /* NCZoomableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NCZoomableView.swift; sourceTree = "<group>"; };
 		1F1B50422B9095C900B0F2F4 /* FederatedCapabilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FederatedCapabilities.h; sourceTree = "<group>"; };
 		1F1B50432B9095D100B0F2F4 /* FederatedCapabilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FederatedCapabilities.m; sourceTree = "<group>"; };
@@ -1220,6 +1227,7 @@
 			children = (
 				1FBC3BE82B61BD09003909E0 /* TestBaseRealm.swift */,
 				1F5CDAE62B3B05110040ECC0 /* UnitColorGeneratorTest.swift */,
+				1F0B0A762BA26BE10073FF8D /* UnitMentionSuggestionTest.swift */,
 				1FBC3BE42B61ACD5003909E0 /* UnitChatCellTest.swift */,
 			);
 			path = Unit;
@@ -1899,6 +1907,7 @@
 				1FAB2E842ACB482B001214EB /* ChatViewController.swift */,
 				1F35F8FA2AEEDBC600044BDA /* ChatViewControllerExtension.swift */,
 				2C4230F62B207AB00013E1FA /* ContextChatViewController.swift */,
+				1F0B0A712BA264540073FF8D /* MentionSuggestion.swift */,
 			);
 			name = Chat;
 			sourceTree = "<group>";
@@ -2495,6 +2504,7 @@
 				1F5CDAE72B3B05110040ECC0 /* UnitColorGeneratorTest.swift in Sources */,
 				1F6D8C412B2F26D5004376B8 /* TestConstants.swift in Sources */,
 				1FBC3BE52B61ACD5003909E0 /* UnitChatCellTest.swift in Sources */,
+				1F0B0A772BA26BE10073FF8D /* UnitMentionSuggestionTest.swift in Sources */,
 				1F6D8C432B2F26EE004376B8 /* Helpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2529,6 +2539,7 @@
 				1F77A5F82AB9A4CD007B6037 /* NCDeckCardParameter.m in Sources */,
 				1F77A5FD2AB9A4F3007B6037 /* ServerCapabilities.m in Sources */,
 				1F77A6062AB9A581007B6037 /* NCKeyChainController.m in Sources */,
+				1F0B0A732BA265300073FF8D /* MentionSuggestion.swift in Sources */,
 				1F77A5FB2AB9A4E6007B6037 /* NCMessageParameter.m in Sources */,
 				1F77A6042AB9A574007B6037 /* NCImageSessionManager.m in Sources */,
 				1F77A5F62AB9A4BF007B6037 /* NCChatReaction.m in Sources */,
@@ -2678,6 +2689,7 @@
 				2CBF82B21FCC7DBA00636459 /* CCCertificate.m in Sources */,
 				2CC1FF4828183958009F7288 /* NCDeckCardParameter.m in Sources */,
 				2C3780BD2107209C003F9AE8 /* NCRoomParticipants.m in Sources */,
+				1F0B0A722BA264540073FF8D /* MentionSuggestion.swift in Sources */,
 				2CA1CCCD1F181741002FE6A2 /* NCUser.m in Sources */,
 				2CBF82B61FD0939600636459 /* NCAPISessionManager.m in Sources */,
 				1F77A6162AB9B161007B6037 /* ScreenCaptureController.m in Sources */,
@@ -2803,6 +2815,7 @@
 				1FDCC3ED29EC7E6700DEB39B /* AvatarImageView.swift in Sources */,
 				1F35F8E32AEEBBE000044BDA /* NCChatTitleView.m in Sources */,
 				1FDCC3EE29EC7E8500DEB39B /* AvatarManager.swift in Sources */,
+				1F0B0A742BA265310073FF8D /* MentionSuggestion.swift in Sources */,
 				2C62B00D24C1BDC1007E460A /* NCPushNotification.m in Sources */,
 				1F1B50492B90CF0800B0F2F4 /* TalkCapabilities.m in Sources */,
 				2C62B01C24C1BDC9007E460A /* CCCertificate.m in Sources */,
@@ -2876,6 +2889,7 @@
 				2C4446FD265D5DFA00DF1DBC /* ABContact.m in Sources */,
 				2C4446F8265D5A0700DF1DBC /* NotificationCenterNotifications.m in Sources */,
 				2C6955142B0CE1A20070F6E1 /* NCUtils.swift in Sources */,
+				1F0B0A752BA265310073FF8D /* MentionSuggestion.swift in Sources */,
 				1FC940B92A5F21FC00FFFADE /* SwiftMarkdownObjCBridge.swift in Sources */,
 				2CB6ACDB2641483800D3D641 /* NCMessageLocationParameter.m in Sources */,
 				2C4446FB265D5C5700DF1DBC /* NCRoomParticipants.m in Sources */,

--- a/NextcloudTalk/AddParticipantsTableViewController.m
+++ b/NextcloudTalk/AddParticipantsTableViewController.m
@@ -406,14 +406,7 @@
     }
     
     cell.labelTitle.text = participant.name;
-    
-    if ([participant.source isEqualToString:kParticipantTypeUser]) {
-        [cell.contactImage setUserAvatarFor:participant.userId with:self.traitCollection.userInterfaceStyle];
-    } else if ([participant.source isEqualToString:kParticipantTypeEmail]) {
-        [cell.contactImage setImage:[UIImage imageNamed:@"mail-avatar"]];
-    } else {
-        [cell.contactImage setImage:[UIImage imageNamed:@"group-avatar"]];
-    }
+    [cell.contactImage setActorAvatarForId:participant.userId withType:participant.source withDisplayName:participant.name withStyle:self.traitCollection.userInterfaceStyle];
 
     UIImage *selectionImage = [UIImage systemImageNamed:@"circle"];
     UIColor *selectionImageColor = [UIColor tertiaryLabelColor];

--- a/NextcloudTalk/AddParticipantsTableViewController.m
+++ b/NextcloudTalk/AddParticipantsTableViewController.m
@@ -406,7 +406,7 @@
     }
     
     cell.labelTitle.text = participant.name;
-    [cell.contactImage setActorAvatarForId:participant.userId withType:participant.source withDisplayName:participant.name withStyle:self.traitCollection.userInterfaceStyle];
+    [cell.contactImage setActorAvatarForId:participant.userId withType:participant.source withDisplayName:participant.name withRoomToken:_room.token];
 
     UIImage *selectionImage = [UIImage systemImageNamed:@"circle"];
     UIColor *selectionImageColor = [UIColor tertiaryLabelColor];

--- a/NextcloudTalk/AvatarButton.swift
+++ b/NextcloudTalk/AvatarButton.swift
@@ -71,14 +71,18 @@ import SDWebImage
 
     // MARK: - User avatars
 
-    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withStyle style: UIUserInterfaceStyle) {
-        self.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withStyle: style, using: nil)
+    public func setActorAvatar(forMessage message: NCChatMessage) {
+        self.setActorAvatar(forId: message.actorId, withType: message.actorType, withDisplayName: message.actorDisplayName, withRoomToken: message.token)
     }
 
-    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withStyle style: UIUserInterfaceStyle, using account: TalkAccount?) {
+    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?) {
+        self.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, using: nil)
+    }
+
+    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, using account: TalkAccount?) {
         self.cancelCurrentRequest()
 
-        self.currentRequest = AvatarManager.shared.getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withStyle: style, usingAccount: account) { image in
+        self.currentRequest = AvatarManager.shared.getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, withStyle: self.traitCollection.userInterfaceStyle, usingAccount: account) { image in
             guard let image = image else {
                 return
             }

--- a/NextcloudTalk/AvatarButton.swift
+++ b/NextcloudTalk/AvatarButton.swift
@@ -71,14 +71,14 @@ import SDWebImage
 
     // MARK: - User avatars
 
-    public func setUserAvatar(for userId: String, with style: UIUserInterfaceStyle) {
-        self.setUserAvatar(for: userId, with: style, using: nil)
+    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withStyle style: UIUserInterfaceStyle) {
+        self.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withStyle: style, using: nil)
     }
 
-    public func setUserAvatar(for userId: String, with style: UIUserInterfaceStyle, using account: TalkAccount?) {
+    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withStyle style: UIUserInterfaceStyle, using account: TalkAccount?) {
         self.cancelCurrentRequest()
 
-        self.currentRequest = AvatarManager.shared.getUserAvatar(for: userId, with: style, using: account) { image in
+        self.currentRequest = AvatarManager.shared.getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withStyle: style, usingAccount: account) { image in
             guard let image = image else {
                 return
             }

--- a/NextcloudTalk/AvatarButton.swift
+++ b/NextcloudTalk/AvatarButton.swift
@@ -51,10 +51,10 @@ import SDWebImage
 
     // MARK: - Conversation avatars
 
-    public func setAvatar(for room: NCRoom, with style: UIUserInterfaceStyle) {
+    public func setAvatar(for room: NCRoom) {
         self.cancelCurrentRequest()
 
-        self.currentRequest = AvatarManager.shared.getAvatar(for: room, with: style) { image in
+        self.currentRequest = AvatarManager.shared.getAvatar(for: room, with: self.traitCollection.userInterfaceStyle) { image in
             guard let image = image else {
                 return
             }
@@ -63,8 +63,8 @@ import SDWebImage
         }
     }
 
-    public func setGroupAvatar(with style: UIUserInterfaceStyle) {
-        if let image = AvatarManager.shared.getGroupAvatar(with: style) {
+    public func setGroupAvatar() {
+        if let image = AvatarManager.shared.getGroupAvatar(with: self.traitCollection.userInterfaceStyle) {
             self.setImage(image, for: .normal)
         }
     }

--- a/NextcloudTalk/AvatarImageView.swift
+++ b/NextcloudTalk/AvatarImageView.swift
@@ -48,10 +48,10 @@ import SDWebImage
 
     // MARK: - Conversation avatars
 
-    public func setAvatar(for room: NCRoom, with style: UIUserInterfaceStyle) {
+    public func setAvatar(for room: NCRoom) {
         self.cancelCurrentRequest()
 
-        self.currentRequest = AvatarManager.shared.getAvatar(for: room, with: style) { image in
+        self.currentRequest = AvatarManager.shared.getAvatar(for: room, with: self.traitCollection.userInterfaceStyle) { image in
             guard let image = image else {
                 return
             }
@@ -61,14 +61,14 @@ import SDWebImage
         }
     }
 
-    public func setGroupAvatar(with style: UIUserInterfaceStyle) {
-        if let image = AvatarManager.shared.getGroupAvatar(with: style) {
+    public func setGroupAvatar() {
+        if let image = AvatarManager.shared.getGroupAvatar(with: self.traitCollection.userInterfaceStyle) {
             self.image = image
         }
     }
 
-    public func setMailAvatar(with style: UIUserInterfaceStyle) {
-        if let image = AvatarManager.shared.getMailAvatar(with: style) {
+    public func setMailAvatar() {
+        if let image = AvatarManager.shared.getMailAvatar(with: self.traitCollection.userInterfaceStyle) {
             self.image = image
         }
     }

--- a/NextcloudTalk/AvatarImageView.swift
+++ b/NextcloudTalk/AvatarImageView.swift
@@ -75,14 +75,14 @@ import SDWebImage
 
     // MARK: - User avatars
 
-    public func setUserAvatar(for userId: String, with style: UIUserInterfaceStyle) {
-        self.setUserAvatar(for: userId, with: style, using: nil)
+    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withStyle style: UIUserInterfaceStyle) {
+        self.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withStyle: style, using: nil)
     }
 
-    public func setUserAvatar(for userId: String, with style: UIUserInterfaceStyle, using account: TalkAccount?) {
+    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withStyle style: UIUserInterfaceStyle, using account: TalkAccount?) {
         self.cancelCurrentRequest()
 
-        self.currentRequest = AvatarManager.shared.getUserAvatar(for: userId, with: style, using: account) { image in
+        self.currentRequest = AvatarManager.shared.getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withStyle: style, usingAccount: account) { image in
             guard let image = image else {
                 return
             }

--- a/NextcloudTalk/AvatarImageView.swift
+++ b/NextcloudTalk/AvatarImageView.swift
@@ -75,14 +75,18 @@ import SDWebImage
 
     // MARK: - User avatars
 
-    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withStyle style: UIUserInterfaceStyle) {
-        self.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withStyle: style, using: nil)
+    public func setActorAvatar(forMessage message: NCChatMessage) {
+        self.setActorAvatar(forId: message.actorId, withType: message.actorType, withDisplayName: message.actorDisplayName, withRoomToken: message.token)
     }
 
-    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withStyle style: UIUserInterfaceStyle, using account: TalkAccount?) {
+    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?) {
+        self.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, using: nil)
+    }
+
+    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, using account: TalkAccount?) {
         self.cancelCurrentRequest()
 
-        self.currentRequest = AvatarManager.shared.getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withStyle: style, usingAccount: account) { image in
+        self.currentRequest = AvatarManager.shared.getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, withStyle: self.traitCollection.userInterfaceStyle, usingAccount: account) { image in
             guard let image = image else {
                 return
             }

--- a/NextcloudTalk/AvatarManager.swift
+++ b/NextcloudTalk/AvatarManager.swift
@@ -26,6 +26,8 @@ import SDWebImage
 
     public static let shared = AvatarManager()
 
+    private let avatarDefaultSize = CGRect(x: 0, y: 0, width: 32, height: 32)
+
     // MARK: - Conversation avatars
 
     public func getAvatar(for room: NCRoom, with style: UIUserInterfaceStyle, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
@@ -65,7 +67,7 @@ import SDWebImage
             switch room.type {
             case kNCRoomTypeOneToOne:
                 let account = NCDatabaseManager.sharedInstance().talkAccount(forAccountId: room.accountId)
-                return self.getUserAvatar(for: room.name, with: style, using: account, completionBlock: completionBlock)
+                return self.getUserAvatar(forId: room.name, withStyle: style, usingAccount: account, completionBlock: completionBlock)
             case kNCRoomTypeFormerOneToOne:
                 completionBlock(UIImage(named: "user-avatar", in: nil, compatibleWith: traitCollection))
             case kNCRoomTypePublic:
@@ -82,16 +84,64 @@ import SDWebImage
         return nil
     }
 
-    // MARK: - User avatars
+    // MARK: - Actor avatars
 
-    public func getUserAvatar(for user: String, with style: UIUserInterfaceStyle, using account: TalkAccount?, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
+    // swiftlint:disable:next function_parameter_count
+    public func getActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount?, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
+        if let actorId {
+            if actorType == "bots" {
+                return getBotsAvatar(forId: actorId, withStyle: style, usingAccount: account, completionBlock: completionBlock)
+            } else if actorType == "guests" {
+                return getGuestsAvatar(forId: actorId, withDisplayName: actorDisplayName ?? "", withStyle: style, usingAccount: account, completionBlock: completionBlock)
+            } else if actorType == "users" {
+                return getUserAvatar(forId: actorId, withStyle: style, usingAccount: account, completionBlock: completionBlock)
+            }
+        }
+
+        var image: UIImage?
+
+        if actorType == NCAttendeeTypeEmail {
+            image = self.getMailAvatar(with: style)
+        } else if actorType == NCAttendeeTypeGroup || actorType == NCAttendeeTypeCircle {
+            image = self.getGroupAvatar(with: style)
+        } else {
+            image = NCUtils.getImage(withString: "?", withBackgroundColor: NCAppBranding.placeholderColor(), withBounds: self.avatarDefaultSize, isCircular: true)
+        }
+
+        completionBlock(image)
+        return nil
+    }
+
+    public func getBotsAvatar(forId actorId: String, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount?, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
+        if actorId == "changelog" {
+            let traitCollection = UITraitCollection(userInterfaceStyle: style)
+            completionBlock(UIImage(named: "changelog-avatar", in: nil, compatibleWith: traitCollection))
+        } else {
+            let image = NCUtils.getImage(withString: ">", withBackgroundColor: .systemGray, withBounds: self.avatarDefaultSize, isCircular: true)
+            completionBlock(image)
+        }
+
+        return nil
+    }
+
+    public func getGuestsAvatar(forId actorId: String, withDisplayName actorDisplayName: String, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount?, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
+        let color = NCAppBranding.placeholderColor()
+        let name = actorDisplayName.isEmpty ? "?" : actorDisplayName
+        let image = NCUtils.getImage(withString: name, withBackgroundColor: color, withBounds: self.avatarDefaultSize, isCircular: true)
+
+        completionBlock(image)
+
+        return nil
+    }
+
+    public func getUserAvatar(forId actorId: String, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount?, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
         let account = account ?? NCDatabaseManager.sharedInstance().activeAccount()
 
-        return NCAPIController.sharedInstance().getUserAvatar(forUser: user, using: account, with: style) { image, _ in
+        return NCAPIController.sharedInstance().getUserAvatar(forUser: actorId, using: account, with: style) { image, _ in
             if image != nil {
                 completionBlock(image)
             } else {
-                NSLog("Unable to get avatar for user %@", user)
+                NSLog("Unable to get avatar for user %@", actorId)
 
                 let traitCollection = UITraitCollection(userInterfaceStyle: style)
                 completionBlock(UIImage(named: "user-avatar", in: nil, compatibleWith: traitCollection))

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -2435,6 +2435,7 @@ import QuickLook
         AudioServicesPlaySystemSound(1519)
 
         let reactionsVC = ReactionsSummaryView(style: .insetGrouped)
+        reactionsVC.room = self.room
         self.presentWithNavigation(reactionsVC, animated: true)
 
         let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()

--- a/NextcloudTalk/CallKitManager.m
+++ b/NextcloudTalk/CallKitManager.m
@@ -278,7 +278,7 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
 
 - (void)getCallInfoForCall:(CallKitCall *)call
 {
-    NCRoom *room = [[NCRoomsManager sharedInstance] roomWithToken:call.token forAccountId:call.accountId];
+    NCRoom *room = [[NCDatabaseManager sharedInstance] roomWithToken:call.token forAccountId:call.accountId];
     if (room) {
         [self updateCall:call withDisplayName:room.displayName];
     }

--- a/NextcloudTalk/CallParticipantViewCell.m
+++ b/NextcloudTalk/CallParticipantViewCell.m
@@ -142,7 +142,7 @@ CGFloat const kCallParticipantCellMinHeight = 128;
         [self setBackgroundColor:[[ColorGenerator shared] usernameToColor:userId]];
     }
 
-    [self.peerAvatarImageView setActorAvatarForId:userId withType:@"users" withDisplayName:@"" withStyle:self.traitCollection.userInterfaceStyle];
+    [self.peerAvatarImageView setActorAvatarForId:userId withType:@"users" withDisplayName:@"" withRoomToken:nil];
 }
 
 - (void)setDisplayName:(NSString *)displayName

--- a/NextcloudTalk/CallParticipantViewCell.m
+++ b/NextcloudTalk/CallParticipantViewCell.m
@@ -141,15 +141,8 @@ CGFloat const kCallParticipantCellMinHeight = 128;
     } else {
         [self setBackgroundColor:[[ColorGenerator shared] usernameToColor:userId]];
     }
-    
-    if (userId && userId.length > 0) {
-        [self.peerAvatarImageView setUserAvatarFor:userId with:self.traitCollection.userInterfaceStyle];
-    } else {
-        UIColor *guestAvatarColor = [UIColor colorWithRed:0.73 green:0.73 blue:0.73 alpha:1.0]; /*#b9b9b9*/
 
-        UIImage *image = [NCUtils getImageWithString:@"?" withBackgroundColor:guestAvatarColor withBounds:self.peerAvatarImageView.bounds isCircular:YES];
-        [self.peerAvatarImageView setImage:image];
-    }
+    [self.peerAvatarImageView setActorAvatarForId:userId withType:@"users" withDisplayName:@"" withStyle:self.traitCollection.userInterfaceStyle];
 }
 
 - (void)setDisplayName:(NSString *)displayName

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1635,7 +1635,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
     if (!_chatNavigationController) {
         // Create new chat controller
         TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
-        NCRoom *room = [[NCRoomsManager sharedInstance] roomWithToken:_room.token forAccountId:activeAccount.accountId];
+        NCRoom *room = [[NCDatabaseManager sharedInstance] roomWithToken:_room.token forAccountId:activeAccount.accountId];
         _chatViewController = [[ChatViewController alloc] initFor:room];
         _chatViewController.presentedInCall = YES;
         _chatNavigationController = [[UINavigationController alloc] initWithRootViewController:_chatViewController];

--- a/NextcloudTalk/ChatMessageTableViewCell.h
+++ b/NextcloudTalk/ChatMessageTableViewCell.h
@@ -56,9 +56,6 @@ static NSString *ReplyMessageCellIdentifier     = @"ReplyMessageCellIdentifier";
 
 + (CGFloat)defaultFontSize;
 - (void)setupForMessage:(NCChatMessage *)message withLastCommonReadMessage:(NSInteger)lastCommonRead;
-- (void)setGuestAvatar:(NSString *)displayName;
-- (void)setBotAvatar;
-- (void)setChangelogAvatar;
 - (void)setUserStatus:(NSString *)userStatus;
 
 @end

--- a/NextcloudTalk/ChatMessageTableViewCell.m
+++ b/NextcloudTalk/ChatMessageTableViewCell.m
@@ -313,19 +313,12 @@
     ServerCapabilities *serverCapabilities = [[NCDatabaseManager sharedInstance] serverCapabilitiesForAccountId:activeAccount.accountId];
     BOOL shouldShowDeliveryStatus = [[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityChatReadStatus forAccountId:activeAccount.accountId];
     BOOL shouldShowReadStatus = !serverCapabilities.readStatusPrivacy;
-    
+
+    [self.avatarButton setActorAvatarForId:message.actorId withType:message.actorType withDisplayName:message.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
+    self.avatarButton.menu = [super getDeferredUserMenuForMessage:message];
+
     if ([message.actorType isEqualToString:@"guests"]) {
         self.titleLabel.text = ([message.actorDisplayName isEqualToString:@""]) ? NSLocalizedString(@"Guest", nil) : message.actorDisplayName;
-        [self setGuestAvatar:message.actorDisplayName];
-    } else if ([message.actorType isEqualToString:@"bots"]) {
-        if ([message.actorId isEqualToString:@"changelog"]) {
-            [self setChangelogAvatar];
-        } else {
-            [self setBotAvatar];
-        }
-    } else {
-        [self.avatarButton setUserAvatarFor:message.actorId with:self.traitCollection.userInterfaceStyle using:activeAccount];
-        _avatarButton.menu = [super getDeferredUserMenuForMessage:message];
     }
     
     // This check is just a workaround to fix the issue with the deleted parents returned by the API.
@@ -334,7 +327,7 @@
         self.quotedMessageView.actorLabel.text = ([parent.actorDisplayName isEqualToString:@""]) ? NSLocalizedString(@"Guest", nil) : parent.actorDisplayName;
         self.quotedMessageView.messageLabel.text = parent.parsedMarkdownForChat.string;
         self.quotedMessageView.highlighted = [parent isMessageFromUser:activeAccount.userId];
-        [self.quotedMessageView.avatarView setUserAvatarFor:parent.actorId with:self.traitCollection.userInterfaceStyle];
+        [self.quotedMessageView.avatarView setActorAvatarForId:parent.actorId withType:parent.actorType withDisplayName:parent.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
     }
     
     if (message.isDeleting) {

--- a/NextcloudTalk/ChatMessageTableViewCell.m
+++ b/NextcloudTalk/ChatMessageTableViewCell.m
@@ -314,7 +314,7 @@
     BOOL shouldShowDeliveryStatus = [[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityChatReadStatus forAccountId:activeAccount.accountId];
     BOOL shouldShowReadStatus = !serverCapabilities.readStatusPrivacy;
 
-    [self.avatarButton setActorAvatarForId:message.actorId withType:message.actorType withDisplayName:message.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
+    [self.avatarButton setActorAvatarForMessage:message];
     self.avatarButton.menu = [super getDeferredUserMenuForMessage:message];
 
     if ([message.actorType isEqualToString:@"guests"]) {
@@ -327,7 +327,7 @@
         self.quotedMessageView.actorLabel.text = ([parent.actorDisplayName isEqualToString:@""]) ? NSLocalizedString(@"Guest", nil) : parent.actorDisplayName;
         self.quotedMessageView.messageLabel.text = parent.parsedMarkdownForChat.string;
         self.quotedMessageView.highlighted = [parent isMessageFromUser:activeAccount.userId];
-        [self.quotedMessageView.avatarView setActorAvatarForId:parent.actorId withType:parent.actorType withDisplayName:parent.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
+        [self.quotedMessageView.avatarView setActorAvatarForMessage:parent];
     }
     
     if (message.isDeleting) {
@@ -393,27 +393,6 @@
             [strongSelf.delegate cellWantsToReplyToMessage:strongSelf.message];
         }];
     }
-}
-
-- (void)setGuestAvatar:(NSString *)displayName
-{
-    UIColor *guestAvatarColor = [NCAppBranding placeholderColor];
-    NSString *name = ([displayName isEqualToString:@""]) ? @"?" : displayName;
-
-    UIImage *image = [NCUtils getImageWithString:name withBackgroundColor:guestAvatarColor withBounds:_avatarButton.bounds isCircular:YES];
-    [_avatarButton setImage:image forState:UIControlStateNormal];
-}
-
-- (void)setBotAvatar
-{
-    UIColor *guestAvatarColor = [UIColor colorWithRed:0.21 green:0.21 blue:0.21 alpha:1.0]; /*#363636*/
-    UIImage *image = [NCUtils getImageWithString:@">" withBackgroundColor:guestAvatarColor withBounds:_avatarButton.bounds isCircular:YES];
-    [_avatarButton setImage:image forState:UIControlStateNormal];
-}
-
-- (void)setChangelogAvatar
-{
-    [_avatarButton setImage:[UIImage imageNamed:@"changelog-avatar"] forState:UIControlStateNormal];
 }
 
 - (void)setDeliveryState:(ChatMessageDeliveryState)state

--- a/NextcloudTalk/FileMessageTableViewCell.m
+++ b/NextcloudTalk/FileMessageTableViewCell.m
@@ -249,7 +249,7 @@
     NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:message.timestamp];
     self.dateLabel.text = [NCUtils getTimeFromDate:date];
     
-    [self.avatarButton setActorAvatarForId:message.actorId withType:message.actorType withDisplayName:message.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
+    [self.avatarButton setActorAvatarForMessage:message];
     _avatarButton.menu = [super getDeferredUserMenuForMessage:message];
 
     [self requestPreviewForMessage:message withAccount:activeAccount];

--- a/NextcloudTalk/FileMessageTableViewCell.m
+++ b/NextcloudTalk/FileMessageTableViewCell.m
@@ -249,8 +249,7 @@
     NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:message.timestamp];
     self.dateLabel.text = [NCUtils getTimeFromDate:date];
     
-    [self.avatarButton setUserAvatarFor:message.actorId with:self.traitCollection.userInterfaceStyle using:activeAccount];
-
+    [self.avatarButton setActorAvatarForId:message.actorId withType:message.actorType withDisplayName:message.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
     _avatarButton.menu = [super getDeferredUserMenuForMessage:message];
 
     [self requestPreviewForMessage:message withAccount:activeAccount];

--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -303,7 +303,7 @@ import UIKit
             if suggestionId == "all" {
                 cell.avatarButton.setAvatar(for: self.room, with: self.traitCollection.userInterfaceStyle)
             } else {
-                cell.avatarButton.setActorAvatar(forId: suggestionId, withType: suggestionSource, withDisplayName: suggestionName, withStyle: self.traitCollection.userInterfaceStyle)
+                cell.avatarButton.setActorAvatar(forId: suggestionId, withType: suggestionSource, withDisplayName: suggestionName, withRoomToken: self.room.token)
             }
         }
 

--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -302,14 +302,8 @@ import UIKit
 
             if suggestionId == "all" {
                 cell.avatarButton.setAvatar(for: self.room, with: self.traitCollection.userInterfaceStyle)
-            } else if suggestionSource == "guests" {
-                let name = suggestionName == "Guest" ? "?" : suggestionName
-                let image = NCUtils.getImage(withString: name, withBackgroundColor: NCAppBranding.placeholderColor(), withBounds: cell.avatarButton.bounds, isCircular: true)
-                cell.avatarButton.setImage(image, for: .normal)
-            } else if suggestionSource == "groups" {
-                cell.avatarButton.setGroupAvatar(with: self.traitCollection.userInterfaceStyle)
             } else {
-                cell.avatarButton.setUserAvatar(for: suggestionId, with: self.traitCollection.userInterfaceStyle)
+                cell.avatarButton.setActorAvatar(forId: suggestionId, withType: suggestionSource, withDisplayName: suggestionName, withStyle: self.traitCollection.userInterfaceStyle)
             }
         }
 

--- a/NextcloudTalk/LocationMessageTableViewCell.m
+++ b/NextcloudTalk/LocationMessageTableViewCell.m
@@ -167,7 +167,7 @@
     self.dateLabel.text = [NCUtils getTimeFromDate:date];
     
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
-    [self.avatarButton setUserAvatarFor:message.actorId with:self.traitCollection.userInterfaceStyle using:activeAccount];
+    [self.avatarButton setActorAvatarForId:message.actorId withType:message.actorType withDisplayName:message.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
 
     _avatarButton.menu = [super getDeferredUserMenuForMessage:message];
    

--- a/NextcloudTalk/LocationMessageTableViewCell.m
+++ b/NextcloudTalk/LocationMessageTableViewCell.m
@@ -167,7 +167,7 @@
     self.dateLabel.text = [NCUtils getTimeFromDate:date];
     
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
-    [self.avatarButton setActorAvatarForId:message.actorId withType:message.actorType withDisplayName:message.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
+    [self.avatarButton setActorAvatarForMessage:message];
 
     _avatarButton.menu = [super getDeferredUserMenuForMessage:message];
    

--- a/NextcloudTalk/MentionSuggestion.swift
+++ b/NextcloudTalk/MentionSuggestion.swift
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2024 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+@objcMembers public class MentionSuggestion: NSObject {
+
+    public var id: String
+    public var label: String
+    public var source: String
+    public var mentionId: String?
+    public var userStatus: String?
+
+    init(dictionary: [String: Any]) {
+        self.id = dictionary["id"] as? String ?? ""
+        self.label = dictionary["label"] as? String ?? ""
+        self.source = dictionary["source"] as? String ?? ""
+        self.mentionId = dictionary["mentionId"] as? String
+        self.userStatus = dictionary["status"] as? String
+
+        super.init()
+    }
+
+    func getIdForChat() -> String {
+        // When we support a mentionId serverside, we use that
+        var id = self.mentionId ?? self.id
+
+        if id.contains("/") || id.rangeOfCharacter(from: .whitespaces) != nil {
+            id = "\"\(id)\""
+        }
+
+        return id
+    }
+
+    func getIdForAvatar() -> String {
+        // For avatars we always want to use the actorId, so ignore a potential serverside mentionId here
+        return self.id
+    }
+
+    func asMessageParameter() -> NCMessageParameter {
+        let messageParameter = NCMessageParameter()
+
+        messageParameter.parameterId = self.getIdForAvatar()
+        messageParameter.name = self.label
+        messageParameter.mentionDisplayName = "@\(self.label)"
+        // Note: The mentionId on NCMessageParameter is different than the one on MentionSuggestion!
+        messageParameter.mentionId = "@\(self.getIdForChat())"
+
+        // Set parameter type
+        if self.source == "calls" {
+            messageParameter.type = "call"
+        } else if self.source == "users" || self.source == "federated_users" {
+            messageParameter.type = "user"
+        } else if self.source == "guests" {
+            messageParameter.type = "guest"
+        } else if self.source == "groups" {
+            messageParameter.type = "user-group"
+        }
+
+        return messageParameter
+    }
+}

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -99,6 +99,7 @@ typedef void (^CheckAttachmentFolderCompletionBlock)(BOOL created, NSInteger err
 typedef void (^GetUserActionsCompletionBlock)(NSDictionary *userActions, NSError *error);
 
 typedef void (^GetUserAvatarImageForUserCompletionBlock)(UIImage *image, NSError *error);
+typedef void (^GetFederatedUserAvatarImageForUserCompletionBlock)(UIImage *image, NSError *error);
 
 typedef void (^GetAvatarForConversationWithImageCompletionBlock)(UIImage *image, NSError *error);
 typedef void (^SetAvatarForConversationWithImageCompletionBlock)(NSError *error);
@@ -267,6 +268,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 
 // User avatars
 - (SDWebImageCombinedOperation *)getUserAvatarForUser:(NSString *)userId usingAccount:(TalkAccount *)account withStyle:(UIUserInterfaceStyle)style withCompletionBlock:(GetUserAvatarImageForUserCompletionBlock)block;
+- (SDWebImageCombinedOperation *)getFederatedUserAvatarForUser:(NSString *)userId inRoom:(NCRoom *)room withStyle:(UIUserInterfaceStyle)style withCompletionBlock:(GetFederatedUserAvatarImageForUserCompletionBlock)block;
 
 // Conversation avatars
 - (SDWebImageCombinedOperation *)getAvatarForRoom:(NCRoom *)room withStyle:(UIUserInterfaceStyle)style withCompletionBlock:(GetAvatarForConversationWithImageCompletionBlock)block;

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -68,7 +68,6 @@ typedef void (^LeaveCallCompletionBlock)(NSError *error);
 
 typedef void (^GetChatMessagesCompletionBlock)(NSArray *messages, NSInteger lastKnownMessage, NSInteger lastCommonReadMessage, NSError *error, NSInteger statusCode);
 typedef void (^SendChatMessagesCompletionBlock)(NSError *error);
-typedef void (^GetMentionSuggestionsCompletionBlock)(NSArray *mentions, NSError *error);
 typedef void (^DeleteChatMessageCompletionBlock)(NSDictionary *messageDict, NSError *error, NSInteger statusCode);
 typedef void (^EditChatMessageCompletionBlock)(NSDictionary *messageDict, NSError *error, NSInteger statusCode);
 typedef void (^ClearChatHistoryCompletionBlock)(NSDictionary *messageDict, NSError *error, NSInteger statusCode);
@@ -222,7 +221,6 @@ extern NSInteger const kReceivedChatMessagesLimit;
 // Chat Controller
 - (NSURLSessionDataTask *)receiveChatMessagesOfRoom:(NSString *)token fromLastMessageId:(NSInteger)messageId history:(BOOL)history includeLastMessage:(BOOL)include timeout:(BOOL)timeout lastCommonReadMessage:(NSInteger)lastCommonReadMessage setReadMarker:(BOOL)setReadMarker markNotificationsAsRead:(BOOL)markNotificationsAsRead forAccount:(TalkAccount *)account withCompletionBlock:(GetChatMessagesCompletionBlock)block;
 - (NSURLSessionDataTask *)sendChatMessage:(NSString *)message toRoom:(NSString *)token displayName:(NSString *)displayName replyTo:(NSInteger)replyTo referenceId:(NSString *)referenceId silently:(BOOL)silently forAccount:(TalkAccount *)account withCompletionBlock:(SendChatMessagesCompletionBlock)block;
-- (NSURLSessionDataTask *)getMentionSuggestionsInRoom:(NSString *)token forString:(NSString *)string forAccount:(TalkAccount *)account withCompletionBlock:(GetMentionSuggestionsCompletionBlock)block;
 - (NSURLSessionDataTask *)deleteChatMessageInRoom:(NSString *)token withMessageId:(NSInteger)messageId forAccount:(TalkAccount *)account withCompletionBlock:(DeleteChatMessageCompletionBlock)block;
 - (NSURLSessionDataTask *)editChatMessageInRoom:(NSString *)token withMessageId:(NSInteger)messageId withMessage:(NSString *)message forAccount:(TalkAccount *)account withCompletionBlock:(EditChatMessageCompletionBlock)block;
 - (NSURLSessionDataTask *)shareRichObject:(NSDictionary *)richObject inRoom:(NSString *)token forAccount:(TalkAccount *)account withCompletionBlock:(SendChatMessagesCompletionBlock)block;

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -1438,36 +1438,6 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     return task;
 }
 
-- (NSURLSessionDataTask *)getMentionSuggestionsInRoom:(NSString *)token forString:(NSString *)string forAccount:(TalkAccount *)account withCompletionBlock:(GetMentionSuggestionsCompletionBlock)block
-{
-    NSString *encodedToken = [token stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
-    NSString *endpoint = [NSString stringWithFormat:@"chat/%@/mentions", encodedToken];
-    NSInteger chatAPIVersion = [self chatAPIVersionForAccount:account];
-    NSString *URLString = [self getRequestURLForEndpoint:endpoint withAPIVersion:chatAPIVersion forAccount:account];
-    ServerCapabilities *serverCapabilities = [[NCDatabaseManager sharedInstance] serverCapabilitiesForAccountId:account.accountId];
-    NSDictionary *parameters = @{@"limit" : @"20",
-                                 @"search" : string ? string : @"",
-                                 @"includeStatus" : @(serverCapabilities.userStatus)
-    };
-    
-    NCAPISessionManager *apiSessionManager = [_apiSessionManagers objectForKey:account.accountId];
-    NSURLSessionDataTask *task = [apiSessionManager GET:URLString parameters:parameters progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
-        NSArray *mentions = [[responseObject objectForKey:@"ocs"] objectForKey:@"data"];
-        NSMutableArray *suggestions = [[NSMutableArray alloc] initWithArray:mentions];;
-        if (block) {
-            block(suggestions, nil);
-        }
-    } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
-        NSInteger statusCode = [self getResponseStatusCode:task.response];
-        [self checkResponseStatusCode:statusCode forAccount:account];
-        if (block) {
-            block(nil, error);
-        }
-    }];
-    
-    return task;
-}
-
 - (NSURLSessionDataTask *)deleteChatMessageInRoom:(NSString *)token withMessageId:(NSInteger)messageId forAccount:(TalkAccount *)account withCompletionBlock:(DeleteChatMessageCompletionBlock)block
 {
     NSString *encodedToken = [token stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];

--- a/NextcloudTalk/NCChatTitleView.m
+++ b/NextcloudTalk/NCChatTitleView.m
@@ -101,7 +101,7 @@
 - (void)updateForRoom:(NCRoom *)room
 {
     // Set room image
-    [self.avatarimage setAvatarFor:room with:self.traitCollection.userInterfaceStyle];
+    [self.avatarimage setAvatarFor:room];
 
     NSString *subtitle = nil;
     

--- a/NextcloudTalk/NCDatabaseManager.h
+++ b/NextcloudTalk/NCDatabaseManager.h
@@ -123,6 +123,9 @@ extern NSString * const NCDatabaseManagerRoomCapabilitiesChangedNotification;
 - (void)updateTalkConfigurationHashForAccountId:(NSString *)accountId withHash:(NSString *)hash;
 - (void)updateLastModifiedSinceForAccountId:(NSString *)accountId with:(nonnull NSString *)modifiedSince;
 
+// Rooms
+- (NCRoom * _Nullable)roomWithToken:(NSString *)token forAccountId:(NSString *)accountId;
+
 // FederatedCapabilities
 - (FederatedCapabilities * __nullable)federatedCapabilitiesForAccountId:(NSString *)accountId remoteServer:(NSString *)remoteServer roomToken:(NSString *)roomToken;
 - (void)setFederatedCapabilities:(NSDictionary *)federatedCapabilitiesDict forAccountId:(NSString *)accountId remoteServer:(NSString *)remoteServer roomToken:(NSString *)roomToken withProxyHash:(NSString *)proxyHash;

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -353,6 +353,19 @@ NSString * const NCDatabaseManagerRoomCapabilitiesChangedNotification = @"NCData
     [bgTask stopBackgroundTask];
 }
 
+#pragma mark - Rooms
+
+- (NCRoom *)roomWithToken:(NSString *)token forAccountId:(NSString *)accountId
+{
+    NCRoom *unmanagedRoom = nil;
+    NSPredicate *query = [NSPredicate predicateWithFormat:@"token = %@ AND accountId = %@", token, accountId];
+    NCRoom *managedRoom = [NCRoom objectsWithPredicate:query].firstObject;
+    if (managedRoom) {
+        unmanagedRoom = [[NCRoom alloc] initWithValue:managedRoom];
+    }
+    return unmanagedRoom;
+}
+
 #pragma mark - Talk capabilities
 
 - (void)setTalkCapabilities:(NSDictionary *)capabilitiesDict onTalkCapabilitiesObject:(TalkCapabilities *)capabilities

--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -568,7 +568,7 @@ NSString * const NCNotificationActionFederationInvitationReject     = @"REJECT_F
                 // We replied to the message, so we can assume, we read it as well
                 [[NCDatabaseManager sharedInstance] decreaseUnreadBadgeNumberForAccountId:pushNotification.accountId];
                 [self updateAppIconBadgeNumber];
-                NCRoom *room = [[NCRoomsManager sharedInstance] roomWithToken:pushNotification.roomToken forAccountId:pushNotification.accountId];
+                NCRoom *room = [[NCDatabaseManager sharedInstance] roomWithToken:pushNotification.roomToken forAccountId:pushNotification.accountId];
                 if (room) {
                     [[NCIntentController sharedInstance] donateSendMessageIntentForRoom:room];
                 }

--- a/NextcloudTalk/NCRoomsManager.h
+++ b/NextcloudTalk/NCRoomsManager.h
@@ -57,7 +57,6 @@ typedef void (^SendOfflineMessagesCompletionBlock)(void);
 + (instancetype)sharedInstance;
 // Room
 - (NSArray *)roomsForAccountId:(NSString *)accountId witRealm:(RLMRealm *)realm;
-- (NCRoom *)roomWithToken:(NSString *)token forAccountId:(NSString *)accountId;
 - (void)updateRoomsAndChatsUpdatingUserStatus:(BOOL)updateStatus onlyLastModified:(BOOL)onlyLastModified withCompletionBlock:(UpdateRoomsAndChatsCompletionBlock)block;
 - (void)updateRoomsUpdatingUserStatus:(BOOL)updateStatus onlyLastModified:(BOOL)onlyLastModified;
 - (void)updateRoom:(NSString *)token withCompletionBlock:(GetRoomCompletionBlock)block;

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -379,17 +379,6 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
     return unmanagedRooms;
 }
 
-- (NCRoom *)roomWithToken:(NSString *)token forAccountId:(NSString *)accountId
-{
-    NCRoom *unmanagedRoom = nil;
-    NSPredicate *query = [NSPredicate predicateWithFormat:@"token = %@ AND accountId = %@", token, accountId];
-    NCRoom *managedRoom = [NCRoom objectsWithPredicate:query].firstObject;
-    if (managedRoom) {
-        unmanagedRoom = [[NCRoom alloc] initWithValue:managedRoom];
-    }
-    return unmanagedRoom;
-}
-
 - (void)resendOfflineMessagesWithCompletionBlock:(SendOfflineMessagesCompletionBlock)block
 {
     // Try to send offline messages for all rooms
@@ -434,7 +423,7 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
             return;
         }
 
-        NCRoom *room = [[NCRoomsManager sharedInstance] roomWithToken:offlineMessage.token forAccountId:offlineMessage.accountId];
+        NCRoom *room = [[NCDatabaseManager sharedInstance] roomWithToken:offlineMessage.token forAccountId:offlineMessage.accountId];
         NCChatController *chatController = [[NCChatController alloc] initForRoom:room];
 
         [chatController sendChatMessage:offlineMessage];
@@ -573,7 +562,7 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
                 [self updateRoomWithDict:roomDict withAccount:activeAccount withTimestamp:[[NSDate date] timeIntervalSince1970] withRealm:realm];
                 NSLog(@"Room updated");
             }];
-            NCRoom *updatedRoom = [self roomWithToken:token forAccountId:activeAccount.accountId];
+            NCRoom *updatedRoom = [[NCDatabaseManager sharedInstance] roomWithToken:token forAccountId:activeAccount.accountId];
             [userInfo setObject:updatedRoom forKey:@"room"];
         } else {
             [userInfo setObject:error forKey:@"error"];
@@ -728,7 +717,7 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
 - (void)startChatWithRoomToken:(NSString *)token
 {
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
-    NCRoom *room = [self roomWithToken:token forAccountId:activeAccount.accountId];
+    NCRoom *room = [[NCDatabaseManager sharedInstance] roomWithToken:token forAccountId:activeAccount.accountId];
     if (room) {
         [self startChatInRoom:room];
     } else {

--- a/NextcloudTalk/ObjectShareMessageTableViewCell.m
+++ b/NextcloudTalk/ObjectShareMessageTableViewCell.m
@@ -174,7 +174,7 @@
     
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
 
-    [self.avatarButton setUserAvatarFor:message.actorId with:self.traitCollection.userInterfaceStyle using:activeAccount];
+    [self.avatarButton setActorAvatarForId:message.actorId withType:message.actorType withDisplayName:message.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
     _avatarButton.menu = [super getDeferredUserMenuForMessage:message];
 
     if (message.sendingFailed) {

--- a/NextcloudTalk/ObjectShareMessageTableViewCell.m
+++ b/NextcloudTalk/ObjectShareMessageTableViewCell.m
@@ -174,7 +174,7 @@
     
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
 
-    [self.avatarButton setActorAvatarForId:message.actorId withType:message.actorType withDisplayName:message.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
+    [self.avatarButton setActorAvatarForMessage:message];
     _avatarButton.menu = [super getDeferredUserMenuForMessage:message];
 
     if (message.sendingFailed) {

--- a/NextcloudTalk/OpenConversationsTableViewController.swift
+++ b/NextcloudTalk/OpenConversationsTableViewController.swift
@@ -170,9 +170,9 @@ class OpenConversationsTableViewController: UITableViewController, UISearchResul
 
         cell.labelTitle.text = openConversation.displayName
         // Set group avatar as default avatar
-        cell.contactImage.setGroupAvatar(with: self.traitCollection.userInterfaceStyle)
+        cell.contactImage.setGroupAvatar()
         // Try to get room avatar even though at the moment (Talk 17) it is not exposed
-        cell.contactImage.setAvatar(for: openConversation, with: self.traitCollection.userInterfaceStyle)
+        cell.contactImage.setAvatar(for: openConversation)
 
         return cell
     }

--- a/NextcloudTalk/PollResultsDetailsViewController.swift
+++ b/NextcloudTalk/PollResultsDetailsViewController.swift
@@ -41,14 +41,19 @@ import UIKit
     var resultsDetails: [Int: [PollResultDetail]] = [:]
     var sortedOptions: [Int] = []
 
+    public var room: NCRoom
+
     required init?(coder aDecoder: NSCoder) {
         self.poll = NCPoll()
+        self.room = NCRoom()
+        
         super.init(coder: aDecoder)
         self.setupPollResultsDetailsView()
     }
 
-    init(poll: NCPoll) {
+    init(poll: NCPoll, room: NCRoom) {
         self.poll = poll
+        self.room = room
 
         super.init(style: .insetGrouped)
         self.setupPollResultsDetailsView()
@@ -130,7 +135,7 @@ import UIKit
         cell.titleLabel.text = detail.actorDisplayName
 
         // Actor avatar
-        cell.avatarImageView.setActorAvatar(forId: detail.actorId, withType: detail.actorType, withDisplayName: detail.actorDisplayName, withStyle: self.traitCollection.userInterfaceStyle)
+        cell.avatarImageView.setActorAvatar(forId: detail.actorId, withType: detail.actorType, withDisplayName: detail.actorDisplayName, withRoomToken: self.room.token)
 
         return cell
     }

--- a/NextcloudTalk/PollResultsDetailsViewController.swift
+++ b/NextcloudTalk/PollResultsDetailsViewController.swift
@@ -130,14 +130,7 @@ import UIKit
         cell.titleLabel.text = detail.actorDisplayName
 
         // Actor avatar
-        if detail.actorType == "users" {
-            cell.avatarImageView.setUserAvatar(for: detail.actorId, with: self.traitCollection.userInterfaceStyle)
-        } else {
-            let color = UIColor(red: 0.73, green: 0.73, blue: 0.73, alpha: 1.0) /*#b9b9b9*/
-            let image = NCUtils.getImage(withString: "?", withBackgroundColor: color, withBounds: cell.avatarImageView.bounds, isCircular: true)
-            cell.avatarImageView.image = image
-            cell.avatarImageView.contentMode = .scaleToFill
-        }
+        cell.avatarImageView.setActorAvatar(forId: detail.actorId, withType: detail.actorType, withDisplayName: detail.actorDisplayName, withStyle: self.traitCollection.userInterfaceStyle)
 
         return cell
     }

--- a/NextcloudTalk/PollVotingView.swift
+++ b/NextcloudTalk/PollVotingView.swift
@@ -307,11 +307,11 @@ import UIKit
             return
         }
 
-        guard let poll = poll else {return}
+        guard let poll, let room else {return}
 
         if showPollResults {
             if poll.details.isEmpty {return}
-            let pollResultsDetailsVC = PollResultsDetailsViewController(poll: poll)
+            let pollResultsDetailsVC = PollResultsDetailsViewController(poll: poll, room: room)
             self.navigationController?.pushViewController(pollResultsDetailsVC, animated: true)
         }
 

--- a/NextcloudTalk/ReactionsSummaryView.swift
+++ b/NextcloudTalk/ReactionsSummaryView.swift
@@ -27,6 +27,8 @@ import UIKit
     var sortedReactions: [String] = []
     var reactionsBackgroundView: PlaceholderView = PlaceholderView(for: .grouped)
 
+    public var room: NCRoom?
+
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         self.setupReactionsSummaryView()
@@ -112,7 +114,7 @@ import UIKit
         let actor = self.reactions[reaction]?[indexPath.row]
 
         // Actor name
-        var actorDisplayName = actor?["actorDisplayName"] as? String ?? ""
+        let actorDisplayName = actor?["actorDisplayName"] as? String ?? ""
 
         cell.titleLabel.text = actorDisplayName.isEmpty ? NSLocalizedString("Guest", comment: "") : actorDisplayName
 
@@ -120,7 +122,7 @@ import UIKit
         let actorId = actor?["actorId"] as? String ?? ""
         let actorType = actor?["actorType"] as? String ?? ""
 
-        cell.avatarImageView.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withStyle: self.traitCollection.userInterfaceStyle)
+        cell.avatarImageView.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: self.room?.token)
 
         return cell
     }

--- a/NextcloudTalk/ReactionsSummaryView.swift
+++ b/NextcloudTalk/ReactionsSummaryView.swift
@@ -112,20 +112,15 @@ import UIKit
         let actor = self.reactions[reaction]?[indexPath.row]
 
         // Actor name
-        let actorDisplayName = actor?["actorDisplayName"] as? String
-        cell.titleLabel.text = actorDisplayName
+        var actorDisplayName = actor?["actorDisplayName"] as? String ?? ""
+
+        cell.titleLabel.text = actorDisplayName.isEmpty ? NSLocalizedString("Guest", comment: "") : actorDisplayName
 
         // Actor avatar
-        let actorId = actor?["actorId"] as? String
-        let actorType = actor?["actorType"] as? String
-        if let actorId = actorId, actorType == "users" {
-            cell.avatarImageView.setUserAvatar(for: actorId, with: self.traitCollection.userInterfaceStyle)
-        } else {
-            let color = UIColor(red: 0.73, green: 0.73, blue: 0.73, alpha: 1.0) /*#b9b9b9*/
-            let image = NCUtils.getImage(withString: "?", withBackgroundColor: color, withBounds: cell.avatarImageView.bounds, isCircular: true)
-            cell.avatarImageView.image = image
-            cell.avatarImageView.contentMode = .scaleToFill
-        }
+        let actorId = actor?["actorId"] as? String ?? ""
+        let actorType = actor?["actorType"] as? String ?? ""
+
+        cell.avatarImageView.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withStyle: self.traitCollection.userInterfaceStyle)
 
         return cell
     }

--- a/NextcloudTalk/ReferenceTalkView.swift
+++ b/NextcloudTalk/ReferenceTalkView.swift
@@ -93,7 +93,7 @@ import SwiftyAttributes
             let room = NCDatabaseManager.sharedInstance().room(withToken: roomToken, forAccountId: activeAccount.accountId)
 
             if let room = room {
-                self.referenceTypeIcon.setAvatar(for: room, with: self.traitCollection.userInterfaceStyle)
+                self.referenceTypeIcon.setAvatar(for: room)
                 self.referenceTypeIcon.layer.cornerRadius = self.referenceTypeIcon.frame.height / 2
             } else {
                 self.referenceTypeIcon.layer.cornerRadius = 0

--- a/NextcloudTalk/ReferenceTalkView.swift
+++ b/NextcloudTalk/ReferenceTalkView.swift
@@ -90,7 +90,7 @@ import SwiftyAttributes
             self.roomToken = roomToken
 
             let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-            let room = NCRoomsManager.sharedInstance().room(withToken: roomToken, forAccountId: activeAccount.accountId)
+            let room = NCDatabaseManager.sharedInstance().room(withToken: roomToken, forAccountId: activeAccount.accountId)
 
             if let room = room {
                 self.referenceTypeIcon.setAvatar(for: room, with: self.traitCollection.userInterfaceStyle)

--- a/NextcloudTalk/ReplyMessageView.m
+++ b/NextcloudTalk/ReplyMessageView.m
@@ -173,7 +173,7 @@
     self.quotedMessageView.actorLabel.text = ([message.actorDisplayName isEqualToString:@""]) ? NSLocalizedString(@"Guest", nil) : message.actorDisplayName;
     self.quotedMessageView.messageLabel.text = message.parsedMarkdownForChat.string;
     self.quotedMessageView.highlighted = [message isMessageFromUser:userId];
-    [self.quotedMessageView.avatarView setUserAvatarFor:message.actorId with:self.traitCollection.userInterfaceStyle];
+    [self.quotedMessageView.avatarView setActorAvatarForId:message.actorId withType:message.actorType withDisplayName:message.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
     [self.cancelButton setHidden:NO];
 
     // Reset button size to 44 in case it was hidden before

--- a/NextcloudTalk/ReplyMessageView.m
+++ b/NextcloudTalk/ReplyMessageView.m
@@ -173,7 +173,7 @@
     self.quotedMessageView.actorLabel.text = ([message.actorDisplayName isEqualToString:@""]) ? NSLocalizedString(@"Guest", nil) : message.actorDisplayName;
     self.quotedMessageView.messageLabel.text = message.parsedMarkdownForChat.string;
     self.quotedMessageView.highlighted = [message isMessageFromUser:userId];
-    [self.quotedMessageView.avatarView setActorAvatarForId:message.actorId withType:message.actorType withDisplayName:message.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
+    [self.quotedMessageView.avatarView setActorAvatarForMessage:message];
     [self.cancelButton setHidden:NO];
 
     // Reset button size to 44 in case it was hidden before

--- a/NextcloudTalk/ResultMultiSelectionTableViewController.m
+++ b/NextcloudTalk/ResultMultiSelectionTableViewController.m
@@ -120,13 +120,7 @@
     
     cell.labelTitle.text = contact.name;
     
-    if ([contact.source isEqualToString:kParticipantTypeUser]) {
-        [cell.contactImage setUserAvatarFor:contact.userId with:self.traitCollection.userInterfaceStyle];
-    } else if ([contact.source isEqualToString:kParticipantTypeEmail]) {
-        [cell.contactImage setImage:[UIImage imageNamed:@"mail-avatar"]];
-    } else {
-        [cell.contactImage setImage:[UIImage imageNamed:@"group-avatar"]];
-    }
+    [cell.contactImage setActorAvatarForId:contact.userId withType:contact.source withDisplayName:contact.name withStyle:self.traitCollection.userInterfaceStyle];
     
     UIImage *selectionImage = [UIImage systemImageNamed:@"circle"];
     UIColor *selectionImageColor = [UIColor tertiaryLabelColor];

--- a/NextcloudTalk/ResultMultiSelectionTableViewController.m
+++ b/NextcloudTalk/ResultMultiSelectionTableViewController.m
@@ -120,8 +120,8 @@
     
     cell.labelTitle.text = contact.name;
     
-    [cell.contactImage setActorAvatarForId:contact.userId withType:contact.source withDisplayName:contact.name withStyle:self.traitCollection.userInterfaceStyle];
-    
+    [cell.contactImage setActorAvatarForId:contact.userId withType:contact.source withDisplayName:contact.name withRoomToken:nil];
+
     UIImage *selectionImage = [UIImage systemImageNamed:@"circle"];
     UIColor *selectionImageColor = [UIColor tertiaryLabelColor];
     for (NCUser *user in _selectedParticipants) {

--- a/NextcloudTalk/RoomAvatarInfoTableViewController.swift
+++ b/NextcloudTalk/RoomAvatarInfoTableViewController.swift
@@ -97,7 +97,7 @@ enum RoomAvatarInfoSection: Int {
     }
 
     func updateHeaderView() {
-        self.headerView.avatarImageView.setAvatar(for: self.room, with: self.traitCollection.userInterfaceStyle)
+        self.headerView.avatarImageView.setAvatar(for: self.room)
 
         self.headerView.editView.isHidden = !NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityConversationAvatars, forAccountId: self.room.accountId)
         self.headerView.trashButton.isHidden = !self.room.isCustomAvatar

--- a/NextcloudTalk/RoomAvatarInfoTableViewController.swift
+++ b/NextcloudTalk/RoomAvatarInfoTableViewController.swift
@@ -176,7 +176,9 @@ enum RoomAvatarInfoSection: Int {
 
     func updateRoomAndRemoveModifyingView() {
         NCRoomsManager.sharedInstance().updateRoom(self.room.token) { _, _ in
-            self.room = NCRoomsManager.sharedInstance().room(withToken: self.room.token, forAccountId: self.room.accountId)
+            guard let room = NCDatabaseManager.sharedInstance().room(withToken: self.room.token, forAccountId: self.room.accountId) else { return }
+
+            self.room = room
             self.currentDescription = self.room.roomDescription
 
             self.updateHeaderView()

--- a/NextcloudTalk/RoomCreationTableViewController.swift
+++ b/NextcloudTalk/RoomCreationTableViewController.swift
@@ -139,7 +139,7 @@ enum RoomVisibilityOption: Int {
         } else if self.selectedEmojiImage != nil {
             self.headerView.avatarImageView.image = self.selectedEmojiImage
         } else {
-            self.headerView.avatarImageView.setGroupAvatar(with: self.traitCollection.userInterfaceStyle)
+            self.headerView.avatarImageView.setGroupAvatar()
         }
 
         self.headerView.trashButton.isHidden = self.selectedAvatarImage == nil && self.selectedEmojiImage == nil

--- a/NextcloudTalk/RoomCreationTableViewController.swift
+++ b/NextcloudTalk/RoomCreationTableViewController.swift
@@ -476,7 +476,7 @@ enum RoomVisibilityOption: Int {
                 participantCell.labelTitle.text = participant.name
 
                 let participantType = participant.source as String
-                participantCell.contactImage.setActorAvatar(forId: participant.userId, withType: participantType, withDisplayName: participant.name, withStyle: self.traitCollection.userInterfaceStyle)
+                participantCell.contactImage.setActorAvatar(forId: participant.userId, withType: participantType, withDisplayName: participant.name, withRoomToken: nil)
 
                 return participantCell
             }

--- a/NextcloudTalk/RoomCreationTableViewController.swift
+++ b/NextcloudTalk/RoomCreationTableViewController.swift
@@ -476,13 +476,7 @@ enum RoomVisibilityOption: Int {
                 participantCell.labelTitle.text = participant.name
 
                 let participantType = participant.source as String
-                if participantType == kParticipantTypeUser {
-                    participantCell.contactImage.setUserAvatar(for: participant.userId, with: self.traitCollection.userInterfaceStyle, using: self.account)
-                } else if participantType == kParticipantTypeEmail {
-                    participantCell.contactImage.setMailAvatar(with: self.traitCollection.userInterfaceStyle)
-                } else {
-                    participantCell.contactImage.setGroupAvatar(with: self.traitCollection.userInterfaceStyle)
-                }
+                participantCell.contactImage.setActorAvatar(forId: participant.userId, withType: participantType, withDisplayName: participant.name, withStyle: self.traitCollection.userInterfaceStyle)
 
                 return participantCell
             }

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -1694,7 +1694,7 @@ typedef enum FileAction {
                 cell.roomNameTextField.text = _room.displayName;
             }
 
-            [cell.roomImage setAvatarFor:_room with:self.traitCollection.userInterfaceStyle];
+            [cell.roomImage setAvatarFor:_room];
 
             if (_room.hasCall) {
                 [cell.favoriteImage setTintColor:[UIColor systemRedColor]];

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -2145,7 +2145,7 @@ typedef enum FileAction {
             cell.labelTitle.text = [self detailedNameForParticipant:participant];
             
             // Avatar
-            [cell.contactImage setActorAvatarForId:participant.actorId withType:participant.actorType withDisplayName:participant.displayName withStyle:self.traitCollection.userInterfaceStyle];
+            [cell.contactImage setActorAvatarForId:participant.actorId withType:participant.actorType withDisplayName:participant.displayName withRoomToken:self.room.token];
 
             // Online status
             if (participant.isOffline) {

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -2145,20 +2145,8 @@ typedef enum FileAction {
             cell.labelTitle.text = [self detailedNameForParticipant:participant];
             
             // Avatar
-            if ([participant.actorType isEqualToString:NCAttendeeTypeEmail]) {
-                [cell.contactImage setImage:[UIImage imageNamed:@"mail-avatar"]];
-            } else if (participant.isGroup || participant.isCircle) {
-                [cell.contactImage setImage:[UIImage imageNamed:@"group-avatar"]];
-            } else if (participant.isGuest) {
-                UIColor *guestAvatarColor = [UIColor colorWithRed:0.84 green:0.84 blue:0.84 alpha:1.0]; /*#d5d5d5*/
-                NSString *avatarName = ([participant.displayName isEqualToString:@""]) ? @"?" : participant.displayName;
+            [cell.contactImage setActorAvatarForId:participant.actorId withType:participant.actorType withDisplayName:participant.displayName withStyle:self.traitCollection.userInterfaceStyle];
 
-                UIImage *image = [NCUtils getImageWithString:avatarName withBackgroundColor:guestAvatarColor withBounds:cell.contactImage.bounds isCircular:YES];
-                [cell.contactImage setImage:image];
-            } else {
-                [cell.contactImage setUserAvatarFor:participant.participantId with:self.traitCollection.userInterfaceStyle];
-            }
-            
             // Online status
             if (participant.isOffline) {
                 cell.contactImage.alpha = 0.5;

--- a/NextcloudTalk/RoomSearchTableViewController.m
+++ b/NextcloudTalk/RoomSearchTableViewController.m
@@ -207,18 +207,11 @@ typedef enum RoomSearchSection {
     NSURL *thumbnailURL = [[NSURL alloc] initWithString:messageEntry.thumbnailURL];
     NSString *actorId = [messageEntry.attributes objectForKey:@"actorId"];
     NSString *actorType = [messageEntry.attributes objectForKey:@"actorType"];
-    if ([actorType isEqualToString:@"users"] && actorId) {
-        [cell.roomImage setUserAvatarFor:actorId with:self.traitCollection.userInterfaceStyle];
-    } else if ([actorType isEqualToString:@"guests"]) {
-        UIImage *image = [NCUtils getImageWithString:@"?" withBackgroundColor:[UIColor clearColor] withBounds:cell.roomImage.bounds isCircular:YES];
-        [cell.roomImage setImage:image];
-        cell.roomImage.contentMode = UIViewContentModeScaleAspectFit;
-    } else if (thumbnailURL) {
+    if (thumbnailURL && thumbnailURL.absoluteString.length > 0) {
         [cell.roomImage setImageWithURL:thumbnailURL placeholderImage:nil];
         cell.roomImage.contentMode = UIViewContentModeScaleToFill;
     } else {
-        [cell.roomImage setImage:[UIImage imageNamed:@"navigationLogo"]];
-        cell.roomImage.contentMode = UIViewContentModeCenter;
+        [cell.roomImage setActorAvatarForId:actorId withType:actorType withDisplayName:@"" withStyle:self.traitCollection.userInterfaceStyle];
     }
     
     // Clear possible content not removed by cell reuse
@@ -259,7 +252,7 @@ typedef enum RoomSearchSection {
 
     cell.titleLabel.text = user.name;
     cell.titleOnly = YES;
-    [cell.roomImage setUserAvatarFor:user.userId with:self.traitCollection.userInterfaceStyle];
+    [cell.roomImage setActorAvatarForId:user.userId withType:user.source withDisplayName:user.name withStyle:self.traitCollection.userInterfaceStyle];
 
     return cell;
 }

--- a/NextcloudTalk/RoomSearchTableViewController.m
+++ b/NextcloudTalk/RoomSearchTableViewController.m
@@ -211,7 +211,7 @@ typedef enum RoomSearchSection {
         [cell.roomImage setImageWithURL:thumbnailURL placeholderImage:nil];
         cell.roomImage.contentMode = UIViewContentModeScaleToFill;
     } else {
-        [cell.roomImage setActorAvatarForId:actorId withType:actorType withDisplayName:@"" withStyle:self.traitCollection.userInterfaceStyle];
+        [cell.roomImage setActorAvatarForId:actorId withType:actorType withDisplayName:@"" withRoomToken:nil];
     }
     
     // Clear possible content not removed by cell reuse
@@ -252,7 +252,7 @@ typedef enum RoomSearchSection {
 
     cell.titleLabel.text = user.name;
     cell.titleOnly = YES;
-    [cell.roomImage setActorAvatarForId:user.userId withType:user.source withDisplayName:user.name withStyle:self.traitCollection.userInterfaceStyle];
+    [cell.roomImage setActorAvatarForId:user.userId withType:user.source withDisplayName:user.name withRoomToken:nil];
 
     return cell;
 }

--- a/NextcloudTalk/RoomSearchTableViewController.m
+++ b/NextcloudTalk/RoomSearchTableViewController.m
@@ -345,7 +345,7 @@ typedef enum RoomSearchSection {
         [cell setUnreadMessages:room.unreadMessages mentioned:mentioned groupMentioned:NO];
     }
 
-    [cell.roomImage setAvatarFor:room with:self.traitCollection.userInterfaceStyle];
+    [cell.roomImage setAvatarFor:room];
 
     // Set favorite or call image
     if (room.hasCall) {

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1306,7 +1306,7 @@ typedef enum RoomsSections {
     if (roomToken && messageIdString) {
         TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
         NSInteger messageId = [messageIdString intValue];
-        NCRoom *room = [[NCRoomsManager sharedInstance] roomWithToken:roomToken forAccountId:activeAccount.accountId];
+        NCRoom *room = [[NCDatabaseManager sharedInstance] roomWithToken:roomToken forAccountId:activeAccount.accountId];
         if (room) {
             [self presentContextChatInRoom:room forMessageId:messageId];
         } else {

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1499,7 +1499,7 @@ typedef enum RoomsSections {
         cell.subtitleLabel.text = pendingInvitationsString;
         cell.dateLabel.text = @"";
 
-        [cell.roomImage setMailAvatarWith:self.traitCollection.userInterfaceStyle];
+        [cell.roomImage setMailAvatar];
 
         return cell;
     }
@@ -1529,7 +1529,7 @@ typedef enum RoomsSections {
         [cell setUnreadMessages:room.unreadMessages mentioned:mentioned groupMentioned:NO];
     }
 
-    [cell.roomImage setAvatarFor:room with:self.traitCollection.userInterfaceStyle];
+    [cell.roomImage setAvatarFor:room];
 
     // Set favorite or call image
     if (room.hasCall) {

--- a/NextcloudTalk/SearchTableViewController.m
+++ b/NextcloudTalk/SearchTableViewController.m
@@ -119,13 +119,7 @@
     
     cell.labelTitle.text = contact.name;
     
-    if ([contact.source isEqualToString:kParticipantTypeUser]) {
-        [cell.contactImage setUserAvatarFor:contact.userId with:self.traitCollection.userInterfaceStyle];
-    } else if ([contact.source isEqualToString:kParticipantTypeEmail]) {
-        [cell.contactImage setImage:[UIImage imageNamed:@"mail-avatar"]];
-    } else {
-        [cell.contactImage setImage:[UIImage imageNamed:@"group-avatar"]];
-    }
+    [cell.contactImage setActorAvatarForId:contact.userId withType:contact.source withDisplayName:contact.name withStyle:self.traitCollection.userInterfaceStyle];
     
     return cell;
 }

--- a/NextcloudTalk/SearchTableViewController.m
+++ b/NextcloudTalk/SearchTableViewController.m
@@ -119,7 +119,7 @@
     
     cell.labelTitle.text = contact.name;
     
-    [cell.contactImage setActorAvatarForId:contact.userId withType:contact.source withDisplayName:contact.name withStyle:self.traitCollection.userInterfaceStyle];
+    [cell.contactImage setActorAvatarForId:contact.userId withType:contact.source withDisplayName:contact.name withRoomToken:nil];
     
     return cell;
 }

--- a/NextcloudTalk/VoiceMessageTableViewCell.m
+++ b/NextcloudTalk/VoiceMessageTableViewCell.m
@@ -199,7 +199,7 @@
     
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
 
-    [self.avatarButton setUserAvatarFor:message.actorId with:self.traitCollection.userInterfaceStyle using:activeAccount];
+    [self.avatarButton setActorAvatarForId:message.actorId withType:message.actorType withDisplayName:message.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
     _avatarButton.menu = [super getDeferredUserMenuForMessage:message];
     
     if (message.sendingFailed) {

--- a/NextcloudTalk/VoiceMessageTableViewCell.m
+++ b/NextcloudTalk/VoiceMessageTableViewCell.m
@@ -199,7 +199,7 @@
     
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
 
-    [self.avatarButton setActorAvatarForId:message.actorId withType:message.actorType withDisplayName:message.actorDisplayName withStyle:self.traitCollection.userInterfaceStyle];
+    [self.avatarButton setActorAvatarForMessage:message];
     _avatarButton.menu = [super getDeferredUserMenuForMessage:message];
     
     if (message.sendingFailed) {

--- a/NextcloudTalkTests/Unit/UnitMentionSuggestionTest.swift
+++ b/NextcloudTalkTests/Unit/UnitMentionSuggestionTest.swift
@@ -1,0 +1,98 @@
+//
+// Copyright (c) 2024 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import NextcloudTalk
+
+final class UnitMentionSuggestionTest: XCTestCase {
+
+    func testLocalMention() throws {
+        let data = [
+            "id": "my-id",
+            "label": "My Label",
+            "source": "users"
+        ]
+
+        let suggestion = MentionSuggestion(dictionary: data)
+
+        XCTAssertEqual(suggestion.id, "my-id")
+        XCTAssertEqual(suggestion.label, "My Label")
+        XCTAssertEqual(suggestion.source, "users")
+        XCTAssertEqual(suggestion.getIdForChat(), "my-id")
+        XCTAssertEqual(suggestion.getIdForAvatar(), "my-id")
+    }
+
+    func testLocalGuestMention() throws {
+        let data = [
+            "id": "guest/guest-id"
+        ]
+
+        let suggestion = MentionSuggestion(dictionary: data)
+
+        XCTAssertEqual(suggestion.id, "guest/guest-id")
+        XCTAssertEqual(suggestion.getIdForChat(), "\"guest/guest-id\"")
+        XCTAssertEqual(suggestion.getIdForAvatar(), "guest/guest-id")
+    }
+
+    func testLocalWhitespaceMention() throws {
+        let data = [
+            "id": "my id"
+        ]
+
+        let suggestion = MentionSuggestion(dictionary: data)
+
+        XCTAssertEqual(suggestion.id, "my id")
+        XCTAssertEqual(suggestion.getIdForChat(), "\"my id\"")
+        XCTAssertEqual(suggestion.getIdForAvatar(), "my id")
+    }
+
+    func testMentionId() throws {
+        let data = [
+            "id": "my-id",
+            "mentionId": "mention-id"
+        ]
+
+        let suggestion = MentionSuggestion(dictionary: data)
+
+        XCTAssertEqual(suggestion.id, "my-id")
+        XCTAssertEqual(suggestion.mentionId, "mention-id")
+        XCTAssertEqual(suggestion.getIdForChat(), "mention-id")
+        XCTAssertEqual(suggestion.getIdForAvatar(), "my-id")
+    }
+
+    func testMessageParameter() throws {
+        let data = [
+            "id": "my-id",
+            "mentionId": "mention-id",
+            "label": "My Label",
+            "source": "users"
+        ]
+
+        let suggestion = MentionSuggestion(dictionary: data)
+        let parameter = suggestion.asMessageParameter()
+
+        XCTAssertEqual(parameter.parameterId, "my-id")
+        XCTAssertEqual(parameter.name, "My Label")
+        XCTAssertEqual(parameter.mentionDisplayName, "@My Label")
+        XCTAssertEqual(parameter.mentionId, "@mention-id")
+        XCTAssertEqual(parameter.type, "user")
+    }
+}

--- a/NotificationServiceExtension/NotificationService.m
+++ b/NotificationServiceExtension/NotificationService.m
@@ -282,7 +282,7 @@ typedef void (^CreateConversationNotificationCompletionBlock)(void);
         return;
     }
 
-    NCRoom *room = [self roomWithToken:pushNotification.roomToken forAccountId:pushNotification.accountId];
+    NCRoom *room = [[NCDatabaseManager sharedInstance] roomWithToken:pushNotification.roomToken forAccountId:pushNotification.accountId];
 
     if (room) {
         [[NCIntentController sharedInstance] getInteractionForRoom:room withTitle:self.bestAttemptContent.title withCompletionBlock:^(INSendMessageIntent *sendMessageIntent) {
@@ -336,19 +336,6 @@ typedef void (^CreateConversationNotificationCompletionBlock)(void);
     }
 
     return nil;
-}
-
-- (NCRoom *)roomWithToken:(NSString *)token forAccountId:(NSString *)accountId
-{
-    NCRoom *unmanagedRoom = nil;
-    NSPredicate *query = [NSPredicate predicateWithFormat:@"token = %@ AND accountId = %@", token, accountId];
-    NCRoom *managedRoom = [NCRoom objectsWithPredicate:query].firstObject;
-
-    if (managedRoom) {
-        unmanagedRoom = [[NCRoom alloc] initWithValue:managedRoom];
-    }
-
-    return unmanagedRoom;
 }
 
 - (void)serviceExtensionTimeWillExpire {

--- a/ShareExtension/ShareViewController.m
+++ b/ShareExtension/ShareViewController.m
@@ -567,7 +567,7 @@
     
     cell.titleLabel.text = room.displayName;
 
-    [cell.avatarImageView setAvatarFor:room with:self.traitCollection.userInterfaceStyle];
+    [cell.avatarImageView setAvatarFor:room];
     
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
         


### PR DESCRIPTION
* Unify access to avatars to use the AvatarManager and not decide in each component how an avatar is displayed (e.g. guests)
* Add support for proxied federated avatars

Fixes https://github.com/nextcloud/talk-ios/issues/1472 as a side effect