### PR TITLE
Fix contentMode for sending error state

### DIFF
--- a/NextcloudTalk/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/BaseChatTableViewCell.swift
@@ -299,6 +299,7 @@ class BaseChatTableViewCell: UITableViewCell, ReactionsViewDelegate {
             let errorImage = UIImage(systemName: "exclamationmark.circle")?.withTintColor(.red).withRenderingMode(.alwaysOriginal)
 
             errorView.image = errorImage
+            errorView.contentMode = .scaleAspectFit
             errorView.heightAnchor.constraint(equalToConstant: 20).isActive = true
 
             self.statusView.addArrangedSubview(errorView)


### PR DESCRIPTION
When using the smallest font size possible on iOS, the statusView is 20x17 instead of 20x20 for single line messages, which makes the exclamation mark look weird. For the other icons we already enforce the correct contentMode.
Should look into taking the statusView size into account as well, but this needs some work -> follow up.