### PR TITLE
Split building and testing into separate steps

### DIFF
--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -23,26 +23,14 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  WORKSPACE: NextcloudTalk.xcworkspace
+  DESTINATION: platform=iOS Simulator,name=iPhone 15,OS=17.2
+  SCHEME: NextcloudTalk
+
 jobs:
-  build-and-test:
-    name: Build and Test
-    runs-on: macos-14
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # Test with stable23 as well to find regressions in older versions
-        configs: [
-          { talkbranch: 'stable23', serverbranch: 'stable23', phpversion: '8.0' },
-          { talkbranch: 'stable27', serverbranch: 'stable27', phpversion: '8.2' },
-          { talkbranch: 'stable28', serverbranch: 'stable28', phpversion: '8.2' },
-          { talkbranch: 'main', serverbranch: 'master', phpversion: '8.2' }
-        ]
-
-    env:
-      WORKSPACE: NextcloudTalk.xcworkspace
-      DESTINATION: platform=iOS Simulator,name=iPhone 15,OS=17.2
-      SCHEME: NextcloudTalk
+  build:
+    name: Build
 
     steps:
     - name: Checkout app
@@ -56,6 +44,49 @@ jobs:
         key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-pods-
+
+    - name: Set up dependencies talk-ios
+      run: |
+        pod install    
+
+    - name: Build & Test NextcloudTalk iOS
+      run: |
+        set -o pipefail && \
+        xcodebuild build-for-testing \
+        -workspace "${{ env.WORKSPACE }}" \
+        -scheme "${{ env.SCHEME }}" \
+        -destination "${{ env.DESTINATION }}" \
+        -derivedDataPath "DerivedData" \
+        | xcbeautify --quieter
+
+    - name: Upload test build
+      uses: actions/upload-artifact@v4
+      with:
+        name: Products
+        path: DerivedData/Build/Products
+        retention-days: 4
+
+  build-and-test:
+    name: Build and Test
+    runs-on: macos-14
+    needs: [build]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test with stable23 as well to find regressions in older versions
+        configs: [
+          { talkbranch: 'stable23', serverbranch: 'stable23', phpversion: '8.0' },
+          { talkbranch: 'stable27', serverbranch: 'stable27', phpversion: '8.2' },
+          { talkbranch: 'stable28', serverbranch: 'stable28', phpversion: '8.2' },
+          { talkbranch: 'main', serverbranch: 'master', phpversion: '8.2' }
+        ]
+
+    steps:
+    - name: Checkout app
+      uses: actions/checkout@v4
+      with:
+        submodules: true
 
     - name: Set up php ${{ matrix.configs.phpversion }}
       uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d # v2.30.0
@@ -97,17 +128,22 @@ jobs:
         ./server/occ config:system:set memcache.local --value="\\OC\\Memcache\\APCu"
         ./server/occ config:system:set memcache.distributed --value="\\OC\\Memcache\\APCu"
         ./server/occ app:enable --force spreed
-        PHP_CLI_SERVER_WORKERS=3 php -S localhost:8080 -t server/ &   
+        PHP_CLI_SERVER_WORKERS=3 php -S localhost:8080 -t server/ &
 
-    - name: Set up dependencies talk-ios
-      run: |
-        pod install    
+    - name: Download test-build
+      uses: actions/download-artifact@v4
+      with:
+        name: Products
 
     - name: Build & Test NextcloudTalk iOS
       run: |
-        set -o pipefail && xcodebuild test -workspace $WORKSPACE \
-        -scheme "$SCHEME" \
-        -destination "$DESTINATION" \
+        set -o pipefail && \
+        xcodebuild test-without-building \
+        -xctestrun $(find . -type f -name "*.xctestrun") \
+        -workspace "${{ env.WORKSPACE }}" \
+        -scheme "${{ env.SCHEME }}" \
+        -destination "${{ env.DESTINATION }}" \
+        -derivedDataPath "DerivedData" \
         -test-iterations 3 \
         -retry-tests-on-failure \
         -resultBundlePath "testResult.xcresult" \

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -131,7 +131,8 @@ jobs:
         ./server/occ config:system:set memcache.local --value="\\OC\\Memcache\\APCu"
         ./server/occ config:system:set memcache.distributed --value="\\OC\\Memcache\\APCu"
         ./server/occ app:enable --force spreed
-        PHP_CLI_SERVER_WORKERS=3 php -S localhost:8080 -t server/ &
+        ./server/occ background:cron
+        PHP_CLI_SERVER_WORKERS=5 php -S localhost:8080 -t server/ &
 
     - name: Download test-build
       uses: actions/download-artifact@v4

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         pod install    
 
