### PR TITLE
Fix NCCallController retain cycle

### DIFF
--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -9,6 +9,7 @@ on:
       - NextcloudTalkTests/**
       - NotificationServiceExtension/**
       - ShareExtension/**
+      - BroadcastUploadExtension/**
 
     push:
       branches:

--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		1F0ECBF72A68277000921E90 /* CDMarkdownKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1F0ECBF62A68277000921E90 /* CDMarkdownKit */; };
 		1F0ECBF92A68277C00921E90 /* CDMarkdownKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1F0ECBF82A68277C00921E90 /* CDMarkdownKit */; };
 		1F11FB7229C07B04001E21E7 /* NCZoomableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11FB7129C07B04001E21E7 /* NCZoomableView.swift */; };
+		1F1B0F252BD94A0D003FD766 /* UnitDarwinCenterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1B0F242BD94A0D003FD766 /* UnitDarwinCenterTest.swift */; };
 		1F1B50342B8E069800B0F2F4 /* BaseChatTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1B50332B8E069800B0F2F4 /* BaseChatTableViewCell.swift */; };
 		1F1B50382B8E070100B0F2F4 /* BaseChatTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1F1B50372B8E070100B0F2F4 /* BaseChatTableViewCell.xib */; };
 		1F1B503A2B8F9E1300B0F2F4 /* BaseChatTableViewCell+File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1B50392B8F9E1300B0F2F4 /* BaseChatTableViewCell+File.swift */; };
@@ -575,6 +576,7 @@
 		1F0B0A712BA264540073FF8D /* MentionSuggestion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MentionSuggestion.swift; sourceTree = "<group>"; };
 		1F0B0A762BA26BE10073FF8D /* UnitMentionSuggestionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitMentionSuggestionTest.swift; sourceTree = "<group>"; };
 		1F11FB7129C07B04001E21E7 /* NCZoomableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NCZoomableView.swift; sourceTree = "<group>"; };
+		1F1B0F242BD94A0D003FD766 /* UnitDarwinCenterTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitDarwinCenterTest.swift; sourceTree = "<group>"; };
 		1F1B50332B8E069800B0F2F4 /* BaseChatTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseChatTableViewCell.swift; sourceTree = "<group>"; };
 		1F1B50372B8E070100B0F2F4 /* BaseChatTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BaseChatTableViewCell.xib; sourceTree = "<group>"; };
 		1F1B50392B8F9E1300B0F2F4 /* BaseChatTableViewCell+File.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BaseChatTableViewCell+File.swift"; sourceTree = "<group>"; };
@@ -1240,6 +1242,7 @@
 			children = (
 				1FBC3BE82B61BD09003909E0 /* TestBaseRealm.swift */,
 				1F5CDAE62B3B05110040ECC0 /* UnitColorGeneratorTest.swift */,
+				1F1B0F242BD94A0D003FD766 /* UnitDarwinCenterTest.swift */,
 				1F0B0A762BA26BE10073FF8D /* UnitMentionSuggestionTest.swift */,
 				1FBC3BE42B61ACD5003909E0 /* UnitChatCellTest.swift */,
 			);
@@ -2521,6 +2524,7 @@
 				1FBC3BE92B61BD09003909E0 /* TestBaseRealm.swift in Sources */,
 				1F6D8C4D2B2F8FE5004376B8 /* IntegrationChatTest.swift in Sources */,
 				1F5CDAE72B3B05110040ECC0 /* UnitColorGeneratorTest.swift in Sources */,
+				1F1B0F252BD94A0D003FD766 /* UnitDarwinCenterTest.swift in Sources */,
 				1F6D8C412B2F26D5004376B8 /* TestConstants.swift in Sources */,
 				1FBC3BE52B61ACD5003909E0 /* UnitChatCellTest.swift in Sources */,
 				1F0B0A772BA26BE10073FF8D /* UnitMentionSuggestionTest.swift in Sources */,

--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		1F0ECBF92A68277C00921E90 /* CDMarkdownKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1F0ECBF82A68277C00921E90 /* CDMarkdownKit */; };
 		1F11FB7229C07B04001E21E7 /* NCZoomableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F11FB7129C07B04001E21E7 /* NCZoomableView.swift */; };
 		1F1B0F252BD94A0D003FD766 /* UnitDarwinCenterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1B0F242BD94A0D003FD766 /* UnitDarwinCenterTest.swift */; };
