### PR TITLE
Use consistent scope button styling on searchbar

### DIFF
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -213,6 +213,10 @@ typedef enum RoomsSections {
     }
     
     _searchController.searchBar.tintColor = [NCAppBranding themeTextColor];
+    [_searchController.searchBar setScopeBarButtonTitleTextAttributes:[NSDictionary dictionaryWithObjectsAndKeys:[NCAppBranding themeTextColor], NSForegroundColorAttributeName, nil] forState:UIControlStateNormal];
+    [_searchController.searchBar setScopeBarButtonTitleTextAttributes:[NSDictionary dictionaryWithObjectsAndKeys:[NCAppBranding themeTextColor], NSForegroundColorAttributeName, nil] forState:UIControlStateSelected];
+    _searchController.searchBar.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+
     UITextField *searchTextField = [_searchController.searchBar valueForKey:@"searchField"];
     UIButton *clearButton = [searchTextField valueForKey:@"_clearButton"];
     searchTextField.tintColor = [NCAppBranding themeTextColor];


### PR DESCRIPTION
The scope buttons always look a bit weird in light mode, because they are not themed:
<img width="368" alt="Bildschirmfoto 2024-04-29 um 21 18 24" src="https://github.com/nextcloud/talk-ios/assets/1580193/3a7c23e0-c934-4c66-90df-5e23dc36f3fd">

It looks nice in dark mode, so we force the dark mode style on the searchbar:

<img width="370" alt="image" src="https://github.com/nextcloud/talk-ios/assets/1580193/d4230b51-4a61-45c8-b987-1e768129abeb">
