### PR TITLE
Show federated avatars when creating a new room and adding a federated participant

### DIFF
--- a/NextcloudTalk/AvatarManager.swift
+++ b/NextcloudTalk/AvatarManager.swift
@@ -96,7 +96,7 @@ import SDWebImage
             } else if actorType == "users" {
                 return getUserAvatar(forId: actorId, withStyle: style, usingAccount: account, completionBlock: completionBlock)
             } else if actorType == "federated_users" {
-                return getFederatedUserAvatar(forId: actorId, withRoomToken: roomToken ?? "", withStyle: style, usingAccount: account, completionBlock: completionBlock)
+                return getFederatedUserAvatar(forId: actorId, withRoomToken: roomToken, withStyle: style, usingAccount: account, completionBlock: completionBlock)
             }
         }
 
@@ -150,16 +150,10 @@ import SDWebImage
         }
     }
 
-    private func getFederatedUserAvatar(forId actorId: String, withRoomToken roomToken: String, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount?, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
+    private func getFederatedUserAvatar(forId actorId: String, withRoomToken roomToken: String?, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount?, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
         let account = account ?? NCDatabaseManager.sharedInstance().activeAccount()
 
-        guard let room = NCDatabaseManager.sharedInstance().room(withToken: roomToken, forAccountId: account.accountId)
-        else {
-            completionBlock(nil)
-            return nil
-        }
-
-        return NCAPIController.sharedInstance().getFederatedUserAvatar(forUser: actorId, in: room, with: style) { image, _ in
+        return NCAPIController.sharedInstance().getFederatedUserAvatar(forUser: actorId, inRoom: roomToken, using: account, with: style) { image, _ in
             if image != nil {
                 completionBlock(image)
             } else {

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -266,7 +266,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 
 // User avatars
 - (SDWebImageCombinedOperation *)getUserAvatarForUser:(NSString *)userId usingAccount:(TalkAccount *)account withStyle:(UIUserInterfaceStyle)style withCompletionBlock:(GetUserAvatarImageForUserCompletionBlock)block;
-- (SDWebImageCombinedOperation *)getFederatedUserAvatarForUser:(NSString *)userId inRoom:(NCRoom *)room withStyle:(UIUserInterfaceStyle)style withCompletionBlock:(GetFederatedUserAvatarImageForUserCompletionBlock)block;
+- (SDWebImageCombinedOperation *)getFederatedUserAvatarForUser:(NSString *)userId inRoom:(NSString *)token usingAccount:(TalkAccount *)account withStyle:(UIUserInterfaceStyle)style withCompletionBlock:(GetFederatedUserAvatarImageForUserCompletionBlock)block;
 
 // Conversation avatars
 - (SDWebImageCombinedOperation *)getAvatarForRoom:(NCRoom *)room withStyle:(UIUserInterfaceStyle)style withCompletionBlock:(GetAvatarForConversationWithImageCompletionBlock)block;

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -2382,10 +2382,12 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     }];
 }
 
-- (SDWebImageCombinedOperation *)getFederatedUserAvatarForUser:(NSString *)userId inRoom:(NCRoom *)room withStyle:(UIUserInterfaceStyle)style withCompletionBlock:(GetFederatedUserAvatarImageForUserCompletionBlock)block
+- (SDWebImageCombinedOperation *)getFederatedUserAvatarForUser:(NSString *)userId inRoom:(NSString *)token usingAccount:(TalkAccount *)account withStyle:(UIUserInterfaceStyle)style withCompletionBlock:(GetFederatedUserAvatarImageForUserCompletionBlock)block
 {
-    TalkAccount *account = [[NCDatabaseManager sharedInstance] talkAccountForAccountId:room.accountId];
-    NSString *encodedToken = [room.token stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+    NSString *encodedToken = @"new";
+    if (token.length > 0) {
+        encodedToken = [token stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+    }
     NSString *endpoint = [NSString stringWithFormat:@"proxy/%@/user-avatar/512", encodedToken];
 
     if (style == UIUserInterfaceStyleDark) {


### PR DESCRIPTION
Now when creating a new room and adding federated participants, its avatars will be shown.