### PR TITLE
Fix federation-v2 capability check

### DIFF
--- a/NextcloudTalk/NCRoom.swift
+++ b/NextcloudTalk/NCRoom.swift
@@ -58,9 +58,17 @@ import Realm
         return false
     }
 
+    public var supportsFederationV2: Bool {
+        guard self.isFederated else { return false }
+
+        let remoteSupported = NCDatabaseManager.sharedInstance().roomHasTalkCapability(kCapabilityFederationV2, for: self)
+        let localSupported = NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityFederationV2, forAccountId: self.accountId)
+
+        return remoteSupported && localSupported
+    }
+
     public var supportsCalling: Bool {
-        // Federated calling is only supported with federation-v2
-        if self.isFederated, !NCDatabaseManager.sharedInstance().roomHasTalkCapability(kCapabilityFederationV2, for: self) {
+        if self.isFederated, !self.supportsFederationV2 {
             return false
         }
 

--- a/NextcloudTalk/NCRoomsManagerExtensions.swift
+++ b/NextcloudTalk/NCRoomsManagerExtensions.swift
@@ -193,10 +193,8 @@ import Foundation
     }
 
     private func getSignalingSettingsHelper(for account: TalkAccount, forRoom token: String, withCompletion completion: @escaping (SignalingSettings?) -> Void) {
-        // Currently we only need the signaling settings in case the room is federated and we support federation-v2
-        if let room = NCDatabaseManager.sharedInstance().room(withToken: token, forAccountId: account.accountId), room.isFederated,
-           NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityFederationV2, forAccountId: account.accountId) {
-
+        // Currently we only need the signaling settings in case the room supports federation-v2
+        if let room = NCDatabaseManager.sharedInstance().room(withToken: token, forAccountId: account.accountId), room.supportsFederationV2 {
             NCAPIController.sharedInstance().getSignalingSettings(for: account, forRoom: token) { signalingSettings, _ in
                 completion(signalingSettings)
             }


### PR DESCRIPTION
For `federation-v2` we need to check the capability on both ends, the local server and the remote server.