### PR TITLE
Set searchBarPlacement to stacked for OpenConversationTableVC

### DIFF
--- a/NextcloudTalk/OpenConversationsTableViewController.swift
+++ b/NextcloudTalk/OpenConversationsTableViewController.swift
@@ -46,6 +46,10 @@ class OpenConversationsTableViewController: UITableViewController, UISearchResul
         self.navigationItem.compactAppearance = appearance
         self.navigationItem.scrollEdgeAppearance = appearance
 
+        if #available(iOS 16.0, *) {
+            self.navigationItem.preferredSearchBarPlacement = .stacked
+        }
+
         self.tableView.separatorInset = UIEdgeInsets(top: 0, left: 64, bottom: 0, right: 0)
         self.tableView.register(UINib(nibName: kContactsTableCellNibName, bundle: nil), forCellReuseIdentifier: kContactCellIdentifier)
 


### PR DESCRIPTION
Before:
<img width="616" alt="Bildschirmfoto 2024-04-05 um 12 35 00" src="https://github.com/nextcloud/talk-ios/assets/1580193/f91f3bca-0292-49d3-8b51-17ebca053a45">

After:
<img width="620" alt="Bildschirmfoto 2024-04-05 um 12 34 26" src="https://github.com/nextcloud/talk-ios/assets/1580193/291ca6f0-e7cc-442b-b76c-cd044bd7cd8e">

As we are doing in other view controllers with a searchbar as well.