### PR TITLE
Fix race condition on setting remote video size

### DIFF
--- a/NextcloudTalk/CallParticipantViewCell.h
+++ b/NextcloudTalk/CallParticipantViewCell.h
@@ -49,6 +49,7 @@ extern CGFloat const kCallParticipantCellMinHeight;
 - (void)setVideoView:(RTCMTLVideoView *)videoView;
 - (void)setSpeaking:(BOOL)speaking;
 - (void)setAvatarForActor:(TalkActor *)actor;
+- (CGSize)getRemoteVideoSize;
 - (void)setRemoteVideoSize:(CGSize)size;
 - (void)setRaiseHand:(BOOL)raised;
 - (void)resizeRemoteVideoView;

--- a/NextcloudTalk/CallParticipantViewCell.m
+++ b/NextcloudTalk/CallParticipantViewCell.m
@@ -292,6 +292,11 @@ CGFloat const kCallParticipantCellMinHeight = 128;
     });
 }
 
+- (CGSize)getRemoteVideoSize
+{
+    return self->_remoteVideoSize;
+}
+
 - (void)setRemoteVideoSize:(CGSize)size
 {
     self->_remoteVideoSize = size;

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1918,7 +1918,20 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
         isVideoDisabled = YES;
     }
     
-    [cell setVideoView:[_videoRenderersDict objectForKey:peerConnection.peerIdentifier]];
+    RTCMTLVideoView *videoView = [_videoRenderersDict objectForKey:peerConnection.peerIdentifier];
+    [cell setVideoView:videoView];
+
+    // It is possible that we receive a `didChangeVideoSize` call, while the participant cell was not yet shown,
+    // therefore the remote video size will never be set. In case we have a videoView here, use the frame size
+    if (videoView) {
+        CGSize videoSize = videoView.frame.size;
+        CGSize currentSize = [cell getRemoteVideoSize];
+
+        // Only set it, when there's no size set yet
+        if (CGSizeEqualToSize(CGSizeZero, currentSize) && !CGSizeEqualToSize(CGSizeZero, videoSize)) {
+            [cell setRemoteVideoSize:videoView.frame.size];
+        }
+    }
 
     [cell setDisplayName:peerConnection.peerName];
     [cell setAudioDisabled:peerConnection.isRemoteAudioDisabled];


### PR DESCRIPTION
This seems to be an issue especially with external signaling, but might in theory be also possible with internal signaling.

It is possible that our delegate `didChangeVideoSize` is called before the cell is visible. Therefore, we are unable to update the cells remote video size at that point. Later, when the cell is added/updated, we never try to set the video size again, therefore a remote video size is never set. This basically disables the cell resize on double tap (to show the original video size, instead of the aspect fitted size).