### PR TITLE
Verify existance of room capabilities

### DIFF
--- a/NextcloudTalk/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/BaseChatTableViewCell.swift
@@ -188,12 +188,14 @@ class BaseChatTableViewCell: UITableViewCell, ReactionsViewDelegate {
 
         let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
 
-        guard let room = NCDatabaseManager.sharedInstance().room(withToken: message.token, forAccountId: activeAccount.accountId),
-              let roomCapabilities = NCDatabaseManager.sharedInstance().roomTalkCapabilities(for: room)
+        guard let room = NCDatabaseManager.sharedInstance().room(withToken: message.token, forAccountId: activeAccount.accountId)
         else { return }
 
         let shouldShowDeliveryStatus = NCDatabaseManager.sharedInstance().roomHasTalkCapability(kCapabilityChatReadStatus, for: room)
-        let shouldShowReadStatus = !roomCapabilities.readStatusPrivacy
+
+        // In case we are not able to retrieve the capabilities of the room, we fall back to readPrivacy = true -> hiding the read status
+        let roomCapabilities = NCDatabaseManager.sharedInstance().roomTalkCapabilities(for: room)
+        let shouldShowReadStatus = !(roomCapabilities?.readStatusPrivacy ?? true)
 
         // This check is just a workaround to fix the issue with the deleted parents returned by the API.
         if let parent = message.parent {

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -3297,7 +3297,15 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     NSPredicate *query = [NSPredicate predicateWithFormat:@"token = %@ AND accountId = %@", token, account.accountId];
     NCRoom *managedRoom = [NCRoom objectsWithPredicate:query].firstObject;
 
-    if (!managedRoom || [proxyHash isEqualToString:managedRoom.lastReceivedProxyHash]) {
+    if (!managedRoom) {
+        // The room is not known to us locally, don't try to fetch room capabilities
+        return;
+    }
+
+    FederatedCapabilities *federatedCapabilities = [[NCDatabaseManager sharedInstance] federatedCapabilitiesForAccountId:managedRoom.accountId remoteServer:managedRoom.remoteServer roomToken:managedRoom.token];
+
+    if ([proxyHash isEqualToString:managedRoom.lastReceivedProxyHash] && federatedCapabilities != nil) {
+        // The proxy hash is equal to our last known proxy hash and we are also able to retrieve capabilities locally -> skip fetching capabilities
         return;
     }
 


### PR DESCRIPTION
 In case a `remoteServer` was changed on the backend, that change is reflected in our locally stored `NCRoom` object. Because of the change we are unable to find our locally stored capabilities for that room anymore. This results in 2 problems:

* When rendering messages of a room, we enforce the existence of capabilities, since we are unable to get the capabilities, we will only render empty messages.
* The logic to update the capabilities solely relies on the comparison of the received hash. Since that hash did not change when the `remoteServer` was changed, we just assume that we already have the capabilities and don't try to retrieve them again.

This PR makes sure that
* Render messages even without capabilities (it only affects showing the read status or not)
* In case the capabilities hash is already known, verify that we correctly stored the capabilities