### PR TITLE
Fix crash when quoting a shared deck card

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -212,6 +212,8 @@
 		1FB78E282B6AE8C900B0D69D /* FederationInvitation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB78E252B6AE5A600B0D69D /* FederationInvitation.swift */; };
 		1FB78E292B6AE8CA00B0D69D /* FederationInvitation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB78E252B6AE5A600B0D69D /* FederationInvitation.swift */; };
 		1FB7B9852BE2EE020093CE98 /* UnitChatViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB7B9842BE2EE020093CE98 /* UnitChatViewControllerTest.swift */; };
+		1FB7B9872BE441450093CE98 /* UIViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB7B9862BE441450093CE98 /* UIViewExtensions.swift */; };
+		1FB7B9892BE442400093CE98 /* UnitBaseChatTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB7B9882BE442400093CE98 /* UnitBaseChatTableViewCell.swift */; };
 		1FBC3BE52B61ACD5003909E0 /* UnitChatCellTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBC3BE42B61ACD5003909E0 /* UnitChatCellTest.swift */; };
 		1FBC3BE92B61BD09003909E0 /* TestBaseRealm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBC3BE82B61BD09003909E0 /* TestBaseRealm.swift */; };
 		1FC940B92A5F21FC00FFFADE /* SwiftMarkdownObjCBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0A1D432A5F1FA800A25433 /* SwiftMarkdownObjCBridge.swift */; };
@@ -672,6 +674,8 @@
 		1FB78E1E2B6ADBAA00B0D69D /* NCAPIControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCAPIControllerExtensions.swift; sourceTree = "<group>"; };
 		1FB78E252B6AE5A600B0D69D /* FederationInvitation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FederationInvitation.swift; sourceTree = "<group>"; };
 		1FB7B9842BE2EE020093CE98 /* UnitChatViewControllerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitChatViewControllerTest.swift; sourceTree = "<group>"; };
+		1FB7B9862BE441450093CE98 /* UIViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtensions.swift; sourceTree = "<group>"; };
+		1FB7B9882BE442400093CE98 /* UnitBaseChatTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitBaseChatTableViewCell.swift; sourceTree = "<group>"; };
 		1FBC3BE42B61ACD5003909E0 /* UnitChatCellTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitChatCellTest.swift; sourceTree = "<group>"; };
 		1FBC3BE82B61BD09003909E0 /* TestBaseRealm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestBaseRealm.swift; sourceTree = "<group>"; };
 		1FD6F83B2B825069004048AB /* NCRoomsManagerExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NCRoomsManagerExtensions.swift; sourceTree = "<group>"; };
@@ -1245,11 +1249,13 @@
 			isa = PBXGroup;
 			children = (
 				1FBC3BE82B61BD09003909E0 /* TestBaseRealm.swift */,
+				1FB7B9862BE441450093CE98 /* UIViewExtensions.swift */,
 				1F5CDAE62B3B05110040ECC0 /* UnitColorGeneratorTest.swift */,
 				1F1B0F242BD94A0D003FD766 /* UnitDarwinCenterTest.swift */,
 				1F0B0A762BA26BE10073FF8D /* UnitMentionSuggestionTest.swift */,
 				1FB7B9842BE2EE020093CE98 /* UnitChatViewControllerTest.swift */,
 				1FBC3BE42B61ACD5003909E0 /* UnitChatCellTest.swift */,
+				1FB7B9882BE442400093CE98 /* UnitBaseChatTableViewCell.swift */,
 			);
 			path = Unit;
 			sourceTree = "<group>";
@@ -2530,9 +2536,11 @@
 				1F6D8C332B2E3756004376B8 /* IntegrationRoomTest.swift in Sources */,
 				1FBC3BE92B61BD09003909E0 /* TestBaseRealm.swift in Sources */,
 				1F6D8C4D2B2F8FE5004376B8 /* IntegrationChatTest.swift in Sources */,
+				1FB7B9892BE442400093CE98 /* UnitBaseChatTableViewCell.swift in Sources */,
 				1F5CDAE72B3B05110040ECC0 /* UnitColorGeneratorTest.swift in Sources */,
 				1F1B0F252BD94A0D003FD766 /* UnitDarwinCenterTest.swift in Sources */,
 				1F6D8C412B2F26D5004376B8 /* TestConstants.swift in Sources */,
+				1FB7B9872BE441450093CE98 /* UIViewExtensions.swift in Sources */,
 				1FBC3BE52B61ACD5003909E0 /* UnitChatCellTest.swift in Sources */,
 				1F0B0A772BA26BE10073FF8D /* UnitMentionSuggestionTest.swift in Sources */,
 				1F6D8C432B2F26EE004376B8 /* Helpers.swift in Sources */,

