### PR TITLE
Add SPDX header for images/infra/ci/translations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md.license
+++ b/.github/ISSUE_TEMPLATE/bug_report.md.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: MIT

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
 blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md.license
+++ b/.github/ISSUE_TEMPLATE/feature_request.md.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: MIT

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
 version: 2
 updates:
 - package-ecosystem: "github-actions"

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
 # Configuration for probot-no-response - https://github.com/probot/no-response
 
 # Number of days of inactivity before an Issue is closed for lack of response

--- a/.github/workflows/localizable.yml
+++ b/.github/workflows/localizable.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
 name: Check for localizable changes
 
 on:

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
 name: SwiftLint
 
 on:

--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
 name: Build main target
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
 Pods
 Podfile.lock
 NextcloudTalk.xcodeproj/xcuserdata

--- a/.pyspelling.yml
+++ b/.pyspelling.yml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
 matrix:
 - name: English localizable file
   aspell:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
 opt_in_rules: # some rules are turned off by default, so you need to opt-in
   - empty_collection_literal
   - empty_count

--- a/LICENSES/LicenseRef-NextcloudTrademarks.txt
+++ b/LICENSES/LicenseRef-NextcloudTrademarks.txt
@@ -1,0 +1,9 @@
+The Nextcloud marks
+Nextcloud and the Nextcloud logo is a registered trademark of Nextcloud GmbH in Germany and/or other countries.
+These guidelines cover the following marks pertaining both to the product names and the logo: “Nextcloud”
+and the blue/white cloud logo with or without the word Nextcloud; the service “Nextcloud Enterprise”;
+and our products: “Nextcloud Files”; “Nextcloud Groupware” and “Nextcloud Talk”.
+This set of marks is collectively referred to as the “Nextcloud marks.”
+
+Use of Nextcloud logos and other marks is only permitted under the guidelines provided by the Nextcloud GmbH.
+A copy can be found at https://nextcloud.com/trademarks/

