### PR TITLE
Fix re-joining a call

### DIFF
--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -319,7 +319,7 @@ static NSString * const kNCScreenTrackKind  = @"screen";
         self->_disableVideoAtStart = ![self isVideoEnabled];
 
         if (self->_externalSignalingController) {
-            [self->_externalSignalingController forceReconnect];
+            [self->_externalSignalingController forceReconnectForRejoin];
         } else {
             [self rejoinCallUsingInternalSignaling];
         }

--- a/NextcloudTalk/NCExternalSignalingController.h
+++ b/NextcloudTalk/NCExternalSignalingController.h
@@ -57,6 +57,6 @@ typedef void (^JoinRoomExternalSignalingCompletionBlock)(NSError *error);
 - (void)connect;
 - (void)forceConnect;
 - (void)disconnect;
-- (void)forceReconnect;
+- (void)forceReconnectForRejoin;
 
 @end

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -182,6 +182,17 @@ NSString * const NCExternalSignalingControllerDidReceiveStoppedTypingNotificatio
     });
 }
 
+- (void)forceReconnectForRejoin
+{
+    // In case we force reconnect in order to rejoin the call again, we need to keep the currently joined room.
+    // In `helloResponseReceived` we determine that we were in a room and that the sessionId changed, in that case
+    // we trigger a re-join in `NCRoomsManager` which takes care of re-joining.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_resumeId = nil;
+        [self reconnect];
+    });
+}
+
 - (void)disconnect
 {
     [NCUtils log:[NSString stringWithFormat:@"Disconnecting from: %@", _serverUrl]];


### PR DESCRIPTION
* Regression from https://github.com/nextcloud/talk-ios/pull/1358
* Contributes to https://github.com/nextcloud/talk-ios/issues/1319

The problem is that we reset the `currentRoom` when we `forceReconnect`, which is fine for "normal" forced reconnects:
https://github.com/nextcloud/talk-ios/blob/a09c4a02064e5de66966ea86bd6cd0e473b66ae6/NextcloudTalk/NCExternalSignalingController.m#L176-L183

In case our publisher peer fails, we want to rejoin the call, for that, we call `forceReconnect` on `NCExternalSignalingController` from `NCCallController`:
https://github.com/nextcloud/talk-ios/blob/a09c4a02064e5de66966ea86bd6cd0e473b66ae6/NextcloudTalk/NCCallController.m#L321-L323

But for the re-join to work correctly, the `NCExternalSignalingController` needs to be aware, that we were in a room already:
https://github.com/nextcloud/talk-ios/blob/a09c4a02064e5de66966ea86bd6cd0e473b66ae6/NextcloudTalk/NCExternalSignalingController.m#L348-L352

And this check failed since we reseted `currentRoom` on a `forceReconnect`. This results in showing the waiting message "Connecting to the call …" but nothing is ever happening.

### How to test

* Establish a call between ios and web
* Hit "Pause" on the Xcode debugger
* Wait until the ios peer is closed/removed from the web
* Continue execution on Xcode