### PR TITLE
Fix color to hexstring conversion

### DIFF
--- a/NextcloudTalk/NCUtils.swift
+++ b/NextcloudTalk/NCUtils.swift
@@ -430,9 +430,9 @@ import AVFoundation
         // We don't expect an alpha component right now
         return String(
             format: "#%02lX%02lX%02lX",
-            Int(red * multiplier),
-            Int(green * multiplier),
-            Int(blue * multiplier)
+            min(Int(red * multiplier), 255),
+            min(Int(green * multiplier), 255),
+            min(Int(blue * multiplier), 255)
         )
     }
 


### PR DESCRIPTION
Depending on the color choosen, we get a value above 1 for each of the color components (because of extended sRGB), resulting in an invalid hex string:

<img width="315" alt="image" src="https://github.com/user-attachments/assets/c690d042-626b-4b85-99db-5691c59ccf4c">

and setting a conversation avatar with emoji might fail.

So we make sure that we have a max value of 255. 