### PR TITLE
Don't query the conversation list twice when force-refreshing

### DIFF
--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -800,11 +800,6 @@ NSString * const NCDatabaseManagerRoomCapabilitiesChangedNotification = @"NCData
     TalkAccount *account = [TalkAccount objectsWithPredicate:query].firstObject;
     account.lastPendingFederationInvitationFetch = timestamp;
     [realm commitWriteTransaction];
-
-    [[NSNotificationCenter defaultCenter] postNotificationName:NCDatabaseManagerPendingFederationInvitationsDidChange
-                                                        object:self
-                                                      userInfo:nil];
-
     [bgTask stopBackgroundTask];
 }
 


### PR DESCRIPTION
When we do a force-refresh (that is manually pulling down the conversation list until a refresh is done) we always check for new federated invitations. When we update our timestamp of the last successful invitation update (`updateLastFederationInvitationUpdateForAccountId`) we also notify about `NCDatabaseManagerPendingFederationInvitationsDidChange`, which in turn will force reload the conversation list (again).

Before:
<img width="1703" alt="Bildschirmfoto 2024-06-26 um 22 10 40" src="https://github.com/nextcloud/talk-ios/assets/1580193/b27084b0-a5fb-4e10-8138-e78f6c5688a5">

After:
<img width="1669" alt="Bildschirmfoto 2024-06-26 um 22 11 20" src="https://github.com/nextcloud/talk-ios/assets/1580193/85a28e26-aa78-4251-9634-50bce1d5a51b">

Found while verifying https://github.com/nextcloud/talk-ios/pull/1689

