### PR TITLE
Revert "Correctly indicate if the last message was from yourself"

### DIFF
--- a/NextcloudTalk/NCRoom.m
+++ b/NextcloudTalk/NCRoom.m
@@ -360,17 +360,6 @@ NSString * const NCRoomObjectTypeRoom           = @"room";
     return levelString;
 }
 
-- (NSString * _Nullable)getFederatedActorId
-{
-    TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
-
-    if ([self isFederated]) {
-        return [NSString stringWithFormat:@"%@@%@", activeAccount.userId, self.remoteServer];
-    }
-
-    return nil;
-}
-
 - (NSString *)lastMessageString
 {
     NCChatMessage *lastMessage = self.lastMessage;
@@ -386,11 +375,6 @@ NSString * const NCRoomObjectTypeRoom           = @"room";
 
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
     BOOL ownMessage = [lastMessage.actorId isEqualToString:activeAccount.userId];
-
-    if (!ownMessage && [self isFederated]) {
-        ownMessage = [lastMessage.actorId isEqualToString:[self getFederatedActorId]];
-    }
-
     NSString *actorName = [[lastMessage.actorDisplayName componentsSeparatedByString:@" "] objectAtIndex:0];
     // For own messages
     if (ownMessage) {


### PR DESCRIPTION
Reverts nextcloud/talk-ios#1584

Reverted PR worked around an issue in the backend https://github.com/nextcloud/spreed/pull/11942 but it's not needed anymore.