### PR TITLE
Fix race condition when retrieving current output

### DIFF
--- a/NextcloudTalk/NCAudioController.m
+++ b/NextcloudTalk/NCAudioController.m
@@ -131,13 +131,9 @@ NSString * const AudioSessionDidChangeRoutingInformationNotification   = @"Audio
 - (void)updateRouteInformation
 {
     AVAudioSession *audioSession = self.rtcAudioSession.session;
-    AVAudioSessionPortDescription *currentOutput = nil;
+    AVAudioSessionPortDescription *currentOutput = [audioSession.currentRoute.outputs firstObject];
 
     self.numberOfAvailableInputs = audioSession.availableInputs.count;
-
-    if (audioSession.currentRoute.outputs.count > 0) {
-        currentOutput = audioSession.currentRoute.outputs[0];
-    }
 
     if ([_rtcAudioSession mode] == AVAudioSessionModeVideoChat || [currentOutput.portType isEqualToString:AVAudioSessionPortBuiltInSpeaker]) {
         self.isSpeakerActive = YES;


### PR DESCRIPTION
Reported on appstore connect, not really able to reproduce it. But `firstObject` returns either the first object or `nil` in case the array is empty, so I guess we should use that one.