### PR TITLE
Don't use app-groups for caches anymore

### DIFF
--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -123,9 +123,14 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     // Make sure we support self-signed certificates we trusted before
     [[SDWebImageDownloader sharedDownloader].config setOperationClass:[NCWebImageDownloaderOperation class]];
 
-    // Set the caching path to be in our app group and limit size to 100 MB
-    NSURL *avatarCacheURL = [[[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:groupIdentifier] URLByAppendingPathComponent:@"AvatarCache"];
-    SDImageCache.defaultDiskCacheDirectory = avatarCacheURL.path;
+    // Try to remove legacy avatar cache in app group
+    NSURL *legacyCacheURL = [[[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:groupIdentifier] URLByAppendingPathComponent:@"AvatarCache"];
+    if (legacyCacheURL != nil) {
+        [[NSFileManager defaultManager] removeItemAtURL:legacyCacheURL error:nil];
+    }
+
+    // Limit the cache size to 100 MB and prevent uploading to iCloud
+    // Don't set the path to an app group in order to prevent crashes
     [SDImageCache sharedImageCache].config.shouldDisableiCloud = YES;
     [SDImageCache sharedImageCache].config.maxDiskSize = 100 * 1024 * 1024;
 

--- a/NextcloudTalk/NCImageSessionManager.swift
+++ b/NextcloudTalk/NCImageSessionManager.swift
@@ -14,9 +14,14 @@ import Foundation
     init() {
         let configuration = AFImageDownloader.defaultURLSessionConfiguration()
 
+        // Try to remove legacy ImageCache directory in app group
+        if let legacyCacheURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupIdentifier)?.appendingPathComponent("ImageCache") {
+            try? FileManager.default .removeItem(at: legacyCacheURL)
+        }
+
         // In case of images we want to use the cache and store it on disk
         // As we use the memory cache from AFImageDownloader, we only want disk cache here
-        let imageCacheURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupIdentifier)?.appendingPathComponent("ImageCache")
+        let imageCacheURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.appendingPathComponent("ImageCache")
         self.cache = URLCache(memoryCapacity: 0, diskCapacity: 100 * 1024 * 1024, directory: imageCacheURL)
 
         configuration.urlCache = self.cache


### PR DESCRIPTION
As discussed, we should try to not save anything SQLite related in app groups (as it is the case when using an `NSURLCache`). Therefore move the caches to local directories.