### PR TITLE
Safeguard talkAccount in getFederationInvitations

### DIFF
--- a/NextcloudTalk/NCAPIControllerExtensions.swift
+++ b/NextcloudTalk/NCAPIControllerExtensions.swift
@@ -70,15 +70,15 @@ import Foundation
     }
 
     public func getFederationInvitations(for accountId: String, completionBlock: @escaping (_ invitations: [FederationInvitation]?) -> Void) {
-        let account = NCDatabaseManager.sharedInstance().talkAccount(forAccountId: accountId)!
-        let apiVersion = self.federationAPIVersion(for: account)
-        let urlString = self.getRequestURL(forEndpoint: "federation/invitation", withAPIVersion: apiVersion, for: account)
-
-        guard let apiSessionManager = self.apiSessionManagers.object(forKey: account.accountId) as? NCAPISessionManager
+        guard let apiSessionManager = self.apiSessionManagers.object(forKey: accountId) as? NCAPISessionManager,
+              let account = NCDatabaseManager.sharedInstance().talkAccount(forAccountId: accountId)
         else {
             completionBlock(nil)
             return
         }
+
+        let apiVersion = self.federationAPIVersion(for: account)
+        let urlString = self.getRequestURL(forEndpoint: "federation/invitation", withAPIVersion: apiVersion, for: account)
 
         apiSessionManager.get(urlString, parameters: nil, progress: nil) { _, result in
             if let ocs = self.getOcsResponse(data: result),


### PR DESCRIPTION
Reported on AppStore Connect. The only way I can see that this happens, if when a token got revoked and we removed the account before calling `getFederationInvitations`. I don't think it's a real issue, but we don't need to crash either.

<img width="637" alt="image" src="https://github.com/nextcloud/talk-ios/assets/1580193/5a1ca1ed-9b8e-4114-9d87-676cf3218ccc">
