### PR TITLE
Only set status icon on roomlist, not search results

### DIFF
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1595,7 +1595,7 @@ typedef enum RoomsSections {
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)rcell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (indexPath.section == kRoomsSectionPendingFederationInvitation) {
+    if (indexPath.section == kRoomsSectionPendingFederationInvitation || tableView != self.tableView) {
         return;
     }
 


### PR DESCRIPTION
Before:
<img width="401" alt="Bildschirmfoto 2024-04-07 um 16 11 59" src="https://github.com/nextcloud/talk-ios/assets/1580193/46aa989a-4eb4-40f0-bec6-a53621296425">

After:
<img width="402" alt="Bildschirmfoto 2024-04-07 um 16 11 37" src="https://github.com/nextcloud/talk-ios/assets/1580193/cf5eab38-f8da-4b5d-8a68-7925a4b4de51">

Note: Searching for conversations does not show the icon as well, regardless of this PR. Might be something we want to look into as a follow up.