### PR TITLE
Fix missing room controller in join notification

### DIFF
--- a/NextcloudTalk/NCRoomsManagerExtensions.swift
+++ b/NextcloudTalk/NCRoomsManagerExtensions.swift
@@ -38,6 +38,9 @@ import Foundation
     }
 
     private func joinRoomHelper(_ token: String, forCall call: Bool) {
+        var userInfo: [AnyHashable: Any] = [:]
+        userInfo["token"] = token
+
         if let roomController = self.activeRooms[token] as? NCRoomController {
             if call {
                 roomController.inCall = true
@@ -45,12 +48,11 @@ import Foundation
                 roomController.inChat = true
             }
 
-            NotificationCenter.default.post(name: .NCRoomsManagerDidJoinRoom, object: self, userInfo: ["token": token])
+            userInfo["roomController"] = roomController
+            NotificationCenter.default.post(name: .NCRoomsManagerDidJoinRoom, object: self, userInfo: userInfo)
 
             return
         }
-
-        var userInfo: [AnyHashable: Any] = [:]
 
         self.joiningRoomToken = token
 
@@ -90,7 +92,6 @@ import Foundation
                 NCUtils.log("Could not join room. Status code: \(statusCode). Error: \(error?.localizedDescription ?? "")")
             }
 
-            userInfo["token"] = token
             NotificationCenter.default.post(name: .NCRoomsManagerDidJoinRoom, object: self, userInfo: userInfo)
         }
     }

--- a/NextcloudTalkTests/Integration/IntegrationRoomsManagerTest.swift
+++ b/NextcloudTalkTests/Integration/IntegrationRoomsManagerTest.swift
@@ -38,6 +38,9 @@ final class IntegrationRoomsManagerTest: TestBase {
             // swiftlint:disable:next force_cast
             XCTAssertEqual(notification.userInfo?["token"] as! String, roomToken)
 
+            // There's no NCRoomController when joining fails
+            XCTAssertNil(notification.userInfo?["roomController"])
+
             return true
         }
 
@@ -76,6 +79,9 @@ final class IntegrationRoomsManagerTest: TestBase {
 
             // Check if the NCRoomController was correctly added to the activeRooms dictionary
             XCTAssertNotNil(NCRoomsManager.sharedInstance().activeRooms[roomToken])
+
+            // When successfully joined, the NCRoomController should be included in the notification
+            XCTAssertNotNil(notification.userInfo?["roomController"])
 
             return true
         }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/talk-ios/issues/1693

The `roomController` was missing in the join notification when internal signaling is used and the controller was already in `activeRooms` dictionary.