### PR TITLE
Remove shared items section for federated rooms

### DIFF
--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -295,7 +295,8 @@ typedef enum FileAction {
         [sections addObject:[NSNumber numberWithInt:kRoomInfoSectionFile]];
     }
     // Shared items section
-    if ([[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityRichObjectListMedia]) {
+    if ([[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityRichObjectListMedia] &&
+        ![self.room isFederated]) {
         [sections addObject:[NSNumber numberWithInt:kRoomInfoSectionSharedItems]];
     }
     // Notifications section


### PR DESCRIPTION
Shared items endpoint is not proxied yet, so removing the section since it doesn't return anything.
https://nextcloud-talk.readthedocs.io/en/latest/chat/#list-items-of-type-shared-in-a-chat