### PR TITLE
Close context menus before hanging up

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1494,7 +1494,11 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
             [_chatViewController leaveChat];
             _chatViewController = nil;
         }
-        
+
+        // Make sure there's no menu interfering with our dismissal
+        [self.moreMenuButton.contextMenuInteraction dismissMenu];
+        [self.hangUpButton.contextMenuInteraction dismissMenu];
+
         [self.delegate callViewControllerWantsToBeDismissed:self];
         
         [_callController stopCapturing];


### PR DESCRIPTION
When a context menu is opened on the screen, the call to `dismissViewControllerAnimated` will close the context menu, instead of the complete view controller. This leads to the problem, that we are already in the "hang up phase", e.g. `hangingUp` is set to true, but we never dismiss the call view controller.