### PR TITLE
Hide non-relevant conversation settings

### DIFF
--- a/NextcloudTalk/NCRoom.swift
+++ b/NextcloudTalk/NCRoom.swift
@@ -68,6 +68,22 @@ import Realm
             self.type != .changelog && self.type != .noteToSelf
     }
 
+    public var supportsMessageExpiration: Bool {
+        if self.type == .formerOneToOne || self.type == .changelog {
+            return false
+        }
+
+        return self.isUserOwnerOrModerator && NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityMessageExpiration)
+    }
+
+    public var supportsBanning: Bool {
+        if self.type == .oneToOne || self.type == .formerOneToOne || self.type == .changelog || self.type == .noteToSelf {
+            return false
+        }
+
+        return self.isUserOwnerOrModerator && NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityBanV1)
+    }
+
     public var isBreakoutRoom: Bool {
         return self.objectType == NCRoomObjectTypeRoom
     }

--- a/NextcloudTalk/NCRoom.swift
+++ b/NextcloudTalk/NCRoom.swift
@@ -68,7 +68,7 @@ import Realm
             self.type != .changelog && self.type != .noteToSelf
     }
 
-    public var supportsMessageExpiration: Bool {
+    public var supportsMessageExpirationModeration: Bool {
         if self.type == .formerOneToOne || self.type == .changelog {
             return false
         }
@@ -76,12 +76,10 @@ import Realm
         return self.isUserOwnerOrModerator && NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityMessageExpiration)
     }
 
-    public var supportsBanning: Bool {
-        if self.type == .oneToOne || self.type == .formerOneToOne || self.type == .changelog || self.type == .noteToSelf {
-            return false
-        }
+    public var supportsBanningModeration: Bool {
+        let supportedType = self.type == .group || self.type == .public
 
-        return self.isUserOwnerOrModerator && NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityBanV1)
+        return supportedType && self.canModerate && NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityBanV1)
     }
 
     public var isBreakoutRoom: Bool {

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -405,12 +405,12 @@ typedef enum FileAction {
     NSMutableArray *actions = [[NSMutableArray alloc] init];
 
     // Message expiration action
-    if ([_room supportsMessageExpiration]) {
+    if ([_room supportsMessageExpirationModeration]) {
         [actions addObject:[NSNumber numberWithInt:kConversationActionMessageExpiration]];
     }
 
     // Banning actors
-    if ([_room supportsBanning]) {
+    if ([_room supportsBanningModeration]) {
         [actions addObject:[NSNumber numberWithInt:kConversationActionBannedActors]];
     }
 

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -405,12 +405,12 @@ typedef enum FileAction {
     NSMutableArray *actions = [[NSMutableArray alloc] init];
 
     // Message expiration action
-    if (_room.isUserOwnerOrModerator && [[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityMessageExpiration]) {
+    if ([_room supportsMessageExpiration]) {
         [actions addObject:[NSNumber numberWithInt:kConversationActionMessageExpiration]];
     }
 
     // Banning actors
-    if (_room.isUserOwnerOrModerator && [[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityBanV1]) {
+    if ([_room supportsBanning]) {
         [actions addObject:[NSNumber numberWithInt:kConversationActionBannedActors]];
     }
 


### PR DESCRIPTION
Currently 
* Message expiration is visible in former one-to-ones
* Banning is visible in former one-to-ones and note-to-self

Moved the checks to `NCRoom` and adjusted accordingly.