### PR TITLE
Ensure that we leave the room on the server in all cases

### DIFF
--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -713,6 +713,17 @@ import UIKit
     }
 
     func didLeaveRoom(notification: Notification) {
+        guard let token = notification.userInfo?["token"] as? String else { return }
+
+        if token != self.room.token {
+            return
+        }
+
+        if notification.userInfo?["error"] != nil {
+            // In case an error occurred when leaving the room, we assume we are still joined
+            return
+        }
+
         self.hasJoinedRoom = false
         self.disableRoomControls()
         self.checkRoomControlsAvailability()

--- a/NextcloudTalk/NCRoomsManager.h
+++ b/NextcloudTalk/NCRoomsManager.h
@@ -40,6 +40,7 @@ typedef void (^SendOfflineMessagesCompletionBlock)(void);
 // START - Public for swift migration
 @property (nonatomic, strong) NSMutableDictionary *activeRooms; //roomToken -> roomController
 @property (nonatomic, strong, nullable) NSString *joiningRoomToken;
+@property (nonatomic, strong, nullable) NSString *leavingRoomToken;
 @property (nonatomic, strong, nullable) NSString *joiningSessionId;
 @property (nonatomic, assign) NSInteger joiningAttempts;
 @property (nonatomic, strong, nullable) NSURLSessionTask *joinRoomTask;

--- a/NextcloudTalkTests/Integration/IntegrationRoomsManagerTest.swift
+++ b/NextcloudTalkTests/Integration/IntegrationRoomsManagerTest.swift
@@ -79,6 +79,9 @@ final class IntegrationRoomsManagerTest: TestBase {
         expectation(forNotification: .NCRoomsManagerDidLeaveRoom, object: nil) { notification -> Bool in
             XCTAssertNil(notification.userInfo?["error"])
 
+            // swiftlint:disable:next force_cast
+            XCTAssertEqual(notification.userInfo?["token"] as! String, roomToken)
+
             // Check if the NCRoomController was correctly removed from the activeRooms dictionary
             XCTAssertNil(NCRoomsManager.sharedInstance().activeRooms[roomToken])
 


### PR DESCRIPTION
Investigated cases where a talk-session was not correctly removed from the server (so we did not leave the room correctly).

The problem is a race-condition between joining the room (and especially the external signaling controller) and leaving the room.

**Correct behavior**
* User joins room
  * Joining the room in Nextcloud
  * Joining the room in external signaling controller
* UI reflects that we joined the room successfully
* User leaves room
  * Leave the room in Nextcloud
  * Leave the room in external signaling controller

**Problematic behavior**
* User joins room
  * Joining the room in Nextcloud
* User leaves room (e.g. moving the app to the background again)
  * Joining the room in external signaling controller

When the user leaves the room in between joining the Nextcloud instance and the external signaling controller, we ignore that join attempt and don't process it any further. But we already have an active talk-session on the server. 

The "User leaves room" action does not do anything, as we did not "fully" joined (that is the Nextcloud instance and the external signaling controller) the room.

Therefore we end up in a situation, where we have an active session that is never ended from the client side. This can be problematic for chat messages, as we will not receive text messages in the following 30s until the server ignores the session again.