+		1F1B0F272BDA61C5003FD766 /* AllocationTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1B0F262BDA61C5003FD766 /* AllocationTracker.swift */; };
 		1F1B50342B8E069800B0F2F4 /* BaseChatTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1B50332B8E069800B0F2F4 /* BaseChatTableViewCell.swift */; };
 		1F1B50382B8E070100B0F2F4 /* BaseChatTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1F1B50372B8E070100B0F2F4 /* BaseChatTableViewCell.xib */; };
 		1F1B503A2B8F9E1300B0F2F4 /* BaseChatTableViewCell+File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1B50392B8F9E1300B0F2F4 /* BaseChatTableViewCell+File.swift */; };
@@ -577,6 +578,7 @@
 		1F0B0A762BA26BE10073FF8D /* UnitMentionSuggestionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitMentionSuggestionTest.swift; sourceTree = "<group>"; };
 		1F11FB7129C07B04001E21E7 /* NCZoomableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NCZoomableView.swift; sourceTree = "<group>"; };
 		1F1B0F242BD94A0D003FD766 /* UnitDarwinCenterTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitDarwinCenterTest.swift; sourceTree = "<group>"; };
+		1F1B0F262BDA61C5003FD766 /* AllocationTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllocationTracker.swift; sourceTree = "<group>"; };
 		1F1B50332B8E069800B0F2F4 /* BaseChatTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseChatTableViewCell.swift; sourceTree = "<group>"; };
 		1F1B50372B8E070100B0F2F4 /* BaseChatTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BaseChatTableViewCell.xib; sourceTree = "<group>"; };
 		1F1B50392B8F9E1300B0F2F4 /* BaseChatTableViewCell+File.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BaseChatTableViewCell+File.swift"; sourceTree = "<group>"; };
@@ -1407,6 +1409,7 @@
 		2C0633102046CCA60043481A /* User Interface */ = {
 			isa = PBXGroup;
 			children = (
+				1F1B0F262BDA61C5003FD766 /* AllocationTracker.swift */,
 				1F5813F628EB23EF00318FC3 /* NCSplitViewController.swift */,
 				1F5813F728EB23EF00318FC3 /* NCSplitViewPlaceholderViewController.swift */,
 				2C06330D2046CC8B0043481A /* NCUserInterfaceController.h */,
@@ -2638,6 +2641,7 @@
 				2CC32E9227F45AE000BB8C39 /* ReactionsViewCell.swift in Sources */,
 				2CBF82AE1FC888FC00636459 /* NCPushNotification.m in Sources */,
 				2CC7159420C54D080045C789 /* ChatTableViewCell.m in Sources */,
+				1F1B0F272BDA61C5003FD766 /* AllocationTracker.swift in Sources */,
 				2CA1CCAA1F02D1A4002FE6A2 /* NCAPIController.m in Sources */,
 				DA66582B27B6992F00B46B11 /* UserProfileTableViewController+AvatarSetup.swift in Sources */,
 				2C69323D2923ECAA00017AD2 /* WSMessage.m in Sources */,

--- a/NextcloudTalk/AllocationTracker.swift
+++ b/NextcloudTalk/AllocationTracker.swift
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2024 Marcel Müller <marcel.mueller@nextcloud.com>
+//
+// Author Marcel Müller <marcel.mueller@nextcloud.com>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import UIKit
+
+@objcMembers class AllocationTracker: NSObject {
+
+    public static let shared = AllocationTracker()
+
+    private var allocationDict: [String: Int] = [:]
+
+    public func addAllocation(_ name: String) {
+        allocationDict[name, default: 0] += 1
+    }
+
+    public func removeAllocation(_ name: String) {
+        if let currentAllocations = allocationDict[name] {
+            if currentAllocations == 1 {
+                allocationDict.removeValue(forKey: name)
+            } else {
+                allocationDict[name] = currentAllocations - 1
+            }
+        } else {
+            print("WARNING: Removing non-existing allocation")
+        }
+    }
+
+    override var description: String {
+        if let jsonData = try? JSONSerialization.data(withJSONObject: allocationDict, options: .sortedKeys),
+           let jsonString = String(data: jsonData, encoding: .utf8) {
+
+            return jsonString
+        }
+
+        return "Unknown"
+    }
+}

--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -109,7 +109,7 @@
 
         __weak typeof(self) weakSelf = self;
         self.debugLabelTimer = [NSTimer scheduledTimerWithTimeInterval:1 repeats:YES block:^(NSTimer * _Nonnull timer) {
-            [weakSelf.debugLabel setText:[[NCUserInterfaceController sharedInstance] allocationTracker].description];
+            [weakSelf.debugLabel setText:[AllocationTracker shared].description];
         }];
     }
 

--- a/NextcloudTalk/AppDelegate.m
+++ b/NextcloudTalk/AppDelegate.m
@@ -94,14 +94,22 @@
     NSArray *arguments = [[NSProcessInfo processInfo] arguments];
 
     if ([arguments containsObject:@"-TestEnvironment"]) {
-        self.debugLabel = [[UILabel alloc] initWithFrame:CGRectMake(20, 30, 200, 50)];
-        [[NCUserInterfaceController sharedInstance].mainViewController.view addSubview:self.debugLabel];
+        UIView *mainView = [NCUserInterfaceController sharedInstance].mainViewController.view;
+
+        self.debugLabel = [[UILabel alloc] initWithFrame:CGRectMake(20, 30, 200, 20)];
+        self.debugLabel.font = [UIFont systemFontOfSize:[UIFont smallSystemFontSize]];
+        self.debugLabel.translatesAutoresizingMaskIntoConstraints = NO;
+
+        [mainView addSubview:self.debugLabel];
+        [NSLayoutConstraint activateConstraints:@[
+            [self.debugLabel.topAnchor constraintEqualToAnchor:mainView.safeAreaLayoutGuide.topAnchor constant:-15],
+            [self.debugLabel.leadingAnchor constraintEqualToAnchor:mainView.safeAreaLayoutGuide.leadingAnchor constant:5],
+            [self.debugLabel.trailingAnchor constraintEqualToAnchor:mainView.safeAreaLayoutGuide.trailingAnchor]
+        ]];
 
         __weak typeof(self) weakSelf = self;
         self.debugLabelTimer = [NSTimer scheduledTimerWithTimeInterval:1 repeats:YES block:^(NSTimer * _Nonnull timer) {
-            long numChatVC = [NCUserInterfaceController sharedInstance].numberOfAllocatedChatViewControllers;
-            long numCallVC = [NCUserInterfaceController sharedInstance].numberOfAllocatedCallViewControllers;
-            [weakSelf.debugLabel setText:[NSString stringWithFormat:@"ChatVC: %ld / CallVC: %ld", numChatVC, numCallVC]];
+            [weakSelf.debugLabel setText:[[NCUserInterfaceController sharedInstance] allocationTracker].description];
         }];
     }
 

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -200,7 +200,7 @@ import QuickLook
         NotificationCenter.default.addObserver(self, selector: #selector(willShowKeyboard(notification:)), name: UIWindow.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(willHideKeyboard(notification:)), name: UIWindow.keyboardWillHideNotification, object: nil)
 
-        NCUserInterfaceController.sharedInstance().allocationTracker.addAllocation("ChatViewController")
+        AllocationTracker.shared.addAllocation("ChatViewController")
     }
 
     // Not using an optional here, because it is not available from ObjC
@@ -230,7 +230,7 @@ import QuickLook
 
     deinit {
         NotificationCenter.default.removeObserver(self)
-        NCUserInterfaceController.sharedInstance().allocationTracker.removeAllocation("ChatViewController")
+        AllocationTracker.shared.removeAllocation("ChatViewController")
         NSLog("Dealloc BaseChatViewController")
     }
 

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -200,7 +200,7 @@ import QuickLook
         NotificationCenter.default.addObserver(self, selector: #selector(willShowKeyboard(notification:)), name: UIWindow.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(willHideKeyboard(notification:)), name: UIWindow.keyboardWillHideNotification, object: nil)
 
-        NCUserInterfaceController.sharedInstance().numberOfAllocatedChatViewControllers += 1
+        NCUserInterfaceController.sharedInstance().allocationTracker.addAllocation("ChatViewController")
     }
 
     // Not using an optional here, because it is not available from ObjC
@@ -230,7 +230,7 @@ import QuickLook
 
     deinit {
         NotificationCenter.default.removeObserver(self)
-        NCUserInterfaceController.sharedInstance().numberOfAllocatedChatViewControllers -= 1
+        NCUserInterfaceController.sharedInstance().allocationTracker.removeAllocation("ChatViewController")
         NSLog("Dealloc BaseChatViewController")
     }
 

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -176,8 +176,8 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
 
-    [NCUserInterfaceController sharedInstance].numberOfAllocatedCallViewControllers += 1;
-    
+    [[NCUserInterfaceController sharedInstance].allocationTracker addAllocation:@"CallViewController"];
+
     return self;
 }
 
