### PR TITLE
Fix potential crash on invalid preview size

### DIFF
--- a/NextcloudTalk/BaseChatTableViewCell+File.swift
+++ b/NextcloudTalk/BaseChatTableViewCell+File.swift
@@ -152,11 +152,16 @@ extension BaseChatTableViewCell {
             self.filePreviewActivityIndicator?.isHidden = true
             self.filePreviewActivityIndicator?.stopAnimating()
 
-            imageView.layer.borderColor = UIColor.secondarySystemFill.cgColor
-            imageView.layer.borderWidth = 1
-
             let imageSize = CGSize(width: image.size.width * image.scale, height: image.size.height * image.scale)
             let previewSize = BaseChatTableViewCell.getPreviewSize(from: imageSize, isMediaFile)
+
+            if !previewSize.width.isFinite || !previewSize.height.isFinite {
+                self.showFallbackIcon(for: message)
+                return
+            }
+
+            imageView.layer.borderColor = UIColor.secondarySystemFill.cgColor
+            imageView.layer.borderWidth = 1
 
             self.filePreviewImageViewHeightConstraint?.constant = previewSize.height
             self.filePreviewImageViewWidthConstraint?.constant = previewSize.width


### PR DESCRIPTION
Some crash reports indicate that we sometimes crash when setting the preview constraint. The only way to reproduce this is using non-finite values, e.g. `CGFloat.nan`. Therefore we make sure that we got a finite value for the preview size, which hopefully fixes the crashes.