### PR TITLE
Fix crash on showing SIP info

### DIFF
--- a/NextcloudTalk/NCConnectionController.m
+++ b/NextcloudTalk/NCConnectionController.m
@@ -12,6 +12,8 @@
 #import "NCSettingsController.h"
 #import "NCUserInterfaceController.h"
 
+#import "NextcloudTalk-Swift.h"
+
 NSString * const NCAppStateHasChangedNotification           = @"NCAppStateHasChangedNotification";
 NSString * const NCConnectionStateHasChangedNotification    = @"NCConnectionStateHasChangedNotification";
 
@@ -85,9 +87,9 @@ NSString * const NCConnectionStateHasChangedNotification    = @"NCConnectionStat
 
 - (void)checkAppState
 {
-    TalkAccount *activeAccount                  = [[NCDatabaseManager sharedInstance] activeAccount];
-    NSDictionary *activeAccountSignalingConfig  = [[[NCSettingsController sharedInstance] signalingConfigurations] objectForKey:activeAccount.accountId];
-    
+    TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+    SignalingSettings *activeAccountSignalingConfig = [[[NCSettingsController sharedInstance] signalingConfigurations] objectForKey:activeAccount.accountId];
+
     if (!activeAccount.server || !activeAccount.user) {
         [self setAppState:kAppStateNotServerProvided];
         [[NCUserInterfaceController sharedInstance] presentLoginViewController];

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -2190,8 +2190,14 @@ typedef enum FileAction {
                         cell = [[RoomDescriptionTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:RoomDescriptionTableViewCell.identifier];
                     }
                     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
-                    NSDictionary *activeAccountSignalingConfig  = [[[NCSettingsController sharedInstance] signalingConfigurations] objectForKey:activeAccount.accountId];
-                    cell.textView.text = [activeAccountSignalingConfig objectForKey:@"sipDialinInfo"];
+                    SignalingSettings *activeAccountSignalingConfig = [[[NCSettingsController sharedInstance] signalingConfigurations] objectForKey:activeAccount.accountId];
+
+                    if (activeAccountSignalingConfig.sipDialinInfo) {
+                        cell.textView.text = activeAccountSignalingConfig.sipDialinInfo;
+                    } else {
+                        cell.textView.text = @"";
+                    }
+
                     cell.selectionStyle = UITableViewCellSelectionStyleNone;
                     
                     return cell;

--- a/NextcloudTalk/SignalingSettings.swift
+++ b/NextcloudTalk/SignalingSettings.swift
@@ -11,6 +11,7 @@ import Foundation
     public var signalingMode: String?
     public var ticket: String?
     public var userId: String?
+    public var sipDialinInfo: String?
     public var stunServers: [StunServer] = []
     public var turnServers: [TurnServer] = []
     public var federation: [String: Any]?
@@ -24,6 +25,7 @@ import Foundation
         self.signalingMode = dictionary["signalingMode"] as? String
         self.ticket = dictionary["ticket"] as? String
         self.userId = dictionary["userId"] as? String
+        self.sipDialinInfo = dictionary["sipDialinInfo"] as? String
         self.federation = dictionary["federation"] as? [String: Any]
 
         if let stunArray = dictionary["stunservers"] as? [[String: Any]] {


### PR DESCRIPTION
Regression from https://github.com/nextcloud/talk-ios/pull/1727

When trying to display the SIP info, we expected a `NSDictionary` instead of `SignalingSettings` -> 💣 