### PR TITLE
Active account improvements

### DIFF
--- a/NextcloudTalk/AddParticipantsTableViewController.m
+++ b/NextcloudTalk/AddParticipantsTableViewController.m
@@ -429,7 +429,12 @@
     }
     
     cell.labelTitle.text = participant.name;
-    [cell.contactImage setActorAvatarForId:participant.userId withType:participant.source withDisplayName:participant.name withRoomToken:_room.token];
+
+    TalkAccount *account = self->_room.account;
+
+    if (account) {
+        [cell.contactImage setActorAvatarForId:participant.userId withType:participant.source withDisplayName:participant.name withRoomToken:_room.token using:account];
+    }
 
     UIImage *selectionImage = [UIImage systemImageNamed:@"circle"];
     UIColor *selectionImageColor = [UIColor tertiaryLabelColor];

--- a/NextcloudTalk/AvatarButton.swift
+++ b/NextcloudTalk/AvatarButton.swift
@@ -64,14 +64,11 @@ import SDWebImage
     // MARK: - User avatars
 
     public func setActorAvatar(forMessage message: NCChatMessage) {
-        self.setActorAvatar(forId: message.actorId, withType: message.actorType, withDisplayName: message.actorDisplayName, withRoomToken: message.token)
+        guard let account = message.account else { return }
+        self.setActorAvatar(forId: message.actorId, withType: message.actorType, withDisplayName: message.actorDisplayName, withRoomToken: message.token, using: account)
     }
 
-    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?) {
-        self.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, using: nil)
-    }
-
-    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, using account: TalkAccount?) {
+    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, using account: TalkAccount) {
         self.cancelCurrentRequest()
 
         self.currentRequest = AvatarManager.shared.getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, withStyle: self.traitCollection.userInterfaceStyle, usingAccount: account) { image in

--- a/NextcloudTalk/AvatarImageView.swift
+++ b/NextcloudTalk/AvatarImageView.swift
@@ -61,14 +61,11 @@ import SDWebImage
     // MARK: - User avatars
 
     public func setActorAvatar(forMessage message: NCChatMessage) {
-        self.setActorAvatar(forId: message.actorId, withType: message.actorType, withDisplayName: message.actorDisplayName, withRoomToken: message.token)
+        guard let account = message.account else { return }
+        self.setActorAvatar(forId: message.actorId, withType: message.actorType, withDisplayName: message.actorDisplayName, withRoomToken: message.token, using: account)
     }
 
-    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?) {
-        self.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, using: nil)
-    }
-
-    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, using account: TalkAccount?) {
+    public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, using account: TalkAccount) {
         self.cancelCurrentRequest()
 
         self.currentRequest = AvatarManager.shared.getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, withStyle: self.traitCollection.userInterfaceStyle, usingAccount: account) { image in

--- a/NextcloudTalk/AvatarManager.swift
+++ b/NextcloudTalk/AvatarManager.swift
@@ -15,7 +15,7 @@ import SDWebImage
     // MARK: - Conversation avatars
 
     public func getAvatar(for room: NCRoom, with style: UIUserInterfaceStyle, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
-        if room.accountId != nil, NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityConversationAvatars, forAccountId: room.accountId) {
+        if NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityConversationAvatars, forAccountId: room.accountId) {
             // Server supports conversation avatars -> try to get the avatar using this API
 
             return NCAPIController.sharedInstance().getAvatarFor(room, with: style) { image, _ in
@@ -50,7 +50,7 @@ import SDWebImage
         } else {
             switch room.type {
             case .oneToOne:
-                let account = NCDatabaseManager.sharedInstance().talkAccount(forAccountId: room.accountId)
+                guard let account = room.account else { return nil }
                 return self.getUserAvatar(forId: room.name, withStyle: style, usingAccount: account, completionBlock: completionBlock)
             case .formerOneToOne:
                 completionBlock(UIImage(named: "user-avatar", in: nil, compatibleWith: traitCollection))
@@ -71,7 +71,7 @@ import SDWebImage
     // MARK: - Actor avatars
 
     // swiftlint:disable:next function_parameter_count
-    public func getActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount?, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
+    public func getActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
         if let actorId {
             if actorType == "bots" {
                 return getBotsAvatar(forId: actorId, withStyle: style, completionBlock: completionBlock)
@@ -123,9 +123,7 @@ import SDWebImage
         return NCUtils.getImage(withString: "X", withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true)
     }
 
-    private func getUserAvatar(forId actorId: String, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount?, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
-        let account = account ?? NCDatabaseManager.sharedInstance().activeAccount()
-
+    private func getUserAvatar(forId actorId: String, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
         return NCAPIController.sharedInstance().getUserAvatar(forUser: actorId, using: account, with: style) { image, _ in
             if image != nil {
                 completionBlock(image)
@@ -138,9 +136,7 @@ import SDWebImage
         }
     }
 
-    private func getFederatedUserAvatar(forId actorId: String, withRoomToken roomToken: String?, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount?, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
-        let account = account ?? NCDatabaseManager.sharedInstance().activeAccount()
-
+    private func getFederatedUserAvatar(forId actorId: String, withRoomToken roomToken: String?, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
         return NCAPIController.sharedInstance().getFederatedUserAvatar(forUser: actorId, inRoom: roomToken, using: account, with: style) { image, _ in
             if image != nil {
                 completionBlock(image)

--- a/NextcloudTalk/BannedActorTableViewController.swift
+++ b/NextcloudTalk/BannedActorTableViewController.swift
@@ -54,9 +54,7 @@
     }
 
     func getData() {
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-
-        NCAPIController.sharedInstance().listBans(for: activeAccount.accountId, in: room.token) { [weak self] bannedActors in
+        NCAPIController.sharedInstance().listBans(for: room.accountId, in: room.token) { [weak self] bannedActors in
             guard let self else { return }
 
             self.bannedActors = bannedActors ?? []
@@ -105,9 +103,7 @@
         self.showActivityIndicator()
         cell.setDisabledState()
 
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-
-        NCAPIController.sharedInstance().unbanActor(for: activeAccount.accountId, in: self.room.token, with: bannedActor.banId) { [weak self] success in
+        NCAPIController.sharedInstance().unbanActor(for: room.accountId, in: self.room.token, with: bannedActor.banId) { [weak self] success in
             if !success {
                 NotificationPresenter.shared().present(text: NSLocalizedString("Failed to unban selected entry", comment: ""), dismissAfterDelay: 5.0, includedStyle: .error)
             }

--- a/NextcloudTalk/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/BaseChatTableViewCell.swift
@@ -189,7 +189,9 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
 
         self.titleLabel.attributedText = titleLabel
 
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        guard let account = message.account
+        else { return }
+
         let shouldShowDeliveryStatus = NCDatabaseManager.sharedInstance().roomHasTalkCapability(kCapabilityChatReadStatus, for: room)
         var shouldShowReadStatus = false
 
@@ -221,7 +223,7 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
             self.setDeliveryState(to: .failed)
         } else if message.isTemporary {
             self.setDeliveryState(to: .sending)
-        } else if message.isMessage(from: activeAccount.userId), shouldShowDeliveryStatus {
+        } else if message.isMessage(from: account.userId), shouldShowDeliveryStatus {
             if room.lastCommonReadMessage >= message.messageId, shouldShowReadStatus {
                 self.setDeliveryState(to: .read)
             } else {

--- a/NextcloudTalk/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/BaseChatTableViewCell.swift
@@ -204,7 +204,7 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
             let quoteString = parent.parsedMarkdownForChat()?.string ?? ""
             self.quotedMessageView?.messageLabel.text = quoteString
             self.quotedMessageView?.actorLabel.attributedText = parent.actor.attributedDisplayName
-            self.quotedMessageView?.highlighted = parent.isMessage(from: activeAccount.userId)
+            self.quotedMessageView?.highlighted = parent.isMessage(from: account.userId)
             self.quotedMessageView?.avatarView.setActorAvatar(forMessage: parent)
         }
 
@@ -269,7 +269,7 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
             self.setupForPollCell(with: message)
         } else if message.file() != nil {
             // File message
-            self.setupForFileCell(with: message, with: activeAccount)
+            self.setupForFileCell(with: message, with: account)
         } else if message.geoLocation() != nil {
             // Location message
             self.setupForLocationCell(with: message)
@@ -461,11 +461,10 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
     // MARK: - Avatar User Menu
 
     func getDeferredUserMenu() -> UIMenu? {
-        guard let message = self.message else { return nil }
+        guard let message = self.message, let account = message.account
+        else { return nil }
 
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-
-        if message.actorType != "users" || message.actorId == activeAccount.userId {
+        if message.actorType != "users" || message.actorId == account.userId {
             return nil
         }
 
@@ -480,9 +479,9 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
     }
 
     func getMenuUserAction(for message: NCChatMessage, completionBlock: @escaping ([UIMenuElement]) -> Void) {
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        guard let account = message.account else { return }
 
-        NCAPIController.sharedInstance().getUserActions(forUser: message.actorId, using: activeAccount) { userActionsRaw, error in
+        NCAPIController.sharedInstance().getUserActions(forUser: message.actorId, using: account) { userActionsRaw, error in
             guard error == nil,
                   let userActionsDict = userActionsRaw as? [String: AnyObject],
                   let userActions = userActionsDict["actions"] as? [[String: String]],

--- a/NextcloudTalk/CallParticipantViewCell.m
+++ b/NextcloudTalk/CallParticipantViewCell.m
@@ -124,7 +124,8 @@ CGFloat const kCallParticipantCellMinHeight = 128;
         [self setBackgroundColor:[[ColorGenerator shared] usernameToColor:actor.id]];
     }
 
-    [self.peerAvatarImageView setActorAvatarForId:actor.id withType:actor.type withDisplayName:actor.displayName withRoomToken:nil];
+    TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+    [self.peerAvatarImageView setActorAvatarForId:actor.id withType:actor.type withDisplayName:actor.displayName withRoomToken:nil using:activeAccount];
 }
 
 - (void)setDisplayName:(NSString *)displayName

--- a/NextcloudTalk/CallViewController.swift
+++ b/NextcloudTalk/CallViewController.swift
@@ -831,7 +831,8 @@ class CallViewController: UIViewController,
         // Connect to new call
         let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
         NCRoomsManager.sharedInstance().updateRoom(token) { roomDict, error in
-            guard error == nil else {
+            guard error == nil, let newRoom = NCRoom(dictionary: roomDict, andAccountId: activeAccount.accountId)
+            else {
                 print("Error getting room to switch")
                 return
             }
@@ -842,7 +843,7 @@ class CallViewController: UIViewController,
                 self.delegate?.callViewController(self, wantsToSwitchFromCall: self.room.token, toRoom: token)
 
                 // Assign new room as current room
-                self.room = NCRoom(dictionary: roomDict, andAccountId: activeAccount.accountId)
+                self.room = newRoom
 
                 // Save current audio and video state
                 self.audioDisabledAtStart = !audioEnabled

--- a/NextcloudTalk/ContactsSearchResultTableViewContoller.swift
+++ b/NextcloudTalk/ContactsSearchResultTableViewContoller.swift
@@ -86,7 +86,8 @@ import UIKit
         contactCell.labelTitle.text = contact.name
 
         let contactType = contact.source as String
-        contactCell.contactImage.setActorAvatar(forId: contact.userId, withType: contactType, withDisplayName: contact.name, withRoomToken: nil)
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        contactCell.contactImage.setActorAvatar(forId: contact.userId, withType: contactType, withDisplayName: contact.name, withRoomToken: nil, using: activeAccount)
 
         return contactCell
     }

--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -220,8 +220,7 @@ import UIKit
     func showSuggestions(for string: String) {
         self.autocompletionUsers = []
 
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        NCAPIController.sharedInstance().getMentionSuggestions(for: activeAccount.accountId, in: self.room.token, with: string) { mentions in
+        NCAPIController.sharedInstance().getMentionSuggestions(for: self.room.accountId, in: self.room.token, with: string) { mentions in
             guard let mentions else { return }
 
             self.autocompletionUsers = mentions
@@ -310,7 +309,9 @@ import UIKit
         if suggestion.id == "all" {
             cell.avatarButton.setAvatar(for: self.room)
         } else {
-            cell.avatarButton.setActorAvatar(forId: suggestion.id, withType: suggestion.source, withDisplayName: suggestion.label, withRoomToken: self.room.token)
+            if let account = room.account {
+                cell.avatarButton.setActorAvatar(forId: suggestion.id, withType: suggestion.source, withDisplayName: suggestion.label, withRoomToken: self.room.token, using: account)
+            }
         }
 
         cell.accessibilityIdentifier = AutoCompletionCellIdentifier

--- a/NextcloudTalk/NCChatMessage.h
+++ b/NextcloudTalk/NCChatMessage.h
@@ -40,8 +40,8 @@ typedef void (^GetReferenceDataCompletionBlock)(NCChatMessage *message, NSDictio
 
 @interface NCChatMessage : RLMObject <NSCopying>
 
-@property (nonatomic, strong) NSString *internalId; // accountId@token@messageId
-@property (nonatomic, strong) NSString *accountId;
+@property (nonatomic, strong, nullable) NSString *internalId; // accountId@token@messageId
+@property (nonatomic, strong, nullable) NSString *accountId;
 @property (nonatomic, strong) NSString *actorDisplayName;
 @property (nonatomic, strong) NSString *actorId;
 @property (nonatomic, strong) NSString *actorType;

--- a/NextcloudTalk/NCChatMessage.swift
+++ b/NextcloudTalk/NCChatMessage.swift
@@ -195,7 +195,7 @@ import SwiftyAttributes
 
     internal var isReferenceApiSupported: Bool {
         // Check capabilities directly, otherwise NCSettingsController introduces new dependencies in NotificationServiceExtension
-        if self.accountId != nil, let serverCapabilities = NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: self.accountId) {
+        if let accountId, let serverCapabilities = NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: accountId) {
             return serverCapabilities.referenceApiSupported
         }
 
@@ -231,7 +231,8 @@ import SwiftyAttributes
     }
 
     public var account: TalkAccount? {
-        return NCDatabaseManager.sharedInstance().talkAccount(forAccountId: self.accountId)
+        guard let accountId else { return nil }
+        return NCDatabaseManager.sharedInstance().talkAccount(forAccountId: accountId)
     }
 
     public var messageIconName: String? {

--- a/NextcloudTalk/NCChatMessage.swift
+++ b/NextcloudTalk/NCChatMessage.swift
@@ -195,9 +195,7 @@ import SwiftyAttributes
 
     internal var isReferenceApiSupported: Bool {
         // Check capabilities directly, otherwise NCSettingsController introduces new dependencies in NotificationServiceExtension
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-
-        if let serverCapabilities = NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: activeAccount.accountId) {
+        if self.accountId != nil, let serverCapabilities = NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: self.accountId) {
             return serverCapabilities.referenceApiSupported
         }
 
@@ -230,6 +228,10 @@ import SwiftyAttributes
 
     public var actor: TalkActor {
         return TalkActor(actorId: self.actorId, actorType: self.actorType, actorDisplayName: self.actorDisplayName)
+    }
+
+    public var account: TalkAccount? {
+        return NCDatabaseManager.sharedInstance().talkAccount(forAccountId: self.accountId)
     }
 
     public var messageIconName: String? {
@@ -267,5 +269,4 @@ import SwiftyAttributes
 
         return file.size <= maxGifSize
     }
-
 }

--- a/NextcloudTalk/NCMediaViewerViewController.swift
+++ b/NextcloudTalk/NCMediaViewerViewController.swift
@@ -94,8 +94,10 @@ import UIKit
 
     // MARK: - PageViewController delegate
 
-    func getAllFileMessages() -> RLMResults<AnyObject> {
-        let query = NSPredicate(format: "accountId = %@ AND token = %@ AND messageParametersJSONString contains[cd] %@", self.initialMessage.accountId, self.initialMessage.token, "\"file\":")
+    func getAllFileMessages() -> RLMResults<AnyObject>? {
+        guard let accountId = self.initialMessage.accountId else { return nil }
+
+        let query = NSPredicate(format: "accountId = %@ AND token = %@ AND messageParametersJSONString contains[cd] %@", accountId, self.initialMessage.token, "\"file\":")
         let messages = NCChatMessage.objects(with: query).sortedResults(usingKeyPath: "messageId", ascending: true)
 
         return messages
@@ -103,7 +105,9 @@ import UIKit
 
     func getPreviousFileMessage(from message: NCChatMessage) -> NCChatMessage? {
         let prevQuery = NSPredicate(format: "messageId < %ld", message.messageId)
-        let messageObject = self.getAllFileMessages().objects(with: prevQuery).lastObject()
+
+        guard let queriedObjects = self.getAllFileMessages()?.objects(with: prevQuery) else { return nil }
+        let messageObject = queriedObjects.lastObject()
 
         if let message = messageObject as? NCChatMessage {
             if NCUtils.isImage(fileType: message.file().mimetype) {
@@ -119,7 +123,8 @@ import UIKit
 
     func getNextFileMessage(from message: NCChatMessage) -> NCChatMessage? {
         let prevQuery = NSPredicate(format: "messageId > %ld", message.messageId)
-        let messageObject = self.getAllFileMessages().objects(with: prevQuery).firstObject()
+
+        guard let messageObject = self.getAllFileMessages()?.objects(with: prevQuery).firstObject() else { return nil }
 
         if let message = messageObject as? NCChatMessage {
             if NCUtils.isImage(fileType: message.file().mimetype) {

--- a/NextcloudTalk/NCRoom.h
+++ b/NextcloudTalk/NCRoom.h
@@ -88,8 +88,8 @@ extern NSString * const NCRoomObjectTypeRoom;
 
 @interface NCRoom : RLMObject
 
-@property (nonatomic, copy) NSString *internalId; // accountId@token
-@property (nonatomic, copy) NSString *accountId;
+@property (nonatomic, copy, nonnull) NSString *internalId; // accountId@token
+@property (nonatomic, copy, nonnull) NSString *accountId;
 @property (nonatomic, copy) NSString *token;
 @property (nonatomic, copy) NSString *name;
 @property (nonatomic, copy) NSString *displayName;
@@ -143,8 +143,7 @@ extern NSString * const NCRoomObjectTypeRoom;
 @property (nonatomic, copy) NSString *lastReceivedProxyHash;
 @property (nonatomic, assign) NSInteger mentionPermissions;
 
-+ (instancetype)roomWithDictionary:(NSDictionary *)roomDict;
-+ (instancetype)roomWithDictionary:(NSDictionary *)roomDict andAccountId:(NSString *)accountId;
-+ (void)updateRoom:(NCRoom *)managedRoom withRoom:(NCRoom *)room;
++ (instancetype _Nullable)roomWithDictionary:(NSDictionary * _Nullable)roomDict andAccountId:(NSString * _Nullable)accountId;
++ (void)updateRoom:(NCRoom * _Nonnull)managedRoom withRoom:(NCRoom * _Nonnull)room;
 
 @end

--- a/NextcloudTalk/NCRoom.m
+++ b/NextcloudTalk/NCRoom.m
@@ -23,8 +23,8 @@ NSString * const NCRoomObjectTypeRoom           = @"room";
 
     NCRoom *room = [[self alloc] init];
     room.accountId = accountId;
-    room.internalId = [NSString stringWithFormat:@"%@@%@", room.accountId, room.token];
     room.token = [roomDict objectForKey:@"token"];
+    room.internalId = [NSString stringWithFormat:@"%@@%@", room.accountId, room.token];
     room.type = (NCRoomType)[[roomDict objectForKey:@"type"] integerValue];
     room.roomDescription = [roomDict objectForKey:@"description"];
     room.hasPassword = [[roomDict objectForKey:@"hasPassword"] boolValue];

--- a/NextcloudTalk/NCRoom.m
+++ b/NextcloudTalk/NCRoom.m
@@ -14,13 +14,16 @@ NSString * const NCRoomObjectTypeRoom           = @"room";
 
 @implementation NCRoom
 
-+ (instancetype)roomWithDictionary:(NSDictionary *)roomDict
++ (instancetype)roomWithDictionary:(NSDictionary *)roomDict andAccountId:(NSString *)accountId
 {
+
     if (!roomDict) {
         return nil;
     }
-    
+
     NCRoom *room = [[self alloc] init];
+    room.accountId = accountId;
+    room.internalId = [NSString stringWithFormat:@"%@@%@", room.accountId, room.token];
     room.token = [roomDict objectForKey:@"token"];
     room.type = (NCRoomType)[[roomDict objectForKey:@"type"] integerValue];
     room.roomDescription = [roomDict objectForKey:@"description"];
@@ -126,17 +129,6 @@ NSString * const NCRoomObjectTypeRoom           = @"room";
         }
     }
 
-    return room;
-}
-
-+ (instancetype)roomWithDictionary:(NSDictionary *)roomDict andAccountId:(NSString *)accountId
-{
-    NCRoom *room = [self roomWithDictionary:roomDict];
-    if (room) {
-        room.accountId = accountId;
-        room.internalId = [NSString stringWithFormat:@"%@@%@", room.accountId, room.token];
-    }
-    
     return room;
 }
 

--- a/NextcloudTalk/NCRoom.swift
+++ b/NextcloudTalk/NCRoom.swift
@@ -268,4 +268,8 @@ import Realm
         return "\(account.server)\(indexString)/call/\(token)"
     }
 
+    public var account: TalkAccount? {
+        return NCDatabaseManager.sharedInstance().talkAccount(forAccountId: self.accountId)
+    }
+
 }

--- a/NextcloudTalk/NCRoomsManagerExtensions.swift
+++ b/NextcloudTalk/NCRoomsManagerExtensions.swift
@@ -421,7 +421,8 @@ import Foundation
                 // Inform the chatViewController about this change
                 NotificationCenter.default.post(name: .NCChatControllerDidSendChatMessage, object: self, userInfo: userInfo)
             } else {
-                if let room = NCDatabaseManager.sharedInstance().room(withToken: offlineMessage.token, forAccountId: offlineMessage.accountId),
+                if let accountId = offlineMessage.accountId,
+                   let room = NCDatabaseManager.sharedInstance().room(withToken: offlineMessage.token, forAccountId: accountId),
                    let chatController = NCChatController(for: room) {
                     chatController.send(offlineMessage)
                 }

--- a/NextcloudTalk/NewRoomTableViewController.swift
+++ b/NextcloudTalk/NewRoomTableViewController.swift
@@ -215,7 +215,8 @@ enum NewRoomOption: Int {
             contactCell.labelTitle.text = contact.name
 
             let contactType = contact.source as String
-            contactCell.contactImage.setActorAvatar(forId: contact.userId, withType: contactType, withDisplayName: contact.name, withRoomToken: nil)
+            let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+            contactCell.contactImage.setActorAvatar(forId: contact.userId, withType: contactType, withDisplayName: contact.name, withRoomToken: nil, using: account)
 
             return contactCell
         }

--- a/NextcloudTalk/PollResultsDetailsViewController.swift
+++ b/NextcloudTalk/PollResultsDetailsViewController.swift
@@ -119,7 +119,9 @@ import UIKit
         cell.titleLabel.text = detail.actorDisplayName
 
         // Actor avatar
-        cell.avatarImageView.setActorAvatar(forId: detail.actorId, withType: detail.actorType, withDisplayName: detail.actorDisplayName, withRoomToken: self.room.token)
+        if let account = room.account {
+            cell.avatarImageView.setActorAvatar(forId: detail.actorId, withType: detail.actorType, withDisplayName: detail.actorDisplayName, withRoomToken: self.room.token, using: account)
+        }
 
         return cell
     }

--- a/NextcloudTalk/PollVotingView.swift
+++ b/NextcloudTalk/PollVotingView.swift
@@ -73,7 +73,8 @@ import UIKit
     }
 
     func setupPollView() {
-        guard let poll = poll else {return}
+        guard let poll else {return}
+
         // Set poll settings
         let activeAccountUserId = NCDatabaseManager.sharedInstance().activeAccount().userId
         self.isPollOpen = poll.status == .open
@@ -130,7 +131,8 @@ import UIKit
     }
 
     func voteButtonPressed() {
-        guard let poll = poll, let room = room else {return}
+        guard let poll, let room else {return}
+
         footerView.primaryButton.isEnabled = false
         NCAPIController.sharedInstance().voteOnPoll(withId: poll.pollId, inRoom: room.token, withOptions: userSelectedOptions,
         for: NCDatabaseManager.sharedInstance().activeAccount()) { responsePoll, error, _ in
@@ -190,7 +192,8 @@ import UIKit
     }
 
     func closePoll() {
-        guard let poll = poll, let room = room else {return}
+        guard let poll, let room else {return}
+
         NCAPIController.sharedInstance().closePoll(withId: poll.pollId, inRoom: room.token, for: NCDatabaseManager.sharedInstance().activeAccount()) { responsePoll, error, _ in
             if let responsePoll = responsePoll, error == nil {
                 self.poll = responsePoll

--- a/NextcloudTalk/ReactionsSummaryView.swift
+++ b/NextcloudTalk/ReactionsSummaryView.swift
@@ -106,7 +106,9 @@ import UIKit
         let actorId = actor?["actorId"] as? String ?? ""
         let actorType = actor?["actorType"] as? String ?? ""
 
-        cell.avatarImageView.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: self.room?.token)
+        if let room, let account = room.account {
+            cell.avatarImageView.setActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: room.token, using: account)
+        }
 
         return cell
     }

--- a/NextcloudTalk/ReferenceTalkView.swift
+++ b/NextcloudTalk/ReferenceTalkView.swift
@@ -76,7 +76,7 @@ import SwiftyAttributes
             let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
             let room = NCDatabaseManager.sharedInstance().room(withToken: roomToken, forAccountId: activeAccount.accountId)
 
-            if let room = room {
+            if let room {
                 self.referenceTypeIcon.setAvatar(for: room)
                 self.referenceTypeIcon.layer.cornerRadius = self.referenceTypeIcon.frame.height / 2
             } else {

--- a/NextcloudTalk/ResultMultiSelectionTableViewController.m
+++ b/NextcloudTalk/ResultMultiSelectionTableViewController.m
@@ -107,8 +107,13 @@
         // Only when adding new (email) participants we show the mail avatar
         [cell.contactImage setMailAvatar];
     } else {
-        [cell.contactImage setActorAvatarForId:contact.userId withType:contact.source withDisplayName:contact.name withRoomToken:_room.token];
+        TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+
+        if (activeAccount) {
+            [cell.contactImage setActorAvatarForId:contact.userId withType:contact.source withDisplayName:contact.name withRoomToken:_room.token using:activeAccount];
+        }
     }
+
     UIImage *selectionImage = [UIImage systemImageNamed:@"circle"];
     UIColor *selectionImageColor = [UIColor tertiaryLabelColor];
     for (NCUser *user in _selectedParticipants) {

--- a/NextcloudTalk/RoomAvatarInfoTableViewController.swift
+++ b/NextcloudTalk/RoomAvatarInfoTableViewController.swift
@@ -169,11 +169,12 @@ enum RoomAvatarInfoSection: Int {
     }
 
     func setButtonPressed() {
+        guard let account = room.account else { return }
+
         self.showModifyingView()
         self.descriptionHeaderView.button.isHidden = true
 
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        NCAPIController.sharedInstance().setRoomDescription(currentDescription, forRoom: room.token, forAccount: activeAccount) { error in
+        NCAPIController.sharedInstance().setRoomDescription(currentDescription, forRoom: room.token, forAccount: account) { error in
             if error != nil {
                 NCUserInterfaceController.sharedInstance().presentAlert(withTitle: NSLocalizedString("An error occurred while setting description", comment: ""), withMessage: nil)
             }
@@ -380,10 +381,11 @@ enum RoomAvatarInfoSection: Int {
             return true
         }
 
+        guard let account = room.account else { return true }
+
         self.showModifyingView()
 
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        NCAPIController.sharedInstance().renameRoom(self.room.token, forAccount: activeAccount, withName: newRoomValue) { error in
+        NCAPIController.sharedInstance().renameRoom(self.room.token, forAccount: account, withName: newRoomValue) { error in
             if error != nil {
                 let alertTitle = NSLocalizedString("Could not rename the conversation", comment: "")
                 NCUserInterfaceController.sharedInstance().presentAlert(withTitle: alertTitle, withMessage: nil)

--- a/NextcloudTalk/RoomCreationTableViewController.swift
+++ b/NextcloudTalk/RoomCreationTableViewController.swift
@@ -455,7 +455,8 @@ enum RoomVisibilityOption: Int {
                 participantCell.labelTitle.text = participant.name
 
                 let participantType = participant.source as String
-                participantCell.contactImage.setActorAvatar(forId: participant.userId, withType: participantType, withDisplayName: participant.name, withRoomToken: nil)
+                let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+                participantCell.contactImage.setActorAvatar(forId: participant.userId, withType: participantType, withDisplayName: participant.name, withRoomToken: nil, using: activeAccount)
 
                 return participantCell
             }

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -2275,7 +2275,11 @@ typedef enum FileAction {
             cell.labelTitle.text = [self detailedNameForParticipant:participant];
             
             // Avatar
-            [cell.contactImage setActorAvatarForId:participant.actorId withType:participant.actorType withDisplayName:participant.displayName withRoomToken:self.room.token];
+            TalkAccount *account = self->_room.account;
+
+            if (account) {
+                [cell.contactImage setActorAvatarForId:participant.actorId withType:participant.actorType withDisplayName:participant.displayName withRoomToken:self.room.token using:account];
+            }
 
             // User status
             [cell setUserStatus:participant.status];

--- a/NextcloudTalk/RoomSearchTableViewController.m
+++ b/NextcloudTalk/RoomSearchTableViewController.m
@@ -193,7 +193,8 @@ typedef enum RoomSearchSection {
         [cell.roomImage setImageWithURL:thumbnailURL placeholderImage:nil];
         cell.roomImage.contentMode = UIViewContentModeScaleToFill;
     } else {
-        [cell.roomImage setActorAvatarForId:actorId withType:actorType withDisplayName:@"" withRoomToken:nil];
+        TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+        [cell.roomImage setActorAvatarForId:actorId withType:actorType withDisplayName:@"" withRoomToken:nil using:activeAccount];
     }
     
     // Clear possible content not removed by cell reuse
@@ -234,7 +235,8 @@ typedef enum RoomSearchSection {
 
     cell.titleLabel.text = user.name;
     cell.titleOnly = YES;
-    [cell.roomImage setActorAvatarForId:user.userId withType:user.source withDisplayName:user.name withRoomToken:nil];
+    TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+    [cell.roomImage setActorAvatarForId:user.userId withType:user.source withDisplayName:user.name withRoomToken:nil using:activeAccount];
 
     return cell;
 }

--- a/NextcloudTalk/RoomSharedItemsTableViewController.swift
+++ b/NextcloudTalk/RoomSharedItemsTableViewController.swift
@@ -13,7 +13,6 @@ import QuickLook
                                                         VLCKitVideoViewControllerDelegate {
 
     let room: NCRoom
-    let account: TalkAccount = NCDatabaseManager.sharedInstance().activeAccount()
     let itemsOverviewLimit: Int = 1
     let itemLimit: Int = 100
     var sharedItemsOverview: [String: [NCChatMessage]] = [:]
@@ -72,7 +71,10 @@ import QuickLook
     }
 
     func getItemsForItemType(itemType: String) {
+        guard let account = room.account else { return }
+
         showFetchingItemsPlaceholderView()
+
         NCAPIController.sharedInstance()
             .getSharedItems(ofType: itemType, fromLastMessageId: currentLastItemId, withLimit: itemLimit,
                             inRoom: room.token, for: account) { items, lastItemId, error, _ in
@@ -109,7 +111,10 @@ import QuickLook
     }
 
     func getItemsOverview() {
+        guard let account = room.account else { return }
+
         showFetchingItemsPlaceholderView()
+
         NCAPIController.sharedInstance()
             .getSharedItemsOverview(inRoom: room.token, withLimit: itemsOverviewLimit, for: account) { itemsOverview, error, _ in
                 if error == nil {

--- a/NextcloudTalk/SearchTableViewController.m
+++ b/NextcloudTalk/SearchTableViewController.m
@@ -102,8 +102,12 @@
     
     cell.labelTitle.text = contact.name;
     
-    [cell.contactImage setActorAvatarForId:contact.userId withType:contact.source withDisplayName:contact.name withRoomToken:nil];
-    
+    TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+
+    if (activeAccount) {
+        [cell.contactImage setActorAvatarForId:contact.userId withType:contact.source withDisplayName:contact.name withRoomToken:nil using:activeAccount];
+    }
+
     return cell;
 }
 

--- a/NextcloudTalk/UserStatusOptionsSwiftUI.swift
+++ b/NextcloudTalk/UserStatusOptionsSwiftUI.swift
@@ -51,8 +51,8 @@ struct UserStatusOptionsSwiftUI: View {
     }
 
     func setActiveUserStatus(userStatus: String) {
-        let activeAcoount: TalkAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        NCAPIController.sharedInstance().setUserStatus(userStatus, for: activeAcoount) { _ in
+        let activeAccount: TalkAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        NCAPIController.sharedInstance().setUserStatus(userStatus, for: activeAccount) { _ in
             getActiveUserStatus()
             dismiss()
             changed.toggle()

--- a/NextcloudTalkTests/Integration/Helpers.swift
+++ b/NextcloudTalkTests/Integration/Helpers.swift
@@ -10,11 +10,11 @@ import Foundation
 extension XCTestCase {
 
     // TODO: This should probably be part of APIController
-    func getRoomDict(from rawRoomDict: [Any]) -> [NCRoom] {
+    func getRoomDict(from rawRoomDict: [Any], for account: TalkAccount) -> [NCRoom] {
         var rooms: [NCRoom] = []
         for roomDict in rawRoomDict {
             if let roomDict = roomDict as? [AnyHashable: Any] {
-                rooms.append(NCRoom(dictionary: roomDict))
+                rooms.append(NCRoom(dictionary: roomDict, andAccountId: account.accountId))
             }
         }
 
@@ -27,7 +27,7 @@ extension XCTestCase {
         NCAPIController.sharedInstance().getRooms(forAccount: account, updateStatus: false, modifiedSince: 0) { roomsDict, error in
             XCTAssertNil(error)
 
-            let rooms = self.getRoomDict(from: roomsDict!)
+            let rooms = self.getRoomDict(from: roomsDict!, for: account)
             let room = rooms.first(where: { $0.displayName == roomName })
             XCTAssertNotNil(room)
 

--- a/NextcloudTalkTests/Integration/Helpers.swift
+++ b/NextcloudTalkTests/Integration/Helpers.swift
@@ -13,8 +13,8 @@ extension XCTestCase {
     func getRoomDict(from rawRoomDict: [Any], for account: TalkAccount) -> [NCRoom] {
         var rooms: [NCRoom] = []
         for roomDict in rawRoomDict {
-            if let roomDict = roomDict as? [AnyHashable: Any] {
-                rooms.append(NCRoom(dictionary: roomDict, andAccountId: account.accountId))
+            if let roomDict = roomDict as? [AnyHashable: Any], let ncRooms = NCRoom(dictionary: roomDict, andAccountId: account.accountId) {
+                rooms.append(ncRooms)
             }
         }
 

--- a/NextcloudTalkTests/Unit/Chat/UnitBaseChatViewControllerTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitBaseChatViewControllerTest.swift
@@ -39,7 +39,7 @@ final class UnitBaseChatViewControllerTest: TestBaseRealm {
         try super.setUpWithError()
 
         baseController = BaseChatViewController(for: NCRoom())!
-        testMessage = NCChatMessage()
+        testMessage = NCChatMessage(dictionary: [:], andAccountId: UnitBaseChatViewControllerTest.fakeAccountId)
     }
 
     func testInvisibleCellHeight() throws {


### PR DESCRIPTION
In most cases we are able to get the associated TalkAccount through a different way than using `activeAccount`, so we should try to do that.
Currently that does not work in all situations, so that's something to improve on.

At the same time, we only used the method to create a `NCRoom` object without an `accountId` in our tests. So I got rid of that method entirely.