### PR TITLE
Try to forceReconnect on 404 when joining call

### DIFF
--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -208,7 +208,15 @@ static NSString * const kNCScreenTrackKind  = @"screen";
                 if (self->_joinCallAttempts < 3) {
                     NSLog(@"Could not join call, retrying. %ld", (long)self->_joinCallAttempts);
                     self->_joinCallAttempts += 1;
-                    [self joinCall];
+
+                    if (statusCode == 404) {
+                        // The conversation was not correctly joined by us / our session expired
+                        // Instead of joining again, try to reconnect to correctly join the conversation again
+                        [self forceReconnect];
+                    } else {
+                        [self joinCall];
+                    }
+
                     return;
                 }
 


### PR DESCRIPTION
* Fixes https://github.com/nextcloud/talk-ios/issues/1756

https://github.com/nextcloud/talk-ios/pull/1773 implemented the completion blocks for rejoining already as a side-effect, so we can use that.

How to test:
* Join a conversation
* Remove that session from the database
* Try to join a call

Without this PR: Error that the conversation was not joined
With this PR: Call reconnects and joins successfully