### PR TITLE
Remove padding when calculating the cell height with a quote

### DIFF
--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -2733,7 +2733,7 @@ import QuickLook
         }
 
         if message.parent() != nil {
-            height += 65 // left(5) + quoteView(60)
+            height += 60 // quoteView(60)
         }
 
         // Voice message should be before message.file check since it contains a file

--- a/NextcloudTalkTests/Unit/UnitChatCellTest.swift
+++ b/NextcloudTalkTests/Unit/UnitChatCellTest.swift
@@ -116,7 +116,7 @@ final class UnitChatCellTest: TestBaseRealm {
         testMessage.message = "test"
         testMessage.parentId = "internal-1"
         testMessage.isGroupMessage = true
-        XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 135.0)
+        XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 130.0)
     }
 
     func testCellWithUrlHeight() throws {
@@ -215,7 +215,7 @@ final class UnitChatCellTest: TestBaseRealm {
         }
 
         testMessage.parentId = "internal-1"
-        XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 275.0)
+        XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 270.0)
     }
 
     func testCellWithVoiceMessageHeight() {
@@ -238,7 +238,7 @@ final class UnitChatCellTest: TestBaseRealm {
         // Chat message with a quote
         testMessage.message = "test"
         testMessage.parentId = "internal-1"
-        XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 135.0)
+        XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 130.0)
     }
 
     func testUnreadMessageSeparatorUrlCheck() throws {


### PR DESCRIPTION
Before:
<img width="388" alt="Bildschirmfoto 2024-03-27 um 14 29 30" src="https://github.com/nextcloud/talk-ios/assets/1580193/896213d8-ad59-4e32-a873-4ee94c2c3a1f">

After: 
<img width="386" alt="Bildschirmfoto 2024-03-27 um 14 30 04" src="https://github.com/nextcloud/talk-ios/assets/1580193/d280622d-0304-4d4e-9348-21b1bc4ff5e1">

The `MessageBodyView` from the `BaseChatTableViewCell` already contains a 5px padding to the top, there's no additional padding involved if there's a quote or not.