### PR TITLE
User status message setting fixes

### DIFF
--- a/NextcloudTalk/EmojiTextField.swift
+++ b/NextcloudTalk/EmojiTextField.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 import Dynamic
 
-struct EmojiTextFieldWrapper: UIViewRepresentable {
+struct SingleEmojiTextFieldWrapper: UIViewRepresentable {
     @State var placeholder: String
     @Binding var text: String
 
@@ -22,14 +22,14 @@ struct EmojiTextFieldWrapper: UIViewRepresentable {
         uiView.placeholder = placeholder
     }
 
-    func makeCoordinator() -> EmojiTextFieldWrapper.Coordinator {
+    func makeCoordinator() -> SingleEmojiTextFieldWrapper.Coordinator {
         Coordinator(parent: self)
     }
 
     class Coordinator: NSObject, UITextFieldDelegate {
-        var parent: EmojiTextFieldWrapper
+        var parent: SingleEmojiTextFieldWrapper
 
-        init(parent: EmojiTextFieldWrapper) {
+        init(parent: SingleEmojiTextFieldWrapper) {
             self.parent = parent
         }
 

--- a/NextcloudTalk/UserStatusMessageSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusMessageSwiftUIView.swift
@@ -237,8 +237,8 @@ struct UserStatusMessageSwiftUIView: View {
     }
 
     func triggerErrorAlert(title: String, message: String) {
-        errorAlertTitle = NSLocalizedString("Could not clear status message", comment: "")
-        errorAlertMessage = NSLocalizedString("Could not clear status message", comment: "")
+        errorAlertTitle = title
+        errorAlertMessage = message
         showErrorAlert.toggle()
     }
 

--- a/NextcloudTalk/UserStatusMessageSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusMessageSwiftUIView.swift
@@ -12,8 +12,8 @@ struct UserStatusMessageSwiftUIView: View {
     @Binding var changed: Bool
     @State var showClearAtAlert: Bool = false
 
-    @State private var selectedPredifinedStatusId: String?
-    @State private var statusPredefinedStatuses: [NKUserStatus] = []
+    @State private var selectedPredefinedMessageId: String?
+    @State private var predefinedStatuses: [NKUserStatus] = []
 
     @State private var selectedIcon: String = ""
     @State private var selectedMessage: String = ""
@@ -50,23 +50,23 @@ struct UserStatusMessageSwiftUIView: View {
                                 .frame(maxWidth: 23)
                                 .opacity(selectedIcon.isEmpty ? 0.5 : 1.0)
                                 .onChange(of: selectedIcon) { _ in
-                                    selectedPredifinedStatusId = nil
+                                    selectedPredefinedMessageId = nil
                                 }
                                 .tint(.primary)
                                 .focused($textFieldIsFocused)
                             Divider()
                             TextField(NSLocalizedString("What is your status?", comment: ""), text: $selectedMessage)
                                 .onChange(of: selectedMessage) { _ in
-                                    selectedPredifinedStatusId = nil
+                                    selectedPredefinedMessageId = nil
                                 }
                                 .tint(.primary)
                                 .focused($textFieldIsFocused)
                         }
                     }
                     Section {
-                        ForEach(statusPredefinedStatuses, id: \.id) { status in
+                        ForEach(predefinedStatuses, id: \.id) { status in
                             Button(action: {
-                                selectedPredifinedStatusId = status.id
+                                selectedPredefinedMessageId = status.id
                                 selectedIcon = status.icon ?? ""
                                 selectedMessage = status.message ?? ""
                                 selectedClearAt = status.clearAt?.timeIntervalSince1970 ?? 0
@@ -187,14 +187,14 @@ struct UserStatusMessageSwiftUIView: View {
                 userHasStatusSet = !(icon?.isEmpty ?? true) || !(message?.isEmpty ?? true)
                 selectedIcon = icon ?? ""
                 selectedMessage = message ?? ""
-                selectedPredifinedStatusId = messageId
+                selectedPredefinedMessageId = messageId
                 selectedClearAt = clearAt?.timeIntervalSince1970 ?? 0
                 selectedClearAtString = getPredefinedClearStatusText(clearAt: clearAt, clearAtTime: nil, clearAtType: nil)
             }
         }
         NextcloudKit.shared.getUserStatusPredefinedStatuses { _, userStatuses, _, error in
             if error.errorCode == 0 {
-                statusPredefinedStatuses = userStatuses!
+                predefinedStatuses = userStatuses ?? []
                 withAnimation {
                     isLoading = false
                 }
@@ -203,8 +203,8 @@ struct UserStatusMessageSwiftUIView: View {
     }
 
     func setActiveUserStatus() {
-        if let selectedPredifinedStatusId {
-            NextcloudKit.shared.setCustomMessagePredefined(messageId: selectedPredifinedStatusId, clearAt: selectedClearAt) { _, error in
+        if let selectedPredefinedMessageId {
+            NextcloudKit.shared.setCustomMessagePredefined(messageId: selectedPredefinedMessageId, clearAt: selectedClearAt) { _, error in
                 if error.errorCode == 0 {
                     dismiss()
                     changed.toggle()

--- a/NextcloudTalk/UserStatusMessageSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusMessageSwiftUIView.swift
@@ -21,7 +21,6 @@ struct UserStatusMessageSwiftUIView: View {
     @State private var selectedMessage: String = ""
     @State private var selectedClearAt: Double = 0
     @State private var selectedClearAtString: String = ""
-    @State private var changedSmth: Bool = false
 
     @State private var isLoading: Bool = true
     @FocusState private var textFieldIsFocused: Bool
@@ -63,7 +62,6 @@ struct UserStatusMessageSwiftUIView: View {
                             Divider()
                             TextField(NSLocalizedString("What is your status?", comment: ""), text: $selectedMessage)
                                 .onChange(of: selectedMessage) { _ in
-                                    changedSmth = true
                                     customStatusSelected = !changedStatusFromPredefined
                                     changedStatusFromPredefined = false
                                 }
@@ -119,11 +117,11 @@ struct UserStatusMessageSwiftUIView: View {
                                                                          comment: ""),
                                                 action: clearActiveUserStatus,
                                                 style: .tertiary, height: 40,
-                                                disabled: Binding.constant(selectedMessage.isEmpty  && selectedIcon.isEmpty))
+                                                disabled: Binding.constant(selectedMessage.isEmpty && selectedIcon.isEmpty))
                                 NCButtonSwiftUI(title: NSLocalizedString("Set status message", comment: ""),
                                                 action: setActiveUserStatus,
                                                 style: .primary, height: 40,
-                                                disabled: Binding.constant(selectedMessage.isEmpty  || changedSmth == false))
+                                                disabled: Binding.constant(selectedMessage.isEmpty && selectedIcon.isEmpty))
                                 .padding(.bottom, 16)
                             }
                         } else {
@@ -138,7 +136,7 @@ struct UserStatusMessageSwiftUIView: View {
                                 NCButtonSwiftUI(title: NSLocalizedString("Set status message", comment: ""),
                                                 action: setActiveUserStatus,
                                                 style: .primary, height: 40,
-                                                disabled: Binding.constant(selectedMessage.isEmpty || changedSmth == false))
+                                                disabled: Binding.constant(selectedMessage.isEmpty && selectedIcon.isEmpty))
                                 .padding(.bottom, 16)
                                 Spacer()
                             }
@@ -194,7 +192,7 @@ struct UserStatusMessageSwiftUIView: View {
         NCAPIController.sharedInstance().setupNCCommunication(for: NCDatabaseManager.sharedInstance().activeAccount())
         NextcloudKit.shared.getUserStatus { _, clearAt, icon, message, _, _, _, _, _, _, error in
             if error.errorCode == 0 {
-                selectedIcon = icon ?? "😀"
+                selectedIcon = icon ?? ""
                 selectedMessage = message ?? ""
                 selectedClearAt = clearAt?.timeIntervalSince1970 ?? 0
                 selectedClearAtString = getPredefinedClearStatusText(clearAt: clearAt, clearAtTime: nil, clearAtType: nil)
@@ -222,7 +220,8 @@ struct UserStatusMessageSwiftUIView: View {
                 }
             }
         } else {
-            NextcloudKit.shared.setCustomMessageUserDefined(statusIcon: selectedIcon.isEmpty ? "😀" : selectedIcon, message: selectedMessage, clearAt: selectedClearAt) { _, error in
+            let statusIcon = selectedIcon.isEmpty ? nil : selectedIcon
+            NextcloudKit.shared.setCustomMessageUserDefined(statusIcon: statusIcon, message: selectedMessage, clearAt: selectedClearAt) { _, error in
                 if error.errorCode == 0 {
                     dismiss()
                     changed.toggle()

--- a/NextcloudTalk/UserStatusMessageSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusMessageSwiftUIView.swift
@@ -65,11 +65,11 @@ struct UserStatusMessageSwiftUIView: View {
                     Section {
                         ForEach(statusPredefinedStatuses, id: \.id) { status in
                             Button(action: {
-                                selectedPredifinedStatus = status
                                 customStatusSelected = false
-                                selectedIcon = selectedPredifinedStatus!.icon ?? "Empty"
-                                selectedMessage = selectedPredifinedStatus!.message ?? "Empty"
-                                selectedClearAt = selectedPredifinedStatus!.clearAt?.timeIntervalSince1970 ?? 0
+                                selectedPredifinedStatus = status
+                                selectedIcon = status.icon ?? ""
+                                selectedMessage = status.message ?? ""
+                                selectedClearAt = status.clearAt?.timeIntervalSince1970 ?? 0
                                 selectedClearAtString = getPredefinedClearStatusText(clearAt: status.clearAt, clearAtTime: status.clearAtTime, clearAtType: status.clearAtType)
                                 setClearAt(clearAt: selectedClearAtString)
                             }) {

--- a/NextcloudTalk/UserStatusMessageSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusMessageSwiftUIView.swift
@@ -12,7 +12,6 @@ struct UserStatusMessageSwiftUIView: View {
     @Binding var changed: Bool
     @State var showClearAtAlert: Bool = false
 
-    @State private var changedStatusFromPredefined: Bool = false
     @State private var customStatusSelected: Bool = false
     @State private var selectedPredifinedStatus: NKUserStatus?
     @State private var statusPredefinedStatuses: [NKUserStatus] = []
@@ -46,24 +45,18 @@ struct UserStatusMessageSwiftUIView: View {
                 List {
                     Section(header: Text(NSLocalizedString("What is your status?", comment: ""))) {
                         HStack(spacing: 10) {
-                            EmojiTextFieldWrapper(placeholder: "😀", text: $selectedIcon)
+                            SingleEmojiTextFieldWrapper(placeholder: "😀", text: $selectedIcon)
                                 .frame(maxWidth: 23)
                                 .opacity(selectedIcon.isEmpty ? 0.5 : 1.0)
-                                .onChange(of: selectedIcon) { newString in
-                                    changedSmth = true
-                                    customStatusSelected = !changedStatusFromPredefined
-                                    changedStatusFromPredefined = false
-                                    if newString.count > 1 {
-                                        selectedIcon = String(newString.first!)
-                                    }
+                                .onChange(of: selectedIcon) { _ in
+                                    customStatusSelected = true
                                 }
                                 .tint(.primary)
                                 .focused($textFieldIsFocused)
                             Divider()
                             TextField(NSLocalizedString("What is your status?", comment: ""), text: $selectedMessage)
                                 .onChange(of: selectedMessage) { _ in
-                                    customStatusSelected = !changedStatusFromPredefined
-                                    changedStatusFromPredefined = false
+                                    customStatusSelected = true
                                 }
                                 .tint(.primary)
                                 .focused($textFieldIsFocused)
@@ -72,7 +65,6 @@ struct UserStatusMessageSwiftUIView: View {
                     Section {
                         ForEach(statusPredefinedStatuses, id: \.id) { status in
                             Button(action: {
-                                changedStatusFromPredefined = true
                                 selectedPredifinedStatus = status
                                 customStatusSelected = false
                                 selectedIcon = selectedPredifinedStatus!.icon ?? "Empty"

--- a/NextcloudTalk/UserStatusMessageSwiftUIView.swift
+++ b/NextcloudTalk/UserStatusMessageSwiftUIView.swift
@@ -20,6 +20,8 @@ struct UserStatusMessageSwiftUIView: View {
     @State private var selectedClearAt: Double = 0
     @State private var selectedClearAtString: String = ""
 
+    @State private var userHasStatusSet: Bool = false
+
     @State private var isLoading: Bool = true
     @FocusState private var textFieldIsFocused: Bool
     @State private var showErrorAlert = false
@@ -107,7 +109,7 @@ struct UserStatusMessageSwiftUIView: View {
                                                                          comment: ""),
                                                 action: clearActiveUserStatus,
                                                 style: .tertiary, height: 40,
-                                                disabled: Binding.constant(selectedMessage.isEmpty && selectedIcon.isEmpty))
+                                                disabled: Binding.constant(!userHasStatusSet))
                                 NCButtonSwiftUI(title: NSLocalizedString("Set status message", comment: ""),
                                                 action: setActiveUserStatus,
                                                 style: .primary, height: 40,
@@ -121,7 +123,7 @@ struct UserStatusMessageSwiftUIView: View {
                                                                          comment: ""),
                                                 action: clearActiveUserStatus,
                                                 style: .tertiary, height: 40,
-                                                disabled: Binding.constant(selectedMessage.isEmpty && selectedIcon.isEmpty))
+                                                disabled: Binding.constant(!userHasStatusSet))
                                 .padding(.bottom, 16)
                                 NCButtonSwiftUI(title: NSLocalizedString("Set status message", comment: ""),
                                                 action: setActiveUserStatus,
@@ -182,6 +184,7 @@ struct UserStatusMessageSwiftUIView: View {
         NCAPIController.sharedInstance().setupNCCommunication(for: NCDatabaseManager.sharedInstance().activeAccount())
         NextcloudKit.shared.getUserStatus { _, clearAt, icon, message, messageId, _, _, _, _, _, error in
             if error.errorCode == 0 {
+                userHasStatusSet = !(icon?.isEmpty ?? true) || !(message?.isEmpty ?? true)
                 selectedIcon = icon ?? ""
                 selectedMessage = message ?? ""
                 selectedPredifinedStatusId = messageId


### PR DESCRIPTION
- [x] Allow to set user status with only an icon or only a message
- [x] Enable "Clear status message" only when the user has one status already set

Fix #1823 