--- a/LICENSES/LicenseRef-XTrademarks.txt
+++ b/LICENSES/LicenseRef-XTrademarks.txt
@@ -1,0 +1,49 @@
+Trademark policy
+April 2023
+
+
+You may not violate others’ intellectual property rights, including copyright and trademark.
+
+A trademark is a word, logo, phrase, or device that distinguishes a trademark holder’s good or service in the marketplace. Trademark law may prevent others from using a trademark in an unauthorized or confusing manner.  
+
+
+What is in violation of this policy?
+
+Using another’s trademark in a way that may mislead or confuse people about your affiliation may be a violation of our trademark policy.
+ 
+
+What is not a violation of this policy?
+
+Referencing another’s trademark is not automatically a violation of X's trademark policy. Examples of non-violations include:
+
+* using a trademark in a way that is outside the scope of the trademark registration e.g., in a different territory, or a different class of goods or services than that identified in the registration; and
+* using a trademark in a nominative or other fair use manner. For more information, see our Misleading and deceptive identities policy (https://help.twitter.com/en/rules-and-policies/twitter-impersonation-and-deceptive-identities-policy.html).
+ 
+
+Who can report violations of this policy?
+
+X only investigates requests that are submitted by the trademark holder or their authorized representative e.g., a legal representative or other representative for a brand. 
+ 
+
+How can I report violations of this policy?
+
+You can submit a trademark report through our trademark report form (https://help.twitter.com/forms/trademark). Please provide all the information requested in the form. If you submit an incomplete report, we’ll need to follow up about the missing information. Please note that this will result in a delay in processing your report.
+
+Note: We may provide the account holder with your name and other information included in the copy of the report.
+
+
+What happens if you violate this policy?
+
+If we determine that you violated our trademark policy, we may suspend your account. Depending on the type of violation, we may give you an opportunity to comply with our policies. In other instances, an account may be permanently suspended upon first review. If you believe that your account was suspended in error, you can submit an appeal (https://help.twitter.com/forms/general?subtopic=suspended).
+ 
+
+Additional resources
+
+Learn more about our range of enforcement options (https://help.twitter.com/rules-and-policies/enforcement-options) and our approach to policy development and enforcement (https://help.twitter.com/rules-and-policies/enforcement-philosophy).
+
+
+Legal disclaimer
+
+By using the X trademarks and resources on this site, you agree to follow the X Trademark Guidelines in our Brand Guidelines — as well as our Terms of Service and all other X rules and policies. If you have any questions, contact us at trademarks@x.com.
+
+A copy can be found at https://about.x.com/en/who-we-are/brand-toolkit and https://help.twitter.com/en/rules-and-policies/x-trademark-policy

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!--
+  - SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: GPL-3.0-or-later
+-->
 # Nextcloud Talk iOS app
 
 **Video & audio calls and chat through Nextcloud on iOS**

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -12,7 +12,7 @@ SPDX-FileCopyrightText = "2017 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "GPL-3.0-or-later"
 
 [[annotations]]
-path = ["NextcloudTalk/Images.xcassets/AppIcon.appiconset/*.png", "NextcloudTalk/Images.xcassets/navigationLogo.imageset/navigationLogo*.png", "NextcloudTalk/Images.xcassets/navigationLogoDark.imageset/navigationLogoDark*.png", "NextcloudTalk/Images.xcassets/loginLogo.imageset/loginLogo*.png", "NextcloudTalk/Images.xcassets/navigationLogoOffline.imageset/navigationLogoOffline*.png", "NextcloudTalk/Images.xcassets/launchscreen.imageset/launchscreen*.png", "NextcloudTalk/Images.xcassets/logo-action.imageset/logo-action*.png", "NextcloudTalk/Images.xcassets/talk-20.imageset/talk-20*.png", "Icons/talk.svg"]
+path = ["NextcloudTalk/Images.xcassets/app-logo-callkit.imageset/app-logo-callkit*.png", "NextcloudTalk/Images.xcassets/AppIcon.appiconset/*.png", "NextcloudTalk/Images.xcassets/navigationLogo.imageset/navigationLogo*.png", "NextcloudTalk/Images.xcassets/navigationLogoDark.imageset/navigationLogoDark*.png", "NextcloudTalk/Images.xcassets/loginLogo.imageset/loginLogo*.png", "NextcloudTalk/Images.xcassets/navigationLogoOffline.imageset/navigationLogoOffline*.png", "NextcloudTalk/Images.xcassets/launchscreen.imageset/launchscreen*.png", "NextcloudTalk/Images.xcassets/logo-action.imageset/logo-action*.png", "NextcloudTalk/Images.xcassets/talk-20.imageset/talk-20*.png", "Icons/talk.svg"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2016 Nextcloud GmbH"
 SPDX-License-Identifier = "LicenseRef-NextcloudTrademarks"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -18,6 +18,12 @@ SPDX-FileCopyrightText = "2016 Nextcloud GmbH"
 SPDX-License-Identifier = "LicenseRef-NextcloudTrademarks"
 
 [[annotations]]
+path = ["NextcloudTalk/Images.xcassets/twitter.imageset/twitter*.png"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "X Corp."
+SPDX-License-Identifier = "LicenseRef-XTrademarks"
+
+[[annotations]]
 path = ["NextcloudTalk/Images.xcassets/*.imageset/Contents.json", "NextcloudTalk/Images.xcassets/AppIcon.appiconset/Contents.json"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2019-2024 Nextcloud GmbH and Nextcloud contributors"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -18,6 +18,12 @@ SPDX-FileCopyrightText = "2020 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "GPL-3.0-or-later"
 
 [[annotations]]
+path = ["NextcloudTalk/*.lproj/*.strings", "NextcloudTalk/*.lproj/*.stringsdict"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2020 Nextcloud translators"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+[[annotations]]
 path = [".pyspelling.wordlist.txt"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2023 Nextcloud GmbH and Nextcloud contributors"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -12,6 +12,18 @@ SPDX-FileCopyrightText = "2017 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "GPL-3.0-or-later"
 
 [[annotations]]
+path = ["NextcloudTalk/Images.xcassets/AppIcon.appiconset/*.png", "NextcloudTalk/Images.xcassets/navigationLogo.imageset/navigationLogo*.png", "NextcloudTalk/Images.xcassets/navigationLogoDark.imageset/navigationLogoDark*.png", "NextcloudTalk/Images.xcassets/loginLogo.imageset/loginLogo*.png", "NextcloudTalk/Images.xcassets/navigationLogoOffline.imageset/navigationLogoOffline*.png", "NextcloudTalk/Images.xcassets/launchscreen.imageset/launchscreen*.png", "NextcloudTalk/Images.xcassets/logo-action.imageset/logo-action*.png", "NextcloudTalk/Images.xcassets/talk-20.imageset/talk-20*.png", "Icons/talk.svg"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2016 Nextcloud GmbH"
+SPDX-License-Identifier = "LicenseRef-NextcloudTrademarks"
+
+[[annotations]]
+path = ["NextcloudTalk/Images.xcassets/*.imageset/Contents.json", "NextcloudTalk/Images.xcassets/AppIcon.appiconset/Contents.json"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2019-2024 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+[[annotations]]
 path = [".tx/config"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2020 Nextcloud GmbH and Nextcloud contributors"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,9 +6,21 @@ SPDX-PackageSupplier = "Nextcloud GmbH <https://nextcloud.com/impressum/>"
 SPDX-PackageDownloadLocation = "https://github.com/nextcloud/talk-ios/"
 
 [[annotations]]
-path = ["Podfile"]
+path = [".gitmodules", "Podfile"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2017 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+[[annotations]]
+path = [".tx/config"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2020 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+[[annotations]]
+path = [".pyspelling.wordlist.txt"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2023 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "GPL-3.0-or-later"
 
 [[annotations]]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,7 @@
+<!--
+  - SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: GPL-3.0-or-later
+-->
 # Security Policy
 
 ## Supported Versions

--- a/ci-create-docker-server.sh
+++ b/ci-create-docker-server.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Based on the script from Milen Pivchev in nextcloud/ios repository
 
+# SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # This script starts a nextcloud test instance
 
 echo "Creating nextcloud instance for branch $TEST_BRANCH..."

--- a/ci-install-talk.sh
+++ b/ci-install-talk.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Based on the script from Milen Pivchev in nextcloud/ios repository
 
+# SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # This script downloads and installs talk
 
 echo "Installing talk"

--- a/ci-setup-rooms.sh
+++ b/ci-setup-rooms.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # This script is intended to setup specific rooms that we want to test
 
 # Setup a room with lobby enabled and add admin as a normal participant

--- a/ci-wait-for-server.sh
+++ b/ci-wait-for-server.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Based on the script from Milen Pivchev in nextcloud/ios repository
 
+# SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # This scripts waits until a server transitions to the "installed" state
 
 SERVER_URL="http://localhost:${SERVER_PORT}"

--- a/generate-localizable-strings-file.sh
+++ b/generate-localizable-strings-file.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # generate-localizable-strings-file.sh
 
 echo 'Generating Localizable.strings file...'

--- a/start-instance-for-tests.sh
+++ b/start-instance-for-tests.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Based on the script from Milen Pivchev in nextcloud/ios repository
 
+# SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # This script runs the CI scripts needed to set up a test instance and install talk locally
 
 CONTAINER_NAME=nextcloud_test


### PR DESCRIPTION
Adding more SPDX infos, with a focus on config/ci/images

### SUMMARY

* Bad licenses: 0
* Deprecated licenses: 0
* Licenses without file extension: 0
* Missing licenses: 0
* Unused licenses: 0
* Used licenses: LicenseRef-XTrademarks, MIT, LicenseRef-NextcloudTrademarks, Apache-2.0, BSD-3-Clause, GPL-3.0-or-later
* Read errors: 0
* Files with copyright information: 609 / 893
* Files with license information: 609 / 893