### PR TITLE
Fix prefetch crash with unread marker

### DIFF
--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -2523,6 +2523,10 @@ import QuickLook
             guard let message = self.message(for: indexPath) else { continue }
 
             DispatchQueue.global(qos: .userInitiated).async {
+                guard message.messageId != kUnreadMessagesSeparatorIdentifier, 
+                      message.messageId != kChatBlockSeparatorIdentifier
+                else { return }
+
                 if message.containsURL() {
                     message.getReferenceData()
                 }

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -819,6 +819,10 @@ NSString * const kSharedItemTypeRecording   = @"recording";
 
 - (BOOL)containsURL
 {
+    if (!self.message) {
+        return NO;
+    }
+    
     if (_urlDetectionDone) {
         return ([_urlDetected length] != 0);
     }

--- a/NextcloudTalkTests/Unit/UnitChatCellTest.swift
+++ b/NextcloudTalkTests/Unit/UnitChatCellTest.swift
@@ -244,4 +244,15 @@ final class UnitChatCellTest: TestBaseRealm {
         XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 135.0)
     }
 
+    func testUnreadMessageSeparatorUrlCheck() throws {
+        let message = NCChatMessage()
+        message.messageId = kUnreadMessagesSeparatorIdentifier
+
+        updateCapabilities { cap in
+            cap.referenceApiSupported = true
+        }
+
+        XCTAssertFalse(message.containsURL())
+    }
+
 }


### PR DESCRIPTION
Cherry-picked from https://github.com/nextcloud/talk-ios/pull/1579 and added an explicit check in the prefetch method.