### PR TITLE
Fix crash when 422 on join is returned

### DIFF
--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -436,7 +436,12 @@ NSInteger const kReceivedChatMessagesLimit = 100;
         [self checkResponseStatusCode:statusCode forAccount:account];
 
         NSDictionary *errorDict = [[[self getFailureResponseObjectFromError:error] objectForKey:@"ocs"] objectForKey:@"data"];
-        NSString *statusReason = [errorDict objectForKey:@"error"];
+        NSString *statusReason = nil;
+
+        // Depending on the error, an empty array instead of a dictionary is returned by the server
+        if (errorDict && [errorDict isKindOfClass:[NSDictionary class]]) {
+            statusReason = [errorDict objectForKey:@"error"];
+        }
 
         if (block) {
             block(nil, nil, error, statusCode, statusReason);


### PR DESCRIPTION
When we receive a `422 - Unprocessable entity` error (so the remote could not be reached), `ocs.data` is an empty array instead of `nil`, which is why we crash here. So we need to make sure we got a dictionary, before accessing any keys.

Ref
https://github.com/nextcloud/spreed/blob/df923967fa31f9abe1c674f43b2ed88f3064415b/lib/Middleware/InjectionMiddleware.php#L411-L417