### PR TITLE
Fix navigation bar related crashes

### DIFF
--- a/NextcloudTalk/NCSplitViewController.swift
+++ b/NextcloudTalk/NCSplitViewController.swift
@@ -113,6 +113,8 @@
                     // Otherwise UI might break or crash (view not loaded correctly)
                     // This might happen if a chatViewController is shown by a push notification
                     if self.hasActiveChatViewController() {
+                        // First set the placeholderViewController, to make sure it is only referencing one navController
+                        navController.setViewControllers([self.placeholderViewController], animated: false)
                         navController.setViewControllers([vc], animated: false)
                     }
                 }


### PR DESCRIPTION
* Follow-up to https://github.com/nextcloud/talk-ios/pull/1700

This fixes the crashes in the background in my tests. I was still able to reproduce crashes on iPhones that have an iPad UI in landscape when I removed `viewWillTransition` from the split view controller, so I kept that method to prevent these crashes as well. We might want to extend that at some point to correctly set the view hierachy.