@@ -355,7 +355,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
 - (void)dealloc
 {
     NSLog(@"CallViewController dealloc");
-    [NCUserInterfaceController sharedInstance].numberOfAllocatedCallViewControllers -= 1;
+    [[NCUserInterfaceController sharedInstance].allocationTracker removeAllocation:@"CallViewController"];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -176,7 +176,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
 
-    [[NCUserInterfaceController sharedInstance].allocationTracker addAllocation:@"CallViewController"];
+    [[AllocationTracker shared] addAllocation:@"CallViewController"];
 
     return self;
 }
@@ -355,7 +355,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
 - (void)dealloc
 {
     NSLog(@"CallViewController dealloc");
-    [[NCUserInterfaceController sharedInstance].allocationTracker removeAllocation:@"CallViewController"];
+    [[AllocationTracker shared] removeAllocation:@"CallViewController"];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -147,6 +147,8 @@ static NSString * const kNCScreenTrackKind  = @"screen";
         }];
 
         _screensharingController = [[NCScreensharingController alloc] init];
+
+        [[NCUserInterfaceController sharedInstance].allocationTracker addAllocation:@"NCCallController"];
     }
     
     return self;
@@ -410,6 +412,7 @@ static NSString * const kNCScreenTrackKind  = @"screen";
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [[DarwinNotificationCenter shared] removeHandlerWithNotificationName:DarwinNotificationCenter.broadcastStartedNotification owner:self];
     [[DarwinNotificationCenter shared] removeHandlerWithNotificationName:DarwinNotificationCenter.broadcastStoppedNotification owner:self];
