### PR TITLE
Fix message expiration

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		1FB78E272B6AE8C900B0D69D /* FederationInvitation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB78E252B6AE5A600B0D69D /* FederationInvitation.swift */; };
 		1FB78E282B6AE8C900B0D69D /* FederationInvitation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB78E252B6AE5A600B0D69D /* FederationInvitation.swift */; };
 		1FB78E292B6AE8CA00B0D69D /* FederationInvitation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB78E252B6AE5A600B0D69D /* FederationInvitation.swift */; };
+		1FB7B9852BE2EE020093CE98 /* UnitChatViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB7B9842BE2EE020093CE98 /* UnitChatViewControllerTest.swift */; };
 		1FBC3BE52B61ACD5003909E0 /* UnitChatCellTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBC3BE42B61ACD5003909E0 /* UnitChatCellTest.swift */; };
 		1FBC3BE92B61BD09003909E0 /* TestBaseRealm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBC3BE82B61BD09003909E0 /* TestBaseRealm.swift */; };
 		1FC940B92A5F21FC00FFFADE /* SwiftMarkdownObjCBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0A1D432A5F1FA800A25433 /* SwiftMarkdownObjCBridge.swift */; };
@@ -666,6 +667,7 @@
 		1FB6678E28CE381300D29F8D /* SubtitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubtitleTableViewCell.swift; sourceTree = "<group>"; };
 		1FB78E1E2B6ADBAA00B0D69D /* NCAPIControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCAPIControllerExtensions.swift; sourceTree = "<group>"; };
 		1FB78E252B6AE5A600B0D69D /* FederationInvitation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FederationInvitation.swift; sourceTree = "<group>"; };
+		1FB7B9842BE2EE020093CE98 /* UnitChatViewControllerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitChatViewControllerTest.swift; sourceTree = "<group>"; };
 		1FBC3BE42B61ACD5003909E0 /* UnitChatCellTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitChatCellTest.swift; sourceTree = "<group>"; };
 		1FBC3BE82B61BD09003909E0 /* TestBaseRealm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBaseRealm.swift; sourceTree = "<group>"; };
 		1FD6F83B2B825069004048AB /* NCRoomsManagerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NCRoomsManagerExtensions.swift; sourceTree = "<group>"; };
@@ -1241,6 +1243,7 @@
 				1FBC3BE82B61BD09003909E0 /* TestBaseRealm.swift */,
 				1F5CDAE62B3B05110040ECC0 /* UnitColorGeneratorTest.swift */,
 				1F0B0A762BA26BE10073FF8D /* UnitMentionSuggestionTest.swift */,
+				1FB7B9842BE2EE020093CE98 /* UnitChatViewControllerTest.swift */,
 				1FBC3BE42B61ACD5003909E0 /* UnitChatCellTest.swift */,
 			);
 			path = Unit;
@@ -2516,6 +2519,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1FB7B9852BE2EE020093CE98 /* UnitChatViewControllerTest.swift in Sources */,
 				1F6D8C4B2B2F5B61004376B8 /* TestBase.swift in Sources */,
 				1F6D8C332B2E3756004376B8 /* IntegrationRoomTest.swift in Sources */,
 				1FBC3BE92B61BD09003909E0 /* TestBaseRealm.swift in Sources */,

