### PR TITLE
Disable interactivePopGestureRecognizer for room list

### DIFF
--- a/NextcloudTalk/NCSplitViewController.swift
+++ b/NextcloudTalk/NCSplitViewController.swift
@@ -20,7 +20,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-@objcMembers class NCSplitViewController: UISplitViewController, UISplitViewControllerDelegate, UINavigationControllerDelegate {
+@objcMembers class NCSplitViewController: UISplitViewController, UISplitViewControllerDelegate, UINavigationControllerDelegate, UIGestureRecognizerDelegate {
 
     var placeholderViewController = UIViewController()
 
@@ -59,7 +59,17 @@
             // Make sure the chatViewController gets properly deallocated
             setViewController(placeholderViewController, for: .secondary)
             navController.setViewControllers([placeholderViewController], animated: false)
+
+            navigationController.interactivePopGestureRecognizer?.delegate = self
         }
+    }
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        if self.hasActiveChatViewController() {
+            return true
+        }
+
+        return false
     }
 
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {

--- a/NextcloudTalk/NCSplitViewController.swift
+++ b/NextcloudTalk/NCSplitViewController.swift
@@ -60,11 +60,16 @@
             setViewController(placeholderViewController, for: .secondary)
             navController.setViewControllers([placeholderViewController], animated: false)
 
+            // Instead of always allowing a gesture to be recognized, we need more control here.
+            // See gestureRecognizerShouldBegin.
             navigationController.interactivePopGestureRecognizer?.delegate = self
         }
     }
 
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        // We only want to recognize a "back gesture" through the interactivePopGestureRecognizer
+        // when a chatViewController is shown. Otherwise (on the RoomsTableViewController)
+        // recognizing a gesture might result in an unfinished transition and a broken UI
         if self.hasActiveChatViewController() {
             return true
         }


### PR DESCRIPTION
Tries to fix the broken UI state we sometimes end up in (no navigation bar or wrong navigation bar).

How to test:
* When in the room list, try to swipe from left to right as if you would try to leave a chat
* (if the a cell swipe is triggered, try again. There should be no visual feedback if it worked)
* Tap on a conversation to join
* -> UI broken

<img src="https://github.com/nextcloud/talk-ios/assets/1580193/19c89617-3f32-424c-b63e-1a7f37a00253" width=250 />
