### PR TITLE
Only use allocation tracking in test environment

### DIFF
--- a/NextcloudTalk/AllocationTracker.swift
+++ b/NextcloudTalk/AllocationTracker.swift
@@ -26,12 +26,25 @@ import UIKit
     public static let shared = AllocationTracker()
 
     private var allocationDict: [String: Int] = [:]
+    private lazy var isTestEnvironment = {
+        let arguments = ProcessInfo.processInfo.arguments
+
+        return arguments.contains(where: { $0 == "-TestEnvironment" })
+    }()
 
     public func addAllocation(_ name: String) {
+        if !isTestEnvironment {
+            return
+        }
+
         allocationDict[name, default: 0] += 1
     }
 
     public func removeAllocation(_ name: String) {
+        if !isTestEnvironment {
+            return
+        }
+
         if let currentAllocations = allocationDict[name] {
             if currentAllocations == 1 {
                 allocationDict.removeValue(forKey: name)
@@ -44,6 +57,10 @@ import UIKit
     }
 
     override var description: String {
+        if !isTestEnvironment {
+            return "Not running in testing environment."
+        }
+
         if let jsonData = try? JSONSerialization.data(withJSONObject: allocationDict, options: .sortedKeys),
            let jsonString = String(data: jsonData, encoding: .utf8) {
 


### PR DESCRIPTION
I've seen a crash in background fetch where we access the dictionary from another thread (since the background fetch is not happening on main we are allocation a `NCChatController` in a non-main thread). This leads to a concurrency crash in some cases. But since there's no need to track allocations outside of testing environments, we can just ignore this.