--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -449,7 +449,8 @@ import UIKit
         DispatchQueue.main.async {
             let currentTimestamp = Int(Date().timeIntervalSince1970)
 
-            for sectionIndex in self.dateSections.indices {
+            // Iterate backwards in case we need to delete multiple sections in one go
+            for sectionIndex in self.dateSections.indices.reversed() {
                 let section = self.dateSections[sectionIndex]
 
                 guard let messages = self.messages[section] else { continue }
@@ -469,7 +470,7 @@ import UIKit
                     } else {
                         self.messages.removeValue(forKey: section)
                         self.sortDateSections()
-                        self.tableView?.deleteSections(IndexSet(integer: sectionIndex), with: .top  )
+                        self.tableView?.deleteSections(IndexSet(integer: sectionIndex), with: .top)
                     }
 
                     self.tableView?.endUpdates()

--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -440,7 +440,7 @@ import UIKit
     func startObservingExpiredMessages() {
         self.messageExpirationTimer?.invalidate()
         self.removeExpiredMessages()
-        self.messageExpirationTimer = Timer(timeInterval: 30.0, repeats: true, block: { [weak self] _ in
+        self.messageExpirationTimer = Timer.scheduledTimer(withTimeInterval: 30.0, repeats: true, block: { [weak self] _ in
             self?.removeExpiredMessages()
         })
     }

--- a/NextcloudTalkTests/Unit/TestBaseRealm.swift
+++ b/NextcloudTalkTests/Unit/TestBaseRealm.swift
@@ -44,6 +44,8 @@ class TestBaseRealm: XCTestCase {
         let account = TalkAccount()
         account.accountId = fakeAccountId
         account.active = true
+        account.user = TestConstants.username
+        account.server = TestConstants.server
 
         try? realm.transaction {
             realm.add(account)

--- a/NextcloudTalkTests/Unit/UnitChatViewControllerTest.swift
+++ b/NextcloudTalkTests/Unit/UnitChatViewControllerTest.swift
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2024 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import NextcloudTalk
+
+final class UnitChatViewControllerTest: TestBaseRealm {
+
+    func testLocalMention() throws {
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        let roomName = "Expire Messages Test Room"
+        let roomToken = "expToken"
+
+        let room = NCRoom()
+        room.token = roomToken
+        room.name = roomName
+        room.accountId = activeAccount.accountId
+
+        // Create 2 messages which are in different sections
+        let expMessage1 = NCChatMessage()
+
+        expMessage1.internalId = "internal1"
+        expMessage1.accountId = activeAccount.accountId
+        expMessage1.actorDisplayName = activeAccount.userDisplayName
+        expMessage1.actorId = activeAccount.userId
+        expMessage1.actorType = "users"
+        expMessage1.timestamp = Int(Date().timeIntervalSince1970) - 1000000
+        expMessage1.expirationTimestamp = Int(Date().timeIntervalSince1970) - 1000
+        expMessage1.token = roomToken
+        expMessage1.message = "Message 1"
+
+        let expMessage2 = NCChatMessage()
+
+        expMessage2.internalId = "internal2"
+        expMessage2.accountId = activeAccount.accountId
+        expMessage2.actorDisplayName = activeAccount.userDisplayName
+        expMessage2.actorId = activeAccount.userId
+        expMessage2.actorType = "users"
+        expMessage2.timestamp = Int(Date().timeIntervalSince1970)
+        expMessage2.expirationTimestamp = Int(Date().timeIntervalSince1970) - 1000
+        expMessage2.token = roomToken
+        expMessage2.message = "Message 2"
+
+        try? realm.transaction {
+            realm.add(room)
+            realm.add(expMessage1)
+            realm.add(expMessage2)
+        }
+
+        XCTAssertEqual(NCChatMessage.allObjects().count, 2)
+
+        let chatViewController = ChatViewController(for: room)!
+        let messageArray = [expMessage1, expMessage2].map { NCChatMessage(value: $0) }
+
+        chatViewController.appendMessages(messages: messageArray)
+        chatViewController.removeExpiredMessages()
+
+        // Since removeExpiredMessages is dispatched, we need to wait until it was scheduled
+        var exp = expectation(description: "\(#function)\(#line)")
+
+        DispatchQueue.main.async {
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: TestConstants.timeoutShort, handler: nil)
+
+        XCTAssertEqual(NCChatMessage.allObjects().count, 0)
+    }
+}


### PR DESCRIPTION
Seen on appstore connect. Two issues:

* The expiration timer is created but never scheduled
* We iterate forward to remove expired messages, so when we remove a whole section we crash when we try to remove another section 