### PR TITLE
Retry status page curl command

### DIFF
--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -135,13 +135,13 @@ jobs:
         ./server/occ background:cron
         PHP_CLI_SERVER_WORKERS=3 php -S localhost:8080 -t server/ &
 
-    - name: Check status.php
-      run: curl -s --retry 5 --retry-delay 5 --retry-all-errors http://localhost:8080/status.php || true
-
     - name: Download test-build
       uses: actions/download-artifact@v4
       with:
         name: Products
+
+    - name: Check status.php
+      run: curl -s --retry 5 --retry-delay 5 --retry-all-errors http://localhost:8080/status.php || true
 
     - name: Test NextcloudTalk iOS
       run: |

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -133,10 +133,10 @@ jobs:
         ./server/occ config:system:set memcache.distributed --value="\\OC\\Memcache\\APCu"
         ./server/occ app:enable --force spreed
         ./server/occ background:cron
-        PHP_CLI_SERVER_WORKERS=5 php -S localhost:8080 -t server/ &
+        PHP_CLI_SERVER_WORKERS=3 php -S localhost:8080 -t server/ &
 
     - name: Check status.php
-      run: curl -s http://localhost:8080/status.php
+      run: curl -s --retry 5 --retry-delay 5 --retry-all-errors http://localhost:8080/status.php || true
 
     - name: Download test-build
       uses: actions/download-artifact@v4


### PR DESCRIPTION
Seems like sometimes the curl command is too fast to connect to the status page (see https://github.com/nextcloud/talk-ios/actions/runs/8529679303/job/23366327951?pr=1606). So we should retry the command before failing.