### PR TITLE
Check typingPrivacy in local capabilities

### DIFF
--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -1179,7 +1179,9 @@ import UIKit
         let displayName = notification.userInfo?["displayName"] as? String ?? NSLocalizedString("Guest", comment: "")
 
         // Don't show a typing indicator for ourselves or if typing indicator setting is disabled
-        guard let serverCapabilities = NCDatabaseManager.sharedInstance().roomTalkCapabilities(for: self.room)
+        // Workaround: TypingPrivacy should be checked locally, not from the remote server, use serverCapabilities for now
+        // TODO: Remove workaround for federated typing indicators.
+        guard let serverCapabilities = NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: self.room.accountId)
         else { return }
 
         let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()


### PR DESCRIPTION
TypingPrivacy is a local config, therefore should be retrieved through `serverCapabilities`, not `roomCapabilities`:

https://github.com/nextcloud/spreed/blob/df923967fa31f9abe1c674f43b2ed88f3064415b/lib/Capabilities.php#L119-L131