### PR TITLE
Macos fixes

### DIFF
--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -1580,6 +1580,13 @@ import UIKit
             })
         }
 
+        // Show "Add reaction" when running on MacOS because we don't have an accessory view
+        if self.isMessageReactable(message: message), hasChatPermissions, NCUtils.isiOSAppOnMac() {
+            actions.append(UIAction(title: NSLocalizedString("Add reaction", comment: ""), image: .init(systemName: "face.smiling")) { _ in
+                self.didPressAddReaction(for: message, at: indexPath)
+            })
+        }
+
         // Reply-privately option (only to other users and not in one-to-one)
         if self.isMessageReplyable(message: message), self.room.type != kNCRoomTypeOneToOne, message.actorType == "users", message.actorId != activeAccount.userId {
             actions.append(UIAction(title: NSLocalizedString("Reply privately", comment: ""), image: .init(systemName: "person")) { _ in

--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -114,6 +114,10 @@ import UIKit
         self.textView.layoutSubviews()
         self.textView.layer.cornerRadius = self.textView.frame.size.height / 2
 
+        if #available(iOS 17.0, *), NCUtils.isiOSAppOnMac() {
+            self.textView.inlinePredictionType = .no
+        }
+
         self.textInputbar.editorTitle.textColor = .darkGray
         self.textInputbar.editorLeftButton.tintColor = .systemBlue
         self.textInputbar.editorRightButton.tintColor = .systemBlue

--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -195,7 +195,9 @@ import UIKit
 
     func setTitleView() {
         let titleView = NCChatTitleView()
-        titleView.frame = .init(x: 0, y: 0, width: Int.max, height: 30)
+
+        // Int.max is problematic when running on MacOS, so we use Int32.max here
+        titleView.frame = .init(x: 0, y: 0, width: Int(Int32.max), height: 30)
         titleView.delegate = self
         titleView.titleTextView.accessibilityHint = NSLocalizedString("Double tap to go to conversation information", comment: "")
 

--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -114,9 +114,12 @@ import UIKit
         self.textView.layoutSubviews()
         self.textView.layer.cornerRadius = self.textView.frame.size.height / 2
 
+        // Need a compile-time check here for old xcode version on CI
+#if swift(>=5.9)
         if #available(iOS 17.0, *), NCUtils.isiOSAppOnMac() {
             self.textView.inlinePredictionType = .no
         }
+#endif
 
         self.textInputbar.editorTitle.textColor = .darkGray
         self.textInputbar.editorLeftButton.tintColor = .systemBlue

--- a/NextcloudTalk/NCSplitViewController.swift
+++ b/NextcloudTalk/NCSplitViewController.swift
@@ -42,6 +42,12 @@
     }
 
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        if NCUtils.isiOSAppOnMac() {
+            // When the app is running on MacOS there's a gap between the titleBar and the navigationBar.
+            // We can remove that gap when setting a negative additionalSafeAreaInsets.top
+            navigationController.additionalSafeAreaInsets.top = -navigationController.navigationBar.frame.maxY
+        }
+
         if !isCollapsed {
             return
         }

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -89,6 +89,9 @@
 "Add participants" = "Add participants";
 
 /* No comment provided by engineer. */
+"Add reaction" = "Add reaction";
+
+/* No comment provided by engineer. */
 "Add to favorites" = "Add to favorites";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
Just some minor bug fixes when running on macos.

* Fixes #1488 
  Readd "Add reaction" when running on macos, because we can't render the emoji accessory view there.

  <img width="440" alt="image" src="https://github.com/nextcloud/talk-ios/assets/1580193/00f7a0c2-412c-401e-bb9e-30ed3a9b7864">

* Disable inline prediction on mac
   Before:

   https://github.com/nextcloud/talk-ios/assets/1580193/abcb0872-7230-49da-aba1-46a3f38fe2e0

* Fixes #1487 
   MacOS has issues correctly calculating the safe area when we use `Int.max`. When using `Int32.max` instead, everything is working fine.

* Fixes additional gap at the top when running on macos:
  Before: 
    <img width="640" alt="Bildschirmfoto 2024-04-20 um 20 57 41" src="https://github.com/nextcloud/talk-ios/assets/1580193/1708cc9d-6fc6-4efa-9d58-6fd17d4f29ee">

  After:
  <img width="611" alt="Bildschirmfoto 2024-04-20 um 20 57 15" src="https://github.com/nextcloud/talk-ios/assets/1580193/7500a1ff-e672-4e68-a25d-ce385fec3f36">

