### PR TITLE
Add message icons

### DIFF
--- a/NextcloudTalk/NCChatMessage.h
+++ b/NextcloudTalk/NCChatMessage.h
@@ -83,8 +83,8 @@ typedef void (^GetReferenceDataCompletionBlock)(NCChatMessage *message, NSDictio
 + (void)updateChatMessage:(NCChatMessage *)managedChatMessage withChatMessage:(NCChatMessage *)chatMessage isRoomLastMessage:(BOOL)isRoomLastMessage;
 
 - (NCMessageFileParameter *)file;
-- (NCMessageLocationParameter *)geoLocation;
-- (NCDeckCardParameter *)deckCard;
+- (NCMessageLocationParameter * _Nullable)geoLocation;
+- (NCDeckCardParameter * _Nullable)deckCard;
 - (NSString *)objectShareLink;
 - (NSMutableAttributedString *)parsedMessage;
 - (NSMutableAttributedString *)parsedMarkdown;

--- a/NextcloudTalk/NCChatMessage.swift
+++ b/NextcloudTalk/NCChatMessage.swift
@@ -232,4 +232,29 @@ import SwiftyAttributes
         return TalkActor(actorId: self.actorId, actorType: self.actorType, actorDisplayName: self.actorDisplayName)
     }
 
+    public var messageIconName: String? {
+        if let file = self.file() {
+            if NCUtils.isImage(fileType: file.mimetype) {
+                return "photo"
+            } else if NCUtils.isVideo(fileType: file.mimetype) {
+                return "movieclapper"
+            } else if NCUtils.isVCard(fileType: file.mimetype) {
+                return "person.text.rectangle"
+            } else if self.isVoiceMessage {
+                return "mic"
+            } else if NCUtils.isAudio(fileType: file.mimetype) {
+                return "music.note"
+            } else {
+                return "doc"
+            }
+        } else if poll != nil {
+            return "chart.bar"
+        } else if deckCard() != nil {
+            return "rectangle.stack"
+        } else if geoLocation() != nil {
+            return "location"
+        }
+
+        return nil
+    }
 }

--- a/NextcloudTalk/NCRoom.swift
+++ b/NextcloudTalk/NCRoom.swift
@@ -183,7 +183,7 @@ import Realm
         return "\(self.messageExpiration)s"
     }
 
-    public var lastMessageString: String? {
+    public var lastMessageString: NSMutableAttributedString? {
         var lastMessage = self.lastMessage
 
         if self.isFederated && lastMessage == nil {
@@ -218,11 +218,19 @@ import Realm
             actorName = "\(actorName): "
         }
 
-        // Create last message
-        let lastMessageString = "\(actorName)\(lastMessage.parsedMarkdown().string)"
+        let lastMessageString = NSMutableAttributedString(string: actorName)
 
-        // Limit last message string to 80 characters
-        return String(lastMessageString.prefix(80))
+        if let messageIconName = lastMessage.messageIconName, let messageIcon = UIImage(systemName: messageIconName) {
+            let attachmentString = NSMutableAttributedString(attachment: NSTextAttachment(image: messageIcon))
+            attachmentString.append(NSAttributedString(string: " "))
+
+            lastMessageString.append(attachmentString)
+        }
+
+        let parsedMarkdownString = String(lastMessage.parsedMarkdown().string.prefix(80))
+        lastMessageString.append(NSAttributedString(string: parsedMarkdownString))
+
+        return lastMessageString.withFont(.preferredFont(forTextStyle: .callout)).withTextColor(.secondaryLabel)
     }
 
     private var lastMessageProxiedDictionary: [AnyHashable: Any] {

--- a/NextcloudTalk/NCUtils.swift
+++ b/NextcloudTalk/NCUtils.swift
@@ -76,6 +76,14 @@ import AVFoundation
         return self.previewImage(forMimeType: fileType) == "file-video"
     }
 
+    public static func isAudio(fileType: String) -> Bool {
+        return self.previewImage(forMimeType: fileType) == "file-audio"
+    }
+
+    public static func isVCard(fileType: String) -> Bool {
+        return self.previewImage(forMimeType: fileType) == "file-vcard"
+    }
+
     public static func isNextcloudAppInstalled() -> Bool {
         var isInstalled = false
 

--- a/NextcloudTalk/RoomSearchTableViewController.m
+++ b/NextcloudTalk/RoomSearchTableViewController.m
@@ -310,7 +310,7 @@ typedef enum RoomSearchSection {
     // Set last activity
     if (room.lastMessageId || room.lastMessageProxiedJSONString) {
         cell.titleOnly = NO;
-        cell.subtitleLabel.text = room.lastMessageString;
+        cell.subtitleLabel.attributedText = room.lastMessageString;
     } else {
         cell.titleOnly = YES;
     }

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1392,7 +1392,7 @@ typedef enum RoomsSections {
     // Set last activity
     if (room.lastMessageId || room.lastMessageProxiedJSONString) {
         cell.titleOnly = NO;
-        cell.subtitleLabel.text = room.lastMessageString;
+        cell.subtitleLabel.attributedText = room.lastMessageString;
     } else {
         cell.titleOnly = YES;
     }


### PR DESCRIPTION
* Supersedes https://github.com/nextcloud/talk-ios/pull/963
* Ref https://github.com/nextcloud/spreed/pull/13333

We decided to go for icons and not emojis for this one. Only downside for this approach is that it doesn't have an effect on push notifications.

<img src=https://github.com/user-attachments/assets/7d8e2d1f-e44b-4cc5-b7ce-0822cc4da7d7 width=300 />

<br />
<img width="325" alt="Bildschirmfoto 2024-09-18 um 20 16 35" src="https://github.com/user-attachments/assets/cc6bc026-1093-462f-8dbb-2bf9ca06bca2">
