### PR TITLE
Return localVideoView to original position after being pushed by right side bar

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1615,10 +1615,19 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
     [self.collectionViewRightConstraint setConstant:rightConstraintConstant];
     [self adjustTopBar];
 
+    CGPoint localVideoViewOrigin = self.localVideoView.frame.origin;
+    // Check if localVideoView needs to be moved to the right when sidebar is being closed
+    if (!visible) {
+        CGFloat sideBarWidthGap = self.collectionView.frame.size.width - kSidebarWidth;
+        if (localVideoViewOrigin.x > sideBarWidthGap) {
+            localVideoViewOrigin.x = self.localVideoView.superview.frame.size.width;
+        }
+    }
+
     void (^animations)(void) = ^void() {
         [self.titleView layoutIfNeeded];
         [self.view layoutIfNeeded];
-        [self adjustLocalVideoPositionFromOriginPosition:self.localVideoView.frame.origin];
+        [self adjustLocalVideoPositionFromOriginPosition:localVideoViewOrigin];
     };
 
     void (^afterAnimations)(void) = ^void() {


### PR DESCRIPTION
**Before this PR:**
The localVideoView is pushed to the middle of the screen when the right side bar is being shown.
When the side bar is closed, the localVideoView stays at the same position where it was pushed.

**After this PR:**
The localVideoView will return to right side when the right side bar is getting closed.