### PR TITLE
Fix crash when Talk folder does not exist

### DIFF
--- a/ShareExtension/ShareConfirmationViewController.swift
+++ b/ShareExtension/ShareConfirmationViewController.swift
@@ -674,9 +674,8 @@ import AVFoundation
                         self.uploadFile(to: fileServerURL, with: filePath, with: item)
                     } else {
                         self.uploadErrors.append(nkError.errorDescription)
+                        self.uploadGroup.leave()
                     }
-
-                    self.uploadGroup.leave()
                 }
             } else {
                 NCUtils.log(String(format: "Failed to upload file. Error: %@", nkError.errorDescription))


### PR DESCRIPTION
Regression from 
https://github.com/nextcloud/talk-ios/blob/5c6953548a15c550ee85179f1da4d377bc8d6935/ShareExtension/ShareConfirmationViewController.m#L498-L506

which results in an unbalanced enter/leave and therefore crashes. We only need to call leave when we don't retry to upload the file after folder creation.