### PR TITLE
Don't navigate when the app is not active

### DIFF
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1476,6 +1476,14 @@ typedef enum RoomsSections {
     [self setSelectedRoomToken:nil];
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
+    BOOL isAppInForeground = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
+
+    if (!isAppInForeground) {
+        // In case we are not in the active state, we don't want to invoke any navigation event as this might
+        // lead to crashes, when the wrong NavBar is referenced
+        return;
+    }
+
     if (tableView == self.tableView && indexPath.section == kRoomsSectionPendingFederationInvitation) {
         FederationInvitationTableViewController *federationInvitationVC = [[FederationInvitationTableViewController alloc] init];
         NCNavigationController *navigationController = [[NCNavigationController alloc] initWithRootViewController:federationInvitationVC];


### PR DESCRIPTION
How to test the crashes:

```diff
diff --git a/NextcloudTalk/RoomsTableViewController.m b/NextcloudTalk/RoomsTableViewController.m
index b7ab87ed..6ca0a412 100644
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -376,6 +376,11 @@ typedef enum RoomsSections {
 - (void)appWillResignActive:(NSNotification *)notification
 {
     [self stopRefreshRoomsTimer];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NCRoom *room =  [_rooms objectAtIndex:1];
+        [[NCRoomsManager sharedInstance] startChatInRoom:room];
+    });
 }
 
 - (void)roomCreated:(NSNotification *)notification
 ```

* Enter a conversation that is not at index 1
* Move app to the foreground
* Try to leave the conversation
* 💣