### PR TITLE
Update idle timer when jumping in VLC player

### DIFF
--- a/NextcloudTalk/VLCKitVideoViewController.swift
+++ b/NextcloudTalk/VLCKitVideoViewController.swift
@@ -234,6 +234,7 @@ import MobileVLCKit
 
         mediaPlayer.jumpBackward(Self.jumpInterval)
         updateInformation()
+        updateIdleTimer()
     }
 
     @IBAction func jumpForwardButtonTap(_ sender: Any) {
@@ -253,6 +254,7 @@ import MobileVLCKit
         }
 
         updateInformation()
+        updateIdleTimer()
     }
 
     @IBAction func playPauseButtonTap(_ sender: Any) {


### PR DESCRIPTION
**Current**
When pressing back/forward jump multiple times, the buttons disappear because the idle timer fires

**With this PR**
The idle timer is updated at each jump so the buttons will only disappear 5 seconds after the last jump