### PR TITLE
Fix diagnostics

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		1F1C0D8929AFB89900D17C6D /* VLCKitVideoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1C0D8829AFB89900D17C6D /* VLCKitVideoViewController.swift */; };
 		1F1C999D2909846400EACF02 /* BGTaskHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD9182828C55A73009092AB /* BGTaskHelper.swift */; };
 		1F1C999E2909846400EACF02 /* BGTaskHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FD9182828C55A73009092AB /* BGTaskHelper.swift */; };
+		1F1DF8412C63C25900E5EA86 /* UnitNCDatabaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1DF8402C63C25900E5EA86 /* UnitNCDatabaseManager.swift */; };
 		1F24B5A228E0648600654457 /* ReferenceGithubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F24B5A128E0648600654457 /* ReferenceGithubView.swift */; };
 		1F24B5A428E0649200654457 /* ReferenceGithubView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1F24B5A328E0649200654457 /* ReferenceGithubView.xib */; };
 		1F35F8E02AEEB9DE00044BDA /* ShareConfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F35F8DF2AEEB9DE00044BDA /* ShareConfirmationViewController.swift */; };
@@ -663,6 +664,7 @@
 		1F1B50462B90CDF800B0F2F4 /* TalkCapabilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TalkCapabilities.m; sourceTree = "<group>"; };
 		1F1C0D8629AFB88800D17C6D /* VLCKitVideoViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = VLCKitVideoViewController.xib; sourceTree = "<group>"; };
 		1F1C0D8829AFB89900D17C6D /* VLCKitVideoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCKitVideoViewController.swift; sourceTree = "<group>"; };
+		1F1DF8402C63C25900E5EA86 /* UnitNCDatabaseManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnitNCDatabaseManager.swift; sourceTree = "<group>"; };
 		1F24B5A128E0648600654457 /* ReferenceGithubView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReferenceGithubView.swift; sourceTree = "<group>"; };
 		1F24B5A328E0649200654457 /* ReferenceGithubView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReferenceGithubView.xib; sourceTree = "<group>"; };
 		1F35F8DF2AEEB9DE00044BDA /* ShareConfirmationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareConfirmationViewController.swift; sourceTree = "<group>"; };
@@ -1356,6 +1358,7 @@
 				1F1B0F242BD94A0D003FD766 /* UnitDarwinCenterTest.swift */,
 				1F0B0A762BA26BE10073FF8D /* UnitMentionSuggestionTest.swift */,
 				1FF4DAA72C08DE3A00C1B952 /* UnitNCRoomsManagerTest.swift */,
+				1F1DF8402C63C25900E5EA86 /* UnitNCDatabaseManager.swift */,
 				1F8AAC612C596308004DA20A /* UnitSignalingSettings.swift */,
 			);
 			path = Unit;
@@ -2672,6 +2675,7 @@
 				1F6D8C4D2B2F8FE5004376B8 /* IntegrationChatTest.swift in Sources */,
 				1FB7B9892BE442400093CE98 /* UnitBaseChatTableViewCellTest.swift in Sources */,
 				1F5CDAE72B3B05110040ECC0 /* UnitColorGeneratorTest.swift in Sources */,
+				1F1DF8412C63C25900E5EA86 /* UnitNCDatabaseManager.swift in Sources */,
 				1FF4DAA82C08DE3A00C1B952 /* UnitNCRoomsManagerTest.swift in Sources */,
 				1F1B0F252BD94A0D003FD766 /* UnitDarwinCenterTest.swift in Sources */,
 				1F6D8C412B2F26D5004376B8 /* TestConstants.swift in Sources */,

