### PR TITLE
Fix leave room

### DIFF
--- a/NextcloudTalk/NCRoomsManagerExtensions.swift
+++ b/NextcloudTalk/NCRoomsManagerExtensions.swift
@@ -73,7 +73,7 @@ import Foundation
                 }
 
                 // Set room as active
-                self.activeRooms["token"] = controller
+                self.activeRooms[token] = controller
             } else {
                 if self.joiningAttempts < 3 {
                     NCUtils.log("Error joining room, retrying. \(self.joiningAttempts)")


### PR DESCRIPTION
Regression from the swift migration. Room controller can't be retrieved from the `activeRooms` dict which means we never issue a `leaveRoom` API call.