### PR TITLE
Disable UI when microphone permission is missing

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -2043,12 +2043,20 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
 
 - (void)callController:(NCCallController *)callController userPermissionsChanged:(NSInteger)permissions
 {
-    [self setAudioMuteButtonEnabled:(permissions & NCPermissionCanPublishAudio)];
+    [self setAudioMuteButtonEnabled:(permissions & NCPermissionCanPublishAudio) && [callController isMicrophoneAccessAvailable]];
     [self setVideoDisableButtonEnabled:((permissions & NCPermissionCanPublishVideo) && [callController isCameraAccessAvailable])];
 }
 
 - (void)callController:(NCCallController *)callController didCreateLocalAudioTrack:(RTCAudioTrack *)audioTrack
 {
+    if (!audioTrack) {
+        // No audio track was created, probably because there are no publishing rights or microphone access was denied
+        [self setAudioMuteButtonEnabled:NO];
+        [self setAudioMuteButtonActive:NO];
+
+        return;
+    }
+
     [self setAudioMuteButtonActive:audioTrack.isEnabled];
 }
 

--- a/NextcloudTalk/NCCallController.h
+++ b/NextcloudTalk/NCCallController.h
@@ -79,6 +79,7 @@ typedef void (^GetAudioEnabledStateCompletionBlock)(BOOL isEnabled);
 - (void)enableBackgroundBlur:(BOOL)enable;
 - (void)stopCapturing;
 - (BOOL)isCameraAccessAvailable;
+- (BOOL)isMicrophoneAccessAvailable;
 
 - (void)willSwitchToCall:(NSString *)token;
 

--- a/NextcloudTalk/NCCallController.m
+++ b/NextcloudTalk/NCCallController.m
@@ -490,6 +490,12 @@ static NSString * const kNCScreenTrackKind  = @"screen";
     return (authStatus == AVAuthorizationStatusAuthorized);
 }
 
+- (BOOL)isMicrophoneAccessAvailable
+{
+    AVAuthorizationStatus authStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+    return (authStatus == AVAuthorizationStatusAuthorized);
+}
+
 - (void)stopCapturing
 {
     [self.cameraController stopAVCaptureSession];
@@ -856,7 +862,9 @@ static NSString * const kNCScreenTrackKind  = @"screen";
         self->_localAudioTrack = nil;
         self->_localVideoTrack = nil;
 
-        if ((self->_userPermissions & NCPermissionCanPublishAudio) != 0 || !self->_serverSupportsConversationPermissions) {
+        BOOL hasPublishAudioPermission = ((self->_userPermissions & NCPermissionCanPublishAudio) != 0 || !self->_serverSupportsConversationPermissions);
+
+        if (hasPublishAudioPermission && [self isMicrophoneAccessAvailable]) {
             [self createLocalAudioTrack];
         } else {
             [self.delegate callController:self didCreateLocalAudioTrack:nil];


### PR DESCRIPTION
For microphone access we currently only check the publishing permissions, but don't take into account, that the app might not have microphone access at all. In that case, we also need to disable the microphone button, to reflect, that we can not enable it (as it is already done for the camera button).