+    [[NCUserInterfaceController sharedInstance].allocationTracker removeAllocation:@"NCCallController"];
     NSLog(@"NCCallController dealloc");
 }
 

--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -148,7 +148,7 @@ static NSString * const kNCScreenTrackKind  = @"screen";
 
         _screensharingController = [[NCScreensharingController alloc] init];
 
-        [[NCUserInterfaceController sharedInstance].allocationTracker addAllocation:@"NCCallController"];
+        [[AllocationTracker shared] addAllocation:@"NCCallController"];
     }
     
     return self;
@@ -412,7 +412,7 @@ static NSString * const kNCScreenTrackKind  = @"screen";
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [[DarwinNotificationCenter shared] removeHandlerWithNotificationName:DarwinNotificationCenter.broadcastStartedNotification owner:self];
     [[DarwinNotificationCenter shared] removeHandlerWithNotificationName:DarwinNotificationCenter.broadcastStoppedNotification owner:self];
-    [[NCUserInterfaceController sharedInstance].allocationTracker removeAllocation:@"NCCallController"];
+    [[AllocationTracker shared] removeAllocation:@"NCCallController"];
     NSLog(@"NCCallController dealloc");
 }
 

--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -133,14 +133,14 @@ static NSString * const kNCScreenTrackKind  = @"screen";
         
         [self initRecorder];
 
