### PR TITLE
Show fallback image in failure case

### DIFF
--- a/NextcloudTalk/BaseChatTableViewCell+File.swift
+++ b/NextcloudTalk/BaseChatTableViewCell+File.swift
@@ -119,19 +119,9 @@ extension BaseChatTableViewCell {
     // MARK: - Preview
 
     func requestPreview(for message: NCChatMessage, with account: TalkAccount) {
+        // Don't request a preview if we know that there's none
         if !message.file().previewAvailable {
-            // Don't request a preview if we know that there's none
-            let imageName = "\(NCUtils.previewImage(forMimeType: message.file().mimetype))-chat-preview"
-
-            if let image = UIImage(named: imageName) {
-                self.filePreviewImageView?.image = image
-
-                self.filePreviewImageViewHeightConstraint?.constant = image.size.height
-                self.filePreviewImageViewWidthConstraint?.constant = image.size.width
-            }
-
-            self.filePreviewActivityIndicator?.isHidden = true
-            self.filePreviewActivityIndicator?.stopAnimating()
+            self.showFallbackIcon(for: message)
 
             return
         }
@@ -182,7 +172,23 @@ extension BaseChatTableViewCell {
             imageView.image = image
 
             self.delegate?.cellHasDownloadedImagePreview(withHeight: ceil(previewSize.height), for: message)
+        }, failure: { _, _, _ in
+            self.showFallbackIcon(for: message)
         })
+    }
+
+    func showFallbackIcon(for message: NCChatMessage) {
+        let imageName = "\(NCUtils.previewImage(forMimeType: message.file().mimetype))-chat-preview"
+
+        if let image = UIImage(named: imageName) {
+            self.filePreviewImageView?.image = image
+
+            self.filePreviewImageViewHeightConstraint?.constant = image.size.height
+            self.filePreviewImageViewWidthConstraint?.constant = image.size.width
+        }
+
+        self.filePreviewActivityIndicator?.isHidden = true
+        self.filePreviewActivityIndicator?.stopAnimating()
     }
 
     @objc


### PR DESCRIPTION
Currently when we are unable to get a preview, we fail silently and do nothing, so the activity indicator keeps spinning. In case of a failure, we should fall back to the corresponding mime type icon.