### PR TITLE
Use version 0.9.15 of libPhoneNumber-iOS

### DIFF
--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/**'
+      - Podfile
       - NextcloudTalk.xcodeproj/**
       - NextcloudTalk/**
       - NextcloudTalkTests/**

--- a/Podfile
+++ b/Podfile
@@ -17,7 +17,7 @@ def main_dependencies
   pod 'JDStatusBarNotification', '~> 2.0.0'
   pod 'MaterialComponents/ActivityIndicator'
   pod 'Toast', '~> 4.0.0'
-  pod 'libPhoneNumber-iOS'
+  pod 'libPhoneNumber-iOS', '~> 0.9.15'
   pod 'MZTimerLabel'
   pod 'MobileVLCKit', '~> 3.5.0'
 end


### PR DESCRIPTION
Latest version 1.2.0 seems to break for us at the moment, so we keep 0.9.15: https://github.com/nextcloud/talk-ios/actions/runs/10591776571/job/29351045455?pr=1784