### PR TITLE
Fix reference check for same message

### DIFF
--- a/NextcloudTalk/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/BaseChatTableViewCell.swift
@@ -219,11 +219,12 @@ class BaseChatTableViewCell: UITableViewCell, ReactionsViewDelegate {
             self.showReferencePart()
 
             message.getReferenceData { message, referenceDataRaw, url in
-                guard let message = self.message,
-                      message.isSameMessage(message)
+                guard let cellMessage = self.message,
+                      let referenceMessage = message,
+                      cellMessage.isSameMessage(referenceMessage)
                 else { return }
 
-                if referenceDataRaw == nil, let deckCard = message.deckCard() {
+                if referenceDataRaw == nil, let deckCard = cellMessage.deckCard() {
                     // In case we were unable to retrieve reference data (for example if the user has no permissions)
                     // but the message is a shared deck card, we use the shared information to show the deck view
                     self.referenceView?.update(for: deckCard)


### PR DESCRIPTION
The check before would always be true, because it was checking the same variable. This can lead to reference data shown in the wrong cell when a cell was reused. 