### PR TITLE
Adjust view hierarchy after view transition

### DIFF
--- a/NextcloudTalk/NCSplitViewController.swift
+++ b/NextcloudTalk/NCSplitViewController.swift
@@ -99,6 +99,25 @@
         }
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: any UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+
+        coordinator.animate(alongsideTransition: nil) { _ in
+            guard self.isCollapsed else { return }
+
+            if let navController = self.viewController(for: .secondary) as? UINavigationController,
+               let chatViewController = self.getActiveChatViewController() {
+
+                // Make sure the navigationController has the correct reference to the chatViewController.
+                // After a transition (eg. portrait to landscape) the navigationController still references the
+                // the placeholderViewController in the navigationBar. When navigating back the app crashes in iOS 17,
+                // because the navigationBar is referenced twice.
+                navController.setViewControllers([self.placeholderViewController, chatViewController], animated: false)
+                navController.setViewControllers([chatViewController], animated: false)
+            }
+        }
+    }
+
     func internalExecuteAfterTransition(action: @escaping () -> Void) {
         if self.transitionCoordinator == nil {
             // No ongoing animations -> execute action directly


### PR DESCRIPTION
There are multiple reports of crashes since iOS 17.0 that happen in the SplitViewController but outside of our code. After trying to reproduce the issue, I was able the generate the following crash:

> *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Layout requested for visible navigation bar, <UINavigationBar: 0x10760d190; frame = (0 53.6667; 393 44); autoresize = W; tintColor = UIExtendedSRGBColorSpace 1 1 1 1; layer = <CALayer: 0x302fde760>> delegate=0x108820c00, when the top item belongs to a different navigation bar. topItem = <UINavigationItem: 0x10752ee90> style=navigator standardAppearance=0x300ba3420 scrollEdgeAppearance=0x300ba1620 compactAppearance=0x300ba1200, navigation bar = <UINavigationBar: 0x1076044a0; frame = (0 -97.6667; 393 44); hidden = YES; autoresize = W; tintColor = UIExtendedSRGBColorSpace 1 1 1 1; layer = <CALayer: 0x302fd5200>> delegate=0x108837e00 standardAppearance=0x300bfe760, possibly from a client attempt to nest wrapped navigation controllers.'

Steps to reproduce were:
* Start in portrait orientation
* Tap a conversation to join
* Rotate the device

Best reproducible was while starting from debugger, because of the slight delay at the start of the app. It only happens when switch to the ChatViewController happens while transitioning to landscape mode. In this case the navigationBar wrongfully references the placeholderView. After trying to return to the conversation list, the app crashes, because the placeholderView is referenced another time. Before iOS 17 the app would not crash, but we have seen cases, where the navigationBar was not correctly displayed, so it might be the same root cause.