-        // Screensharing is done in an extension, therefore we need to listen to systemwide notifications
-        [[DarwinNotificationCenter shared] addObserverWithNotificationName:DarwinNotificationCenter.broadcastStartedNotification completionBlock:^{
+        // Screensharing is done in an extension, therefore we need to listen to systemwide notifications#
+        [[DarwinNotificationCenter shared] addHandlerWithNotificationName:DarwinNotificationCenter.broadcastStartedNotification owner:self completionBlock:^{
             [[WebRTCCommon shared] dispatch:^{
                 [self startScreenshare];
             }];
         }];
 
-        [[DarwinNotificationCenter shared] addObserverWithNotificationName:DarwinNotificationCenter.broadcastStoppedNotification completionBlock:^{
+        [[DarwinNotificationCenter shared] addHandlerWithNotificationName:DarwinNotificationCenter.broadcastStoppedNotification owner:self completionBlock:^{
             [[WebRTCCommon shared] dispatch:^{
                 [self stopScreenshare];
             }];
@@ -353,8 +353,8 @@ static NSString * const kNCScreenTrackKind  = @"screen";
     [self stopSendingCurrentState];
     
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [[DarwinNotificationCenter shared] removeObserver:DarwinNotificationCenter.broadcastStartedNotification];
-    [[DarwinNotificationCenter shared] removeObserver:DarwinNotificationCenter.broadcastStoppedNotification];
+    [[DarwinNotificationCenter shared] removeHandlerWithNotificationName:DarwinNotificationCenter.broadcastStartedNotification owner:self];
+    [[DarwinNotificationCenter shared] removeHandlerWithNotificationName:DarwinNotificationCenter.broadcastStoppedNotification owner:self];
 
     _externalSignalingController.delegate = nil;
 
@@ -408,8 +408,8 @@ static NSString * const kNCScreenTrackKind  = @"screen";
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [[DarwinNotificationCenter shared] removeObserver:DarwinNotificationCenter.broadcastStartedNotification];
-    [[DarwinNotificationCenter shared] removeObserver:DarwinNotificationCenter.broadcastStoppedNotification];
+    [[DarwinNotificationCenter shared] removeHandlerWithNotificationName:DarwinNotificationCenter.broadcastStartedNotification owner:self];
+    [[DarwinNotificationCenter shared] removeHandlerWithNotificationName:DarwinNotificationCenter.broadcastStoppedNotification owner:self];
     NSLog(@"NCCallController dealloc");
 }
 

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -60,9 +60,16 @@ NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotification     
     if (self) {
         _room = room;
         _account = [[NCDatabaseManager sharedInstance] talkAccountForAccountId:_room.accountId];
+
+        [[NCUserInterfaceController sharedInstance].allocationTracker addAllocation:@"NCChatController"];
     }
     
     return self;
+}
+
+- (void)dealloc
+{
+    [[NCUserInterfaceController sharedInstance].allocationTracker removeAllocation:@"NCChatController"];
 }
 
 #pragma mark - Database

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -61,7 +61,7 @@ NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotification     
         _room = room;
         _account = [[NCDatabaseManager sharedInstance] talkAccountForAccountId:_room.accountId];
 
-        [[NCUserInterfaceController sharedInstance].allocationTracker addAllocation:@"NCChatController"];
+        [[AllocationTracker shared] addAllocation:@"NCChatController"];
     }
     
     return self;
@@ -69,7 +69,7 @@ NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotification     
 
 - (void)dealloc
 {
-    [[NCUserInterfaceController sharedInstance].allocationTracker removeAllocation:@"NCChatController"];
+    [[AllocationTracker shared] removeAllocation:@"NCChatController"];
 }
 
 #pragma mark - Database

--- a/NextcloudTalk/NCUserInterfaceController.h
+++ b/NextcloudTalk/NCUserInterfaceController.h
@@ -31,6 +31,7 @@
 
 @class NCSplitViewController;
 @class ChatViewController;
+@class AllocationTracker;
 
 typedef void (^PresentCallControllerCompletionBlock)(void);
 
@@ -38,8 +39,7 @@ typedef void (^PresentCallControllerCompletionBlock)(void);
 
 @property (nonatomic, strong) NCSplitViewController *mainViewController;
 @property (nonatomic, strong) RoomsTableViewController *roomsTableViewController;
-@property (nonatomic, assign) NSInteger numberOfAllocatedChatViewControllers;
-@property (nonatomic, assign) NSInteger numberOfAllocatedCallViewControllers;
+@property (nonatomic, strong) AllocationTracker *allocationTracker;
 
 + (instancetype)sharedInstance;
 - (void)presentConversationsList;

--- a/NextcloudTalk/NCUserInterfaceController.h
+++ b/NextcloudTalk/NCUserInterfaceController.h
@@ -31,7 +31,6 @@
 
 @class NCSplitViewController;
 @class ChatViewController;
-@class AllocationTracker;
 
 typedef void (^PresentCallControllerCompletionBlock)(void);
 
@@ -39,7 +38,6 @@ typedef void (^PresentCallControllerCompletionBlock)(void);
 
 @property (nonatomic, strong) NCSplitViewController *mainViewController;
 @property (nonatomic, strong) RoomsTableViewController *roomsTableViewController;
-@property (nonatomic, strong) AllocationTracker *allocationTracker;
 
 + (instancetype)sharedInstance;
 - (void)presentConversationsList;

--- a/NextcloudTalk/NCUserInterfaceController.m
+++ b/NextcloudTalk/NCUserInterfaceController.m
@@ -67,6 +67,9 @@
     self = [super init];
     if (self) {
         [self configureToasts];
+
+        self.allocationTracker = [[AllocationTracker alloc] init];
+
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appStateHasChanged:) name:NCAppStateHasChangedNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(connectionStateHasChanged:) name:NCConnectionStateHasChangedNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(presentTalkNotInstalledWarningAlert) name:NCTalkNotInstalledNotification object:nil];

--- a/NextcloudTalk/NCUserInterfaceController.m
+++ b/NextcloudTalk/NCUserInterfaceController.m
@@ -67,9 +67,6 @@
     self = [super init];
     if (self) {
         [self configureToasts];
-
-        self.allocationTracker = [[AllocationTracker alloc] init];
-
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appStateHasChanged:) name:NCAppStateHasChangedNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(connectionStateHasChanged:) name:NCConnectionStateHasChangedNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(presentTalkNotInstalledWarningAlert) name:NCTalkNotInstalledNotification object:nil];

--- a/NextcloudTalkTests/UI/Helpers.swift
+++ b/NextcloudTalkTests/UI/Helpers.swift
@@ -126,4 +126,17 @@ extension XCTestCase {
 
         return app
     }
+
+    func createConversation(for app: XCUIApplication, with newConversationName: String) {
+        app.navigationBars["Nextcloud Talk"].buttons["Create or join a conversation"].tap()
+
+        let createNewConversationButton = app.buttons["Create a new conversation"]
+        XCTAssert(createNewConversationButton.waitForExistence(timeout: TestConstants.timeoutShort))
+        createNewConversationButton.tap()
+
+        let newConversationNavBar = app.navigationBars["New conversation"]
+        XCTAssert(newConversationNavBar.waitForExistence(timeout: TestConstants.timeoutShort))
+        app.typeText(newConversationName)
+        newConversationNavBar.buttons["Create"].tap()
+    }
 }

