### PR TITLE
Ensure non-nil sessionId

### DIFF
--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -202,10 +202,6 @@ import SwiftyAttributes
         }
 
         if !self.offlineMode {
-            if self.room.token == nil {
-                fatalTokenError()
-            }
-
             NCRoomsManager.sharedInstance().joinRoom(self.room.token, forCall: false)
         }
 
@@ -213,39 +209,6 @@ import SwiftyAttributes
         if !AiSummaryController.shared.getSummaryTaskIds(forRoomInternalId: self.room.internalId).isEmpty {
             self.showGeneratingSummaryNotification()
             self.scheduleSummaryTaskCheck()
-        }
-    }
-
-    private func fatalTokenError() {
-        let capabilities = NCDatabaseManager.sharedInstance().serverCapabilities()
-
-        switch capabilities.versionMajor {
-        case 19:
-            fatalError()
-        case 20:
-            fatalError()
-        case 21:
-            fatalError()
-        case 22:
-            fatalError()
-        case 23:
-            fatalError()
-        case 24:
-            fatalError()
-        case 25:
-            fatalError()
-        case 26:
-            fatalError()
-        case 27:
-            fatalError()
-        case 28:
-            fatalError()
-        case 29:
-            fatalError()
-        case 30:
-            fatalError()
-        default:
-            fatalError()
         }
     }
 
@@ -289,11 +252,7 @@ import SwiftyAttributes
         // Check if new messages were added while the app was inactive (eg. via background-refresh)
         self.checkForNewStoredMessages()
 
-        if !self.offlineMode {
-            if self.room.token == nil {
-                fatalTokenError()
-            }
-            
+        if !self.offlineMode {            
             NCRoomsManager.sharedInstance().joinRoom(self.room.token, forCall: false)
         }
 

--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -785,7 +785,7 @@ import SwiftyAttributes
             return
         }
 
-        if let room = notification.userInfo?["room"] as? NCRoom {
+        if let room = notification.userInfo?["room"] as? NCRoom, room.token == self.room.token {
             self.room = room
         }
 

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -368,6 +368,11 @@ NSInteger const kReceivedChatMessagesLimit = 100;
         NCRoom *room = nil;
         if ([[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityListableRooms forAccountId:account.accountId]) {
             room = [NCRoom roomWithDictionary:dataDictionary andAccountId:account.accountId];
+
+            // Don't return a room object, if the token does not match
+            if (!room.token || ![room.token isEqualToString:token]) {
+                room = nil;
+            }
         }
 
         if (block) {

--- a/NextcloudTalk/NCRoomsManagerExtensions.swift
+++ b/NextcloudTalk/NCRoomsManagerExtensions.swift
@@ -7,6 +7,7 @@ import Foundation
 
 @objc extension NCRoomsManager {
 
+    public static let statusCodeNoSessionId = 996
     public static let statusCodeFailedToJoinExternal = 997
     public static let statusCodeShouldIgnoreAttemptButJoinedSuccessfully = 998
     public static let statusCodeIgnoreJoinAttempt = 999
@@ -154,6 +155,13 @@ import Foundation
             // Failed to join room in NC
             if let error {
                 completionBlock(nil, nil, error, statusCode, statusReason)
+                return
+            }
+
+            // While we received a successful http status code, we did not receive a sessionId -> treat it as an error
+            guard let sessionId else {
+                let error = NSError(domain: NSCocoaErrorDomain, code: NCRoomsManager.statusCodeNoSessionId)
+                completionBlock(nil, nil, error, NCRoomsManager.statusCodeNoSessionId, nil)
                 return
             }
 

--- a/NextcloudTalkTests/Unit/Chat/UnitChatViewControllerTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitChatViewControllerTest.swift
@@ -8,7 +8,7 @@ import XCTest
 
 final class UnitChatViewControllerTest: TestBaseRealm {
 
-    func testLocalMention() throws {
+    func testExpireMessages() throws {
         let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
         let roomName = "Expire Messages Test Room"
         let roomToken = "expToken"
@@ -67,6 +67,50 @@ final class UnitChatViewControllerTest: TestBaseRealm {
         waitForExpectations(timeout: TestConstants.timeoutShort, handler: nil)
 
         XCTAssertEqual(NCChatMessage.allObjects().count, 0)
+    }
+
+    func testJoinRoomWithEmptyRoomObject() throws {
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        let roomName = "EmptyRoomObject"
+        let roomToken = "emptyRoomObject"
+
+        let room = NCRoom()
+        room.token = roomToken
+        room.name = roomName
+        room.accountId = activeAccount.accountId
+
+        try? realm.transaction {
+            realm.add(room)
+        }
+
+        let chatViewController = ChatViewController(for: room)!
+
+        expectation(forNotification: .NCRoomsManagerDidJoinRoom, object: nil) { notification -> Bool in
+            XCTAssertNil(notification.userInfo?["error"])
+
+            // swiftlint:disable:next force_cast
+            XCTAssertEqual(notification.userInfo?["token"] as! String, roomToken)
+
+            return true
+        }
+
+        let userInfo: [String: Any] = [
+            "token": roomToken,
+            "room": NCRoom()
+        ]
+
+        NotificationCenter.default.post(name: .NCRoomsManagerDidJoinRoom, object: self, userInfo: userInfo)
+
+        waitForExpectations(timeout: TestConstants.timeoutShort, handler: nil)
+
+        let exp = expectation(description: "\(#function)\(#line)")
+
+        DispatchQueue.main.async {
+            XCTAssertNotNil(chatViewController.room.token)
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: TestConstants.timeoutShort, handler: nil)
     }
 
     func testFrequentlyEmojis() throws {

--- a/NextcloudTalkTests/Unit/Chat/UnitChatViewControllerTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitChatViewControllerTest.swift
@@ -83,7 +83,7 @@ final class UnitChatViewControllerTest: TestBaseRealm {
             realm.add(room)
         }
 
-        let chatViewController = ChatViewController(for: room)!
+        let chatViewController = ChatViewController(forRoom: room, withAccount: activeAccount)!
 
         expectation(forNotification: .NCRoomsManagerDidJoinRoom, object: nil) { notification -> Bool in
             XCTAssertNil(notification.userInfo?["error"])


### PR DESCRIPTION
* Follow-up to https://github.com/nextcloud/talk-ios/pull/1789

Fixed in this PR:
* SessionId is an optional, we only rely on the HTTP status code currently
* For creating a room object, we only rely on the listable capability currently
* In ChatViewController we just ensure that there's a NCRoom object, not, that it is the correct one

(The last 2 fixes are fixing basically the same thing, but I think we should be explicit here)