### PR TITLE
Make sure we correctly cache avatars for up to 24h

### DIFF
--- a/NextcloudTalk/NCAPIControllerExtensions.swift
+++ b/NextcloudTalk/NCAPIControllerExtensions.swift
@@ -255,4 +255,13 @@ import Foundation
             completionBlock(mentions)
         }
     }
+
+    // MARK: - Avatars
+
+    public func getDateHash() -> String {
+        // TODO: Mark private when swift migration is done
+        let dateString = NCUtils.getDate(fromDate: Date())
+
+        return String(NCUtils.sha1(fromString: dateString).prefix(16))
+    }
 }

--- a/NextcloudTalk/NCUtils.swift
+++ b/NextcloudTalk/NCUtils.swift
@@ -201,6 +201,14 @@ import AVFoundation
         return dateFormatter.string(from: date)
     }
 
+    public static func getDate(fromDate date: Date) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .short
+        dateFormatter.timeStyle = .none
+
+        return dateFormatter.string(from: date)
+    }
+
     public static func relativeTimeFromDate(date: Date) -> String {
         let todayDate = Date()
         var ti = date.timeIntervalSince(todayDate)


### PR DESCRIPTION
Until now we used the `SDWebImageRefreshCached` option in SDWebImage to make sure we are using NSURLCache for caching and taking cache-control headers into account. NSURLCache seems to have trouble correctly caching URLs that have a query parameter added to them, which results in a requests made whenever an avatar is requested -> basically ignoring any caches.

We can't provide an `avatarVersion` for all avatars (user avatars, federated conversation avatars, etc.). Therefore we now _disable_ the use of NSURLCache (and therefore rely on the aggressive caching SDWebImage is doing by default) but additionally append a hash from the current date to the URL. This way we can make sure that for each avatar only one request is done per day (as it is currently intended by the cache control header).