--- a/NextcloudTalkTests/UI/UIRoomTest.swift
+++ b/NextcloudTalkTests/UI/UIRoomTest.swift
@@ -28,19 +28,6 @@ final class UIRoomTest: XCTestCase {
         continueAfterFailure = false
     }
 
-    func createConversation(for app: XCUIApplication, with newConversationName: String) {
-        app.navigationBars["Nextcloud Talk"].buttons["Create or join a conversation"].tap()
-
-        let createNewConversationButton = app.buttons["Create a new conversation"]
-        XCTAssert(createNewConversationButton.waitForExistence(timeout: TestConstants.timeoutShort))
-        createNewConversationButton.tap()
-
-        let newConversationNavBar = app.navigationBars["New conversation"]
-        XCTAssert(newConversationNavBar.waitForExistence(timeout: TestConstants.timeoutShort))
-        app.typeText(newConversationName)
-        newConversationNavBar.buttons["Create"].tap()
-    }
-
     func testCreateConversation() {
         let app = launchAndLogin()
         let newConversationName = "Test conversation"
@@ -76,7 +63,7 @@ final class UIRoomTest: XCTestCase {
         XCTAssert(app.tables.cells.staticTexts[newConversationName].waitForExistence(timeout: TestConstants.timeoutLong))
     }
 
-    func testChatViewControllerDeallocation() {
+    func testDeallocation() {
         let app = launchAndLogin()
         let newConversationName = "DeAllocTest"
 
@@ -84,7 +71,7 @@ final class UIRoomTest: XCTestCase {
         self.createConversation(for: app, with: newConversationName)
 
         // Check if we have one chat view controller allocated
-        let predicate = NSPredicate(format: "label CONTAINS[c] %@", "ChatViewController")
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", "ChatViewController\":1")
         XCTAssert(app.staticTexts.containing(predicate).firstMatch.waitForExistence(timeout: TestConstants.timeoutShort))
 
         // Send a test message
@@ -118,8 +105,23 @@ final class UIRoomTest: XCTestCase {
             app.buttons["Reply"].tap()
         }
 
-        // Go back to the main view controller
+        // Start a call
         let chatNavBar = app.navigationBars["NextcloudTalk.ChatView"]
+        let voiceCallButton = chatNavBar.buttons["Voice call"]
+        XCTAssert(voiceCallButton.waitForExistence(timeout: TestConstants.timeoutShort))
+        waitForEnabled(object: voiceCallButton)
+        waitForHittable(object: voiceCallButton)
+
+        voiceCallButton.tap()
+
+        let hangupCallButton = app.buttons["Hang up"]
+        XCTAssert(hangupCallButton.waitForExistence(timeout: TestConstants.timeoutShort))
+        waitForEnabled(object: hangupCallButton)
+        waitForHittable(object: hangupCallButton)
+        hangupCallButton.tap()
+
+        // Go back to the main view controller
+        XCTAssert(voiceCallButton.waitForExistence(timeout: TestConstants.timeoutShort))
         chatNavBar.buttons["Back"].tap()
 
         // Check if all chat view controllers are deallocated

--- a/NextcloudTalkTests/UI/UIRoomTest.swift
+++ b/NextcloudTalkTests/UI/UIRoomTest.swift
@@ -84,7 +84,8 @@ final class UIRoomTest: XCTestCase {
         self.createConversation(for: app, with: newConversationName)
 
         // Check if we have one chat view controller allocated
-        XCTAssert(app.staticTexts["ChatVC: 1 / CallVC: 0"].waitForExistence(timeout: TestConstants.timeoutShort))
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", "ChatViewController")
+        XCTAssert(app.staticTexts.containing(predicate).firstMatch.waitForExistence(timeout: TestConstants.timeoutShort))
 
         // Send a test message
         let testMessage = "TestMessage"
@@ -122,7 +123,7 @@ final class UIRoomTest: XCTestCase {
         chatNavBar.buttons["Back"].tap()
 
         // Check if all chat view controllers are deallocated
-        XCTAssert(app.staticTexts["ChatVC: 0 / CallVC: 0"].waitForExistence(timeout: TestConstants.timeoutShort))
+        XCTAssert(app.staticTexts["{}"].waitForExistence(timeout: TestConstants.timeoutShort))
     }
 
     func testChatViewControllerMentions() {

--- a/NextcloudTalkTests/Unit/UnitDarwinCenterTest.swift
+++ b/NextcloudTalkTests/Unit/UnitDarwinCenterTest.swift
@@ -1,0 +1,125 @@
+//
+// Copyright (c) 2024 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import NextcloudTalk
+
+final class UnitDarwinCenterTest: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Reset any remaining handlers for each test
+        for (notificationName, handlerDict) in DarwinNotificationCenter.shared.handlers {
+            for (owner, _) in handlerDict {
+                DarwinNotificationCenter.shared.removeHandler(notificationName: notificationName, owner: owner)
+            }
+        }
+
+        XCTAssertTrue(DarwinNotificationCenter.shared.handlers.isEmpty)
+    }
+
+    func testDarwinCenterHandlerSingle() throws {
+        let center = DarwinNotificationCenter.shared
+
+        let expStarted = expectation(description: "\(#function)\(#line)")
+        let expStopped = expectation(description: "\(#function)\(#line)")
+
+        center.addHandler(notificationName: DarwinNotificationCenter.broadcastStartedNotification, owner: self) {
+            expStarted.fulfill()
+        }
+
+        center.addHandler(notificationName: DarwinNotificationCenter.broadcastStoppedNotification, owner: self) {
+            expStopped.fulfill()
+        }
+
+        // Check if the handlers are correctly registered
+        XCTAssertEqual(center.handlers[DarwinNotificationCenter.broadcastStartedNotification]?.count, 1)
+        XCTAssertEqual(center.handlers[DarwinNotificationCenter.broadcastStoppedNotification]?.count, 1)
+
+        // Check if the handlers are correctly called after posting a notification
+        center.postNotification(DarwinNotificationCenter.broadcastStartedNotification)
+        center.postNotification(DarwinNotificationCenter.broadcastStoppedNotification)
+        wait(for: [expStarted, expStopped], timeout: TestConstants.timeoutShort)
+
+        // Check if the handlers are correctly cleaned up
+        center.removeHandler(notificationName: DarwinNotificationCenter.broadcastStartedNotification, owner: self)
+        center.removeHandler(notificationName: DarwinNotificationCenter.broadcastStoppedNotification, owner: self)
+
+        XCTAssertNil(center.handlers[DarwinNotificationCenter.broadcastStartedNotification])
+        XCTAssertNil(center.handlers[DarwinNotificationCenter.broadcastStoppedNotification])
+    }
+
+    func testDarwinCenterHandlerMultiple() throws {
+        let center = DarwinNotificationCenter.shared
+
+        let owner1 = NSObject()
+
+        // We need to wait twice for the expectation
+        // 1. Before the handler is removed to ensure it is correctly called
+        // 2. After a notification was posted a second time to ensure the first handler wasn't called multiple times
+        var expSingleStarted = expectation(description: "\(#function)\(#line)")
+        var expSingleStopped = expectation(description: "\(#function)\(#line)")
+        var expSingleStartedEnd = expectation(description: "\(#function)\(#line)")
+        var expSingleStoppedEnd = expectation(description: "\(#function)\(#line)")
+
+        center.addHandler(notificationName: DarwinNotificationCenter.broadcastStartedNotification, owner: owner1) {
+            expSingleStarted.fulfill()
+            expSingleStartedEnd.fulfill()
+        }
+
+        center.addHandler(notificationName: DarwinNotificationCenter.broadcastStoppedNotification, owner: owner1) {
+            expSingleStopped.fulfill()
+            expSingleStoppedEnd.fulfill()
+        }
+
+        let owner2 = NSObject()
+        var expStartedSecond = expectation(description: "\(#function)\(#line)")
+        var expStoppedSecond = expectation(description: "\(#function)\(#line)")
+
+        expStartedSecond.expectedFulfillmentCount = 2
+        expStoppedSecond.expectedFulfillmentCount = 2
+
+        center.addHandler(notificationName: DarwinNotificationCenter.broadcastStartedNotification, owner: owner2) {
+            expStartedSecond.fulfill()
+        }
+
+        center.addHandler(notificationName: DarwinNotificationCenter.broadcastStoppedNotification, owner: owner2) {
+            expStoppedSecond.fulfill()
+        }
+
+        // Call the handlers a first time
+        center.postNotification(DarwinNotificationCenter.broadcastStartedNotification)
+        center.postNotification(DarwinNotificationCenter.broadcastStoppedNotification)
+
+        wait(for: [expSingleStarted, expSingleStopped], timeout: TestConstants.timeoutShort)
+
+        // Remove the handlers of owner1
+        center.removeHandler(notificationName: DarwinNotificationCenter.broadcastStartedNotification, owner: owner1)
+        center.removeHandler(notificationName: DarwinNotificationCenter.broadcastStoppedNotification, owner: owner1)
+
+        // Call the handlers a second time
+        center.postNotification(DarwinNotificationCenter.broadcastStartedNotification)
+        center.postNotification(DarwinNotificationCenter.broadcastStoppedNotification)
+
+        // Also check the expectations from the first call to make sure, they were only called once and not again
+        // We can't wait for an expectation twice, that's why we use a second expectation
+        wait(for: [expStartedSecond, expStoppedSecond, expSingleStartedEnd, expSingleStoppedEnd], timeout: TestConstants.timeoutShort)
+    }
+}

--- a/NextcloudTalkTests/Unit/UnitDarwinCenterTest.swift
+++ b/NextcloudTalkTests/Unit/UnitDarwinCenterTest.swift
@@ -122,4 +122,23 @@ final class UnitDarwinCenterTest: XCTestCase {
         // We can't wait for an expectation twice, that's why we use a second expectation
         wait(for: [expStartedSecond, expStoppedSecond, expSingleStartedEnd, expSingleStoppedEnd], timeout: TestConstants.timeoutShort)
     }
+
+    func testDarwinCenterUnbalancedRemove() throws {
+        let center = DarwinNotificationCenter.shared
+
+        let expStarted = expectation(description: "\(#function)\(#line)")
+
+        center.addHandler(notificationName: DarwinNotificationCenter.broadcastStartedNotification, owner: self) {
+            expStarted.fulfill()
+        }
+
+        center.postNotification(DarwinNotificationCenter.broadcastStartedNotification)
+        wait(for: [expStarted], timeout: TestConstants.timeoutShort)
+
+        // Remove ourselves twice
+        center.removeHandler(notificationName: DarwinNotificationCenter.broadcastStartedNotification, owner: self)
+        center.removeHandler(notificationName: DarwinNotificationCenter.broadcastStartedNotification, owner: self)
+
+        XCTAssertNil(center.handlers[DarwinNotificationCenter.broadcastStartedNotification])
+    }
 }

--- a/NextcloudTalkTests/Unit/UnitDarwinCenterTest.swift
+++ b/NextcloudTalkTests/Unit/UnitDarwinCenterTest.swift
@@ -74,10 +74,10 @@ final class UnitDarwinCenterTest: XCTestCase {
         // We need to wait twice for the expectation
         // 1. Before the handler is removed to ensure it is correctly called
         // 2. After a notification was posted a second time to ensure the first handler wasn't called multiple times
-        var expSingleStarted = expectation(description: "\(#function)\(#line)")
-        var expSingleStopped = expectation(description: "\(#function)\(#line)")
-        var expSingleStartedEnd = expectation(description: "\(#function)\(#line)")
-        var expSingleStoppedEnd = expectation(description: "\(#function)\(#line)")
+        let expSingleStarted = expectation(description: "\(#function)\(#line)")
+        let expSingleStopped = expectation(description: "\(#function)\(#line)")
+        let expSingleStartedEnd = expectation(description: "\(#function)\(#line)")
+        let expSingleStoppedEnd = expectation(description: "\(#function)\(#line)")
 
         center.addHandler(notificationName: DarwinNotificationCenter.broadcastStartedNotification, owner: owner1) {
             expSingleStarted.fulfill()
@@ -90,8 +90,8 @@ final class UnitDarwinCenterTest: XCTestCase {
         }
 
         let owner2 = NSObject()
-        var expStartedSecond = expectation(description: "\(#function)\(#line)")
-        var expStoppedSecond = expectation(description: "\(#function)\(#line)")
+        let expStartedSecond = expectation(description: "\(#function)\(#line)")
+        let expStoppedSecond = expectation(description: "\(#function)\(#line)")
 
         expStartedSecond.expectedFulfillmentCount = 2
         expStoppedSecond.expectedFulfillmentCount = 2


### PR DESCRIPTION
Fixes #1627 
Fixes #1467 

When a call is ended, we remove the observer from the darwin notification center, but since the handler is still stored in the array, we retain the `NCCallController`. Since the starting/stopping of broadcasting is systemwide, all `NCCallControllers` will try to handle it and create publishers. 
An alternative would be to use a `weakself` in the handler itself, but this should be more failsafe