-    - name: Build & Test NextcloudTalk iOS
+    - name: Build NextcloudTalk iOS for testing
       run: |
         set -o pipefail && \
         xcodebuild build-for-testing \
@@ -136,13 +136,11 @@ jobs:
       with:
         name: Products
 
-    - name: Build & Test NextcloudTalk iOS
+    - name: Test NextcloudTalk iOS
       run: |
         set -o pipefail && \
         xcodebuild test-without-building \
         -xctestrun $(find . -type f -name "*.xctestrun") \
-        -workspace "${{ env.WORKSPACE }}" \
-        -scheme "${{ env.SCHEME }}" \
         -destination "${{ env.DESTINATION }}" \
         -derivedDataPath "DerivedData" \
         -test-iterations 3 \

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -134,6 +134,9 @@ jobs:
         ./server/occ background:cron
         PHP_CLI_SERVER_WORKERS=5 php -S localhost:8080 -t server/ &
 
+    - name: Check status.php
+      run: curl -s http://localhost:8080/status.php
+
     - name: Download test-build
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -25,13 +25,13 @@ permissions:
 
 env:
   WORKSPACE: NextcloudTalk.xcworkspace
-  DESTINATION: platform=iOS Simulator,name=iPhone 15,OS=17.2
+  DESTINATION: platform=iOS Simulator,name=iPhone 14,OS=16.2
   SCHEME: NextcloudTalk
 
 jobs:
   build:
     name: Build
-    runs-on: macos-14
+    runs-on: macos-12
 
     steps:
     - name: Checkout app
@@ -69,7 +69,7 @@ jobs:
 
   build-and-test:
     name: Build and Test
-    runs-on: macos-14
+    runs-on: macos-12
     needs: [build]
 
     strategy:

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -31,6 +31,7 @@ env:
 jobs:
   build:
     name: Build
+    runs-on: macos-14
 
     steps:
     - name: Checkout app

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -67,8 +67,8 @@ jobs:
         path: DerivedData/Build/Products
         retention-days: 4
 
-  build-and-test:
-    name: Build and Test
+  test:
+    name: Test
     runs-on: macos-12
     needs: [build]
 
@@ -165,7 +165,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [build-and-test]
+    needs: [test]
 
     if: always()
 
@@ -173,4 +173,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.build-and-test.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.test.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -126,6 +126,8 @@ jobs:
         mkdir server/data
         ./server/occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
         ./server/occ config:system:set hashing_default_password --value=true --type=boolean
+        ./server/occ config:system:set auth.bruteforce.protection.enabled --value false --type bool
+        ./server/occ config:system:set ratelimit.protection.enabled --value false --type bool
         ./server/occ config:system:set memcache.local --value="\\OC\\Memcache\\APCu"
         ./server/occ config:system:set memcache.distributed --value="\\OC\\Memcache\\APCu"
         ./server/occ app:enable --force spreed

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ ThirdParty/WebRTC.xcframework
 .DS_Store
 testResult.xcresult
 dictionary.dic
+DerivedData

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,6 +22,7 @@ excluded:
   - Pods
   - ThirdParty
   - NextcloudTalk/RLMSupport.swift
+  - DerivedData
 
 reporter: "xcode"
 

--- a/NextcloudTalk/FederationInvitationTableViewController.swift
+++ b/NextcloudTalk/FederationInvitationTableViewController.swift
@@ -79,11 +79,10 @@ class FederationInvitationTableViewController: UITableViewController, Federation
 
             if let invitations {
                 // TODO: For now the invitation endpoint also returns accepted invitations, we only want to have pending
-                let pendingNotifications = invitations.filter { $0.invitationState != .accepted }
                 self.pendingInvitations = invitations.filter { $0.invitationState != .accepted }
-                NCDatabaseManager.sharedInstance().setPendingFederationInvitationForAccountId(activeAccount.accountId, with: pendingInvitations.count)
+                NCDatabaseManager.sharedInstance().setPendingFederationInvitationForAccountId(activeAccount.accountId, with: self.pendingInvitations.count)
 
-                if pendingNotifications.isEmpty {
+                if self.pendingInvitations.isEmpty {
                     self.dismiss(animated: true)
                     return
                 }


### PR DESCRIPTION
* Split into 2 steps: building and testing
* Disable bruteforce protection and ratelimiting for testing
* Move to MacOS 12 again. This PR ran 4 times and all 4 times were successful, in contrast the M1 runners have a high failure rate.