--- a/NextcloudTalk/DiagnosticsTableViewController.swift
+++ b/NextcloudTalk/DiagnosticsTableViewController.swift
@@ -72,7 +72,7 @@ class DiagnosticsTableViewController: UITableViewController {
 
     var account: TalkAccount
     var serverCapabilities: ServerCapabilities
-    var signalingConfiguration: NSDictionary?
+    var signalingConfiguration: SignalingSettings?
     var externalSignalingController: NCExternalSignalingController?
     var signalingVersion: Int
 
@@ -95,7 +95,7 @@ class DiagnosticsTableViewController: UITableViewController {
         self.account = account
 
         self.serverCapabilities = NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: account.accountId)!
-        self.signalingConfiguration = NCSettingsController.sharedInstance().signalingConfigurations[account.accountId] as? NSDictionary
+        self.signalingConfiguration = NCSettingsController.sharedInstance().signalingConfigurations[account.accountId] as? SignalingSettings
         self.externalSignalingController = NCSettingsController.sharedInstance().externalSignalingController(forAccountId: account.accountId)
         self.signalingVersion = NCAPIController.sharedInstance().signalingAPIVersion(for: account)
 
@@ -596,58 +596,24 @@ class DiagnosticsTableViewController: UITableViewController {
             cell.textLabel?.text = NSLocalizedString("STUN servers", comment: "")
             cell.detailTextLabel?.text = NSLocalizedString("Unavailable", comment: "")
 
-            let stunServersConfig = signalingConfiguration?.object(forKey: "stunservers") as? [NSDictionary]
             var stunServers: [String] = []
 
-            if let stunServersArray = stunServersConfig {
-                for stunServerDict in stunServersArray {
-                    if signalingVersion >= APIv3 {
-                        guard let stunServerStringDict = stunServerDict["urls"] as? [String] else {
-                            continue
-                        }
+            signalingConfiguration?.stunServers.forEach { stunServers += $0.urls ?? [] }
 
-                        stunServers += stunServerStringDict
-                    } else {
-                        guard let stunServerString = stunServerDict["url"] as? String else {
-                            continue
-                        }
-
-                        stunServers.append(stunServerString)
-                    }
-                }
-
-                if !stunServers.isEmpty {
-                    cell.detailTextLabel?.text = stunServers.joined(separator: "\n")
-                }
+            if !stunServers.isEmpty {
+                cell.detailTextLabel?.text = stunServers.joined(separator: "\n")
             }
 
         case AllSignalingSections.kSignalingSectionTurnServers.rawValue:
             cell.textLabel?.text = NSLocalizedString("TURN servers", comment: "")
             cell.detailTextLabel?.text = NSLocalizedString("Unavailable", comment: "")
 
-            let turnServersConfig = signalingConfiguration?.object(forKey: "turnservers") as? [NSDictionary]
             var turnServers: [String] = []
 
-            if let turnServersArray = turnServersConfig {
-                for turnServerDict in turnServersArray {
-                    if signalingVersion >= APIv3 {
-                        guard let turnServerStringDict = turnServerDict["urls"] as? [String] else {
-                            continue
-                        }
+            signalingConfiguration?.turnServers.forEach { turnServers += $0.urls ?? [] }
 
-                        turnServers += turnServerStringDict
-                    } else {
-                        guard let turnServerString = turnServerDict["url"] as? String else {
-                            continue
-                        }
-
-                        turnServers.append(turnServerString)
-                    }
-                }
-
-                if !turnServers.isEmpty {
-                    cell.detailTextLabel?.text = turnServers.joined(separator: "\n")
-                }
+            if !turnServers.isEmpty {
+                cell.detailTextLabel?.text = turnServers.joined(separator: "\n")
             }
 
         default:

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -246,6 +246,7 @@ NSString * const NCDatabaseManagerRoomCapabilitiesChangedNotification = @"NCData
     ServerCapabilities *serverCapabilities = [ServerCapabilities objectsWithPredicate:query].firstObject;
     if (serverCapabilities) {
         [realm deleteObject:serverCapabilities];
+        [_capabilitiesCache removeObjectForKey:accountId];
     }
     [realm deleteObjects:[NCRoom objectsWithPredicate:query]];
     [realm deleteObjects:[NCChatMessage objectsWithPredicate:query]];

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -681,6 +681,9 @@ NSString * const NCDatabaseManagerRoomCapabilitiesChangedNotification = @"NCData
 
         if (managedServerCapabilities && managedServerCapabilities.externalSignalingServerVersion != version) {
             managedServerCapabilities.externalSignalingServerVersion = version;
+
+            ServerCapabilities *unmanagedServerCapabilities = [[ServerCapabilities alloc] initWithValue:managedServerCapabilities];
+            [self.capabilitiesCache setObject:unmanagedServerCapabilities forKey:accountId];
         }
     }];
 }

--- a/NextcloudTalkTests/Integration/IntegrationRoomTest.swift
+++ b/NextcloudTalkTests/Integration/IntegrationRoomTest.swift
@@ -27,7 +27,7 @@ final class IntegrationRoomTest: TestBase {
 
     func testRoomCreation() throws {
         let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        let roomName = "Integration Test Room"
+        let roomName = "Integration Test Room " + UUID().uuidString
 
         let exp = expectation(description: "\(#function)\(#line)")
 
@@ -44,7 +44,7 @@ final class IntegrationRoomTest: TestBase {
 
     func testRoomDescription() throws {
         let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        let roomName = "Description Test Room"
+        let roomName = "Description Test Room " + UUID().uuidString
         let roomDescription = "This is a room description"
 
         let exp = expectation(description: "\(#function)\(#line)")
@@ -79,7 +79,7 @@ final class IntegrationRoomTest: TestBase {
 
     func testRoomRename() throws {
         let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        let roomName = "Rename Test Room"
+        let roomName = "Rename Test Room " + UUID().uuidString
         let roomNameNew = "\(roomName)- New"
 
         let exp = expectation(description: "\(#function)\(#line)")

--- a/NextcloudTalkTests/Unit/TestBaseRealm.swift
+++ b/NextcloudTalkTests/Unit/TestBaseRealm.swift
@@ -37,12 +37,16 @@ class TestBaseRealm: XCTestCase {
     }
 
     func updateCapabilities(updateBlock: @escaping (ServerCapabilities) -> Void) {
-        let capabilities = ServerCapabilities()
-        capabilities.accountId = TestBaseRealm.fakeAccountId
-        updateBlock(capabilities)
-
         try? realm.transaction {
-            realm.add(capabilities)
+            var capabilities = ServerCapabilities()
+            capabilities.accountId = TestBaseRealm.fakeAccountId
+
+            if let storedCapabilities = ServerCapabilities.object(forPrimaryKey: TestBaseRealm.fakeAccountId) {
+                capabilities = storedCapabilities
+            }
+
+            updateBlock(capabilities)
+            realm.addOrUpdate(capabilities)
         }
     }
 

--- a/NextcloudTalkTests/Unit/TestBaseRealm.swift
+++ b/NextcloudTalkTests/Unit/TestBaseRealm.swift
@@ -24,6 +24,11 @@ class TestBaseRealm: XCTestCase {
         createFakeActiveAccount()
     }
 
+    override func tearDownWithError() throws {
+        // Make sure we correctly remove the fake account again, to clear the capability cache in NCDatabaseManager
+        NCDatabaseManager.sharedInstance().removeAccount(withAccountId: TestBaseRealm.fakeAccountId)
+    }
+
     func createFakeActiveAccount() {
         let account = TalkAccount()
         account.accountId = TestBaseRealm.fakeAccountId

--- a/NextcloudTalkTests/Unit/UnitNCDatabaseManager.swift
+++ b/NextcloudTalkTests/Unit/UnitNCDatabaseManager.swift
@@ -1,0 +1,28 @@
+//
+// SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+import XCTest
+@testable import NextcloudTalk
+
+final class UnitNCDatabaseManager: TestBaseRealm {
+
+    func testSavingExternalSignalingVersion() throws {
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        let testVersion = "Test version"
+        let testVersionUpdated = "Test version updated"
+
+        updateCapabilities { cap in
+            cap.externalSignalingServerVersion = testVersion
+        }
+
+        var capabilities = NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: activeAccount.accountId)
+        XCTAssertEqual(capabilities?.externalSignalingServerVersion, testVersion)
+
+        NCDatabaseManager.sharedInstance().setExternalSignalingServerVersion(testVersionUpdated, forAccountId: activeAccount.accountId)
+
+        capabilities = NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: activeAccount.accountId)
+        XCTAssertEqual(capabilities?.externalSignalingServerVersion, testVersionUpdated)
+    }
+}


### PR DESCRIPTION
Since we don't have a `NSDictionary` for the signaling settings anymore, the diagnostics would show "Unknown" in all cases.

Also our `ServerCapabilities` cache was not correctly invalidated, when we stored the external signaling version. ~~To make sure we don't have an issue in the future _somewhere_, we invalidate based on realm notification for modification.~~
Since this was not easily testable and failed in multiple scenarios, I went for explicitly updating the cache now.