--- a/NextcloudTalk/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/BaseChatTableViewCell.swift
@@ -201,8 +201,10 @@ class BaseChatTableViewCell: UITableViewCell, ReactionsViewDelegate {
         if let parent {
             self.showQuotePart()
 
+            let quoteString = parent.parsedMarkdownForChat()?.string ?? ""
+
             self.quotedMessageView?.actorLabel.text = parent.actorDisplayName.isEmpty ? NSLocalizedString("Guest", comment: "") : parent.actorDisplayName
-            self.quotedMessageView?.messageLabel.text = parent.parsedMarkdownForChat().string
+            self.quotedMessageView?.messageLabel.text = quoteString
             self.quotedMessageView?.highlighted = parent.isMessage(fromUser: activeAccount.userId)
 
             self.quotedMessageView?.avatarView.setActorAvatar(forMessage: parent)

--- a/NextcloudTalk/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/BaseChatTableViewCell.swift
@@ -202,11 +202,16 @@ class BaseChatTableViewCell: UITableViewCell, ReactionsViewDelegate {
             self.showQuotePart()
 
             let quoteString = parent.parsedMarkdownForChat()?.string ?? ""
-
-            self.quotedMessageView?.actorLabel.text = parent.actorDisplayName.isEmpty ? NSLocalizedString("Guest", comment: "") : parent.actorDisplayName
             self.quotedMessageView?.messageLabel.text = quoteString
-            self.quotedMessageView?.highlighted = parent.isMessage(fromUser: activeAccount.userId)
 
+            var parentActorDisplayName = parent.actorDisplayName ?? ""
+
+            if parentActorDisplayName.isEmpty {
+                parentActorDisplayName = NSLocalizedString("Guest", comment: "")
+            }
+
+            self.quotedMessageView?.actorLabel.text = parentActorDisplayName
+            self.quotedMessageView?.highlighted = parent.isMessage(fromUser: activeAccount.userId)
             self.quotedMessageView?.avatarView.setActorAvatar(forMessage: parent)
         }
 

--- a/NextcloudTalkTests/Unit/UIViewExtensions.swift
+++ b/NextcloudTalkTests/Unit/UIViewExtensions.swift
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2024 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+
+import Foundation
+
+extension UIView {
+    // From https://stackoverflow.com/a/36388769
+    class func fromNib<T: UIView>() -> T {
+        // swiftlint:disable:next force_cast
+        return Bundle(for: T.self).loadNibNamed(String(describing: T.self), owner: nil, options: nil)![0] as! T
+    }
+}

--- a/NextcloudTalkTests/Unit/UnitBaseChatTableViewCell.swift
+++ b/NextcloudTalkTests/Unit/UnitBaseChatTableViewCell.swift
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2024 Marcel Müller <marcel-mueller@gmx.de>
+//
+// Author Marcel Müller <marcel-mueller@gmx.de>
+//
+// GNU GPL version 3 or any later version
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import NextcloudTalk
+
+final class UnitBaseChatTableViewCell: TestBaseRealm {
+
+    func testSharedDeckCardQuote() throws {
+        let deckObject = """
+{
+    "actor": {
+        "type": "user",
+        "id": "admin",
+        "name": "admin"
+    },
+    "object": {
+        "id": "9810",
+        "name": "Test",
+        "boardname": "Persönlich",
+        "stackname": "Offen",
+        "link": "https://nextcloud-mm.local/apps/deck/card/9810",
+        "type": "deck-card",
+        "icon-url": "https://nextcloud-mm.local/ocs/v2.php/apps/spreed/api/v1/room/123/avatar?v=abc"
+    }
+}
+"""
+
+        updateCapabilities { cap in
+            cap.referenceApiSupported = true
+        }
+
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        let roomToken = "token"
+
+        let room = NCRoom()
+        room.token = roomToken
+        room.accountId = activeAccount.accountId
+
+        let deckMessage = NCChatMessage()
+        deckMessage.messageId = 1
+        deckMessage.internalId = "internal-1"
+        deckMessage.token = roomToken
+        deckMessage.message = "existing"
+        deckMessage.messageParametersJSONString = deckObject
+
+        // Chat message with a quote
+        let quoteMessage = NCChatMessage()
+        quoteMessage.message = "test"
+        quoteMessage.token = roomToken
+        quoteMessage.parentId = "internal-1"
+
+        try? realm.transaction {
+            realm.add(room)
+            realm.add(deckMessage)
+            realm.add(quoteMessage)
+        }
+
+        let deckCell: BaseChatTableViewCell = .fromNib()
+        deckCell.setup(for: deckMessage, withLastCommonReadMessage: 0)
+
+        let quoteCell: BaseChatTableViewCell = .fromNib()
+        quoteCell.setup(for: quoteMessage, withLastCommonReadMessage: 0)
+    }
+
+}


### PR DESCRIPTION
`parsedMarkdownForChat` can return `nil` in case a deck card was shared as an object to the chat. We need to take care of that for swift.

<img width="682" alt="image" src="https://github.com/nextcloud/talk-ios/assets/1580193/8421ea82-9ac3-444c-897c-ac472b7cf478">
