### PR TITLE
Fix rare crashes

### DIFF
--- a/NextcloudTalk/AvatarManager.swift
+++ b/NextcloudTalk/AvatarManager.swift
@@ -31,7 +31,7 @@ import SDWebImage
     // MARK: - Conversation avatars
 
     public func getAvatar(for room: NCRoom, with style: UIUserInterfaceStyle, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
-        if NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityConversationAvatars, forAccountId: room.accountId) {
+        if room.accountId != nil, NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityConversationAvatars, forAccountId: room.accountId) {
             // Server supports conversation avatars -> try to get the avatar using this API
 
             return NCAPIController.sharedInstance().getAvatarFor(room, with: style) { image, _ in

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -249,7 +249,11 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
                 NSLog(@"Room updated");
             }];
             NCRoom *updatedRoom = [[NCDatabaseManager sharedInstance] roomWithToken:token forAccountId:activeAccount.accountId];
-            [userInfo setObject:updatedRoom forKey:@"room"];
+
+            if (updatedRoom) {
+                // It seems to be somehow possible to have the updatedRoom be nil as seen in AppStore crashes
+                [userInfo setObject:updatedRoom forKey:@"room"];
+            }
         } else {
             [userInfo setObject:error forKey:@"error"];
             NSLog(@"Could not update rooms. Error: %@", error.description);

--- a/NextcloudTalk/NCUtils.swift
+++ b/NextcloudTalk/NCUtils.swift
@@ -83,6 +83,10 @@ import AVFoundation
         return self.previewImage(forMimeType: fileType) == "file-image"
     }
 
+    public static func isImage(fileExtension: String) -> Bool {
+        return self.previewImage(forFileExtension: fileExtension) == "file-image"
+    }
+
     public static func isVideo(fileType: String) -> Bool {
         return self.previewImage(forMimeType: fileType) == "file-video"
     }

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -648,6 +648,7 @@ typedef enum RoomsSections {
         [self.tableView reloadData];
     } else {
         _resultTableViewController.rooms = [self filterRooms:filteredRooms withString:searchString];
+        [self calculateLastRoomWithMention];
     }
 }
 
@@ -906,24 +907,25 @@ typedef enum RoomsSections {
     
     // Calculate index of first room with a mention outside visible cells
     _nextRoomWithMentionIndexPath = nil;
-    if (_lastRoomWithMentionIndexPath) {
-        for (int i = (int)lastVisibleRowIndexPath.row; i <= (int)_lastRoomWithMentionIndexPath.row; i++) {
-            NCRoom *room = [_rooms objectAtIndex:i];
-            if (room.hasUnreadMention) {
-                _nextRoomWithMentionIndexPath = [NSIndexPath indexPathForRow:i inSection:1];
-                break;
-            }
+
+    if (!_lastRoomWithMentionIndexPath) {
+        return;
+    }
+
+    for (int i = (int)lastVisibleRowIndexPath.row; i <= (int)_lastRoomWithMentionIndexPath.row && i < [_rooms count]; i++) {
+        NCRoom *room = [_rooms objectAtIndex:i];
+        if (room.hasUnreadMention) {
+            _nextRoomWithMentionIndexPath = [NSIndexPath indexPathForRow:i inSection:1];
+            break;
         }
     }
-    
-    // Update unread mentions indicator visibility
-    if (_lastRoomWithMentionIndexPath) {
-        _unreadMentionsBottomButton.hidden = [visibleRows containsObject:_lastRoomWithMentionIndexPath] || lastVisibleRowIndexPath.row > _lastRoomWithMentionIndexPath.row;
 
-        // Make sure the style is adjusted to current accounts theme
-        _unreadMentionsBottomButton.backgroundColor = [NCAppBranding themeColor];
-        [_unreadMentionsBottomButton setTitleColor:[NCAppBranding themeTextColor] forState:UIControlStateNormal];
-    }
+    // Update unread mentions indicator visibility
+    _unreadMentionsBottomButton.hidden = [visibleRows containsObject:_lastRoomWithMentionIndexPath] || lastVisibleRowIndexPath.row > _lastRoomWithMentionIndexPath.row;
+
+    // Make sure the style is adjusted to current accounts theme
+    _unreadMentionsBottomButton.backgroundColor = [NCAppBranding themeColor];
+    [_unreadMentionsBottomButton setTitleColor:[NCAppBranding themeTextColor] forState:UIControlStateNormal];
 }
 
 - (void)unreadMentionsBottomButtonPressed:(id)sender

--- a/NextcloudTalk/SettingsTableViewController.swift
+++ b/NextcloudTalk/SettingsTableViewController.swift
@@ -80,9 +80,9 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate, U
 
     var activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
     var inactiveAccounts = NCDatabaseManager.sharedInstance().inactiveAccounts()
-    var serverCapabilities: ServerCapabilities {
+    var serverCapabilities: ServerCapabilities? {
         // Since NCDatabaseManager already caches the capabilities, we don't need a lazy var here
-        NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: activeAccount.accountId)!
+        NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: activeAccount.accountId)
     }
 
     lazy var profilePictures: [String: UIImage] = {
@@ -172,7 +172,7 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate, U
         sections.append(SettingsSection.kSettingsSectionUser.rawValue)
 
         // User status section
-        if serverCapabilities.userStatus {
+        if serverCapabilities?.userStatus ?? false {
             sections.append(SettingsSection.kSettingsSectionUserStatus.rawValue)
         }
 
@@ -874,7 +874,7 @@ extension SettingsTableViewController {
             cell.selectionStyle = .none
             cell.setSettingsImage(image: UIImage(named: "check-all"))
             cell.accessoryView = readStatusSwitch
-            readStatusSwitch.isOn = !serverCapabilities.readStatusPrivacy
+            readStatusSwitch.isOn = !(serverCapabilities?.readStatusPrivacy ?? true)
 
         case AccountSettingsOptions.kAccountSettingsTypingPrivacy.rawValue:
             cell = tableView.dequeueReusableCell(withIdentifier: typingIndicatorCellIdentifier) ?? UITableViewCell(style: .subtitle, reuseIdentifier: typingIndicatorCellIdentifier)
@@ -883,7 +883,7 @@ extension SettingsTableViewController {
             cell.setSettingsImage(image: UIImage(systemName: "rectangle.and.pencil.and.ellipsis")?.applyingSymbolConfiguration(iconConfiguration))
 
             cell.accessoryView = typingIndicatorSwitch
-            typingIndicatorSwitch.isOn = !serverCapabilities.typingPrivacy
+            typingIndicatorSwitch.isOn = !(serverCapabilities?.typingPrivacy ?? true)
 
             let externalSignalingController = NCSettingsController.sharedInstance().externalSignalingController(forAccountId: activeAccount.accountId)
             let externalSignalingServerUsed = externalSignalingController != nil

--- a/ShareExtension/ShareConfirmationViewController.swift
+++ b/ShareExtension/ShareConfirmationViewController.swift
@@ -622,10 +622,9 @@ import AVFoundation
             self.stopAnimatingSharingIndicator()
             self.hud?.hide(animated: true)
 
-            self.shareItemController.removeAllItems()
-
             // TODO: Do error reporting per item
             if self.uploadErrors.isEmpty {
+                self.shareItemController.removeAllItems()
                 self.delegate?.shareConfirmationViewControllerDidFinish(self)
             } else {
                 let alert = UIAlertController(title: NSLocalizedString("Upload failed", comment: ""),
@@ -664,6 +663,9 @@ import AVFoundation
                     if let error {
                         NCUtils.log(String(format: "Failed to share file. Error: %@", error.localizedDescription))
                         self.uploadErrors.append(error.localizedDescription)
+                    } else {
+                        // When upload was successful, remove the item so only the failed items are kept
+                        self.shareItemController.remove(item)
                     }
 
                     self.uploadGroup.leave()

--- a/ShareExtension/ShareConfirmationViewController.swift
+++ b/ShareExtension/ShareConfirmationViewController.swift
@@ -70,6 +70,7 @@ import AVFoundation
     private var uploadGroup = DispatchGroup()
     private var uploadFailed = false
     private var uploadErrors: [String] = []
+    private var uploadSuccess: [ShareItem] = []
 
     private enum ShareConfirmationType {
         case text
@@ -589,6 +590,7 @@ import AVFoundation
 
         self.uploadGroup = DispatchGroup()
         self.uploadErrors = []
+        self.uploadSuccess = []
 
         // Add caption to last shareItem
         if let shareItem = self.shareItemController.shareItems.last {
@@ -627,6 +629,9 @@ import AVFoundation
                 self.shareItemController.removeAllItems()
                 self.delegate?.shareConfirmationViewControllerDidFinish(self)
             } else {
+                // We remove the successfully uploaded items, so only the failed ones are kept
+                self.shareItemController.remove(self.uploadSuccess)
+
                 let alert = UIAlertController(title: NSLocalizedString("Upload failed", comment: ""),
                                               message: self.uploadErrors.joined(separator: "\n"),
                                               preferredStyle: .alert)
@@ -664,8 +669,7 @@ import AVFoundation
                         NCUtils.log(String(format: "Failed to share file. Error: %@", error.localizedDescription))
                         self.uploadErrors.append(error.localizedDescription)
                     } else {
-                        // When upload was successful, remove the item so only the failed items are kept
-                        self.shareItemController.remove(item)
+                        self.uploadSuccess.append(item)
                     }
 
                     self.uploadGroup.leave()

--- a/ShareExtension/ShareConfirmationViewController.swift
+++ b/ShareExtension/ShareConfirmationViewController.swift
@@ -775,7 +775,8 @@ import AVFoundation
         cell.setPlaceHolderImage(item.placeholderImage)
         cell.setPlaceHolderText(item.fileName)
 
-        if let image = self.shareItemController.getImageFrom(item) {
+        if let fileURL = item.fileURL, NCUtils.isImage(fileExtension: fileURL.pathExtension),
+           let image = self.shareItemController.getImageFrom(item) {
             // We're able to get an image directly from the fileURL -> use it
             cell.setPreviewImage(image)
         } else {

--- a/ShareExtension/ShareItemController.h
+++ b/ShareExtension/ShareItemController.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateItem:(ShareItem *)item withImage:(UIImage *)image;
 - (void)updateItem:(ShareItem *)item withURL:(NSURL *)fileURL;
 - (void)removeItem:(ShareItem *)item;
+- (void)removeItems:(NSArray<ShareItem *> *)items;
 - (void)removeAllItems;
 - (UIImage * _Nullable)getImageFromItem:(ShareItem *)item;
 

--- a/ShareExtension/ShareItemController.m
+++ b/ShareExtension/ShareItemController.m
@@ -132,8 +132,8 @@ CGFloat const kShareItemControllerImageQuality = 0.7f;
     
     // Try to determine if the item is an image file
     // This can happen when sharing an image from the native ios files app
-    UIImage *image = [self getImageFromFileURL:fileLocalURL];
-    BOOL fileIsImage = (image != nil);
+    NSString *extension = fileLocalURL.pathExtension;
+    BOOL fileIsImage = (extension && [NCUtils isImageWithFileExtension:extension]);
     
     ShareItem* item = [ShareItem initWithURL:fileLocalURL withName:fileName withPlaceholderImage:[self getPlaceholderImageForFileURL:fileLocalURL] isImage:fileIsImage];
     [self.internalShareItems addObject:item];
@@ -167,15 +167,7 @@ CGFloat const kShareItemControllerImageQuality = 0.7f;
         return nil;
     }
         
-    return [self getImageFromFileURL:item.fileURL];
-}
-
-- (UIImage *)getImageFromFileURL:(NSURL *)fileURL
-{
-    NSData *fileData = [NSData dataWithContentsOfURL:fileURL];
-    UIImage *image = [UIImage imageWithData:fileData];
-    
-    return image;
+    return [UIImage imageWithContentsOfFile:item.filePath];
 }
 
 - (void)addItemWithContactData:(NSData *)data

--- a/ShareExtension/ShareItemController.m
+++ b/ShareExtension/ShareItemController.m
@@ -222,11 +222,18 @@ CGFloat const kShareItemControllerImageQuality = 0.7f;
 
 - (void)removeItem:(ShareItem *)item
 {
-    [self cleanupItem:item];
-    
-    NSLog(@"Removing shareItem: %@ %@", item.fileName, item.fileURL);
-    
-    [self.internalShareItems removeObject:item];
+    [self removeItems:@[item]];
+}
+
+- (void)removeItems:(NSArray<ShareItem *> *)items
+{
+    for (ShareItem *item in items) {
+        [self cleanupItem:item];
+
+        NSLog(@"Removing shareItem: %@ %@", item.fileName, item.fileURL);
+        [self.internalShareItems removeObject:item];
+    }
+
     [self.delegate shareItemControllerItemsChanged:self];
 }
 


### PR DESCRIPTION
The crashes fixed in this PR were reported at AppStore Connect.

* https://github.com/nextcloud/talk-ios/commit/f8e1e572f09ed4f3b26c7416dfb3dd34a6edb767
  It is actually possible that we try to get a room from the `_rooms` array, although that array is empty / has less items than we try to get. 
  * Only have 1 conversation, e.g. with user `admin`
  * Set this conversation to "Unread"
  * Search for the letter "A", see that the conversation `admin` is found
  * Remove the conversation from the web
  * 💣
* https://github.com/nextcloud/talk-ios/commit/92015f6f0beb62a184674766a848da347c94b7aa
  *   The crash report clearly identifies this line and that we try to set a `nil` value in the dictionary. I was not able to reproduce this crash. It seems that the result of the API call needs to succeed (otherwise we wouldn't end up in this line), but we fail to add the room to the database and are therefore unable to retrieve it. If it is actually a race-condition, we might think about moving getting the room inside the transaction. For now this is just a safety check that makes sense anyway.
* https://github.com/nextcloud/talk-ios/commit/2a60f487399c7c8ed1cd720f1f11c7cf95d348da
  * We force-unwrap the capabilities, although it might be possible to open the settings when haven't received the capabilities or when the token was revoked on the server. So make sure that the server capabilities are an optional.
*  https://github.com/nextcloud/talk-ios/commit/86441e3142ab0f1720340eca5704439fa3d1b221
   * This "fix" might not actually be enough, so we need to see. Not really sure how we end up in a situation without an `accountId`, but we should make that an optional in the future in swift.
* https://github.com/nextcloud/talk-ios/commit/f6a4fbbc56351b5aa8687477c8ce3aa147b84dae
  * We always try to generate an `UIImage` from the file we try to share. For big video files this is problematic, because we exceed the memory limit of the ShareExtension. Now we use the file extension to determine the file type and only the try to get an image.
* https://github.com/nextcloud/talk-ios/commit/a277fc0b83f684c2dc0f283ad3d1d67e16abc89b
  * We always remove all share items after the upload finished, regardless of successful or failed. In the failed case, we do not dismiss the ShareConfirmationViewController, so the user is still able to interact with the items. Since we cleared the share items before, any reading of the items will cause a crash. We now directly remove successful files from the share items and leave only the failed items. 
* https://github.com/nextcloud/talk-ios/commit/67c98acb62ae74db8e6c6ac1b3a4b7ba49ff55b7
  * Improve the UX a bit and don't remove each item individually, but as a batch at the end.