### PR TITLE
Use pre-installed PHP 8.3 on runners

### DIFF
--- a/.github/workflows/uitests.yml
+++ b/.github/workflows/uitests.yml
@@ -84,10 +84,10 @@ jobs:
         configs: [
           { talkbranch: 'stable23', serverbranch: 'stable23', phpversion: '8.0' },
           { talkbranch: 'stable27', serverbranch: 'stable27', phpversion: '8.2' },
-          { talkbranch: 'stable28', serverbranch: 'stable28', phpversion: '8.2' },
-          { talkbranch: 'stable29', serverbranch: 'stable29', phpversion: '8.2' },
-          { talkbranch: 'stable30', serverbranch: 'stable30', phpversion: '8.2' },
-          { talkbranch: 'main', serverbranch: 'master', phpversion: '8.2' }
+          { talkbranch: 'stable28', serverbranch: 'stable28', phpversion: '8.3' },
+          { talkbranch: 'stable29', serverbranch: 'stable29', phpversion: '8.3' },
+          { talkbranch: 'stable30', serverbranch: 'stable30', phpversion: '8.3' },
+          { talkbranch: 'main', serverbranch: 'master', phpversion: '8.3' }
         ]
 
     steps:


### PR DESCRIPTION
PHP 8.3 is pre installed on all macos runners (e.g. https://github.com/actions/runner-images/blob/macos-12/20240819.7/images/macos/macos-12-Readme.md). So we should use that to safe some manual installation time.