### PR TITLE
Pass room object to cell

### DIFF
--- a/NextcloudTalk/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/BaseChatTableViewCell.swift
@@ -76,7 +76,6 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
     @IBOutlet weak var referencePart: UIView!
 
     public var message: NCChatMessage?
-    public var messageId: Int = 0
     public var room: NCRoom?
 
     internal var quotedMessageView: QuotedMessageView?
@@ -160,7 +159,6 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
     // swiftlint:disable:next cyclomatic_complexity
     public func setup(for message: NCChatMessage, inRoom room: NCRoom) {
         self.message = message
-        self.messageId = message.messageId
         self.room = room
 
         self.avatarButton.setActorAvatar(forMessage: message)

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -2586,7 +2586,7 @@ import QuickLook
 
             if let cell = self.tableView?.dequeueReusableCell(withIdentifier: cellIdentifier) as? BaseChatTableViewCell {
                 cell.delegate = self
-                cell.setup(for: message, withLastCommonReadMessage: self.room.lastCommonReadMessage)
+                cell.setup(for: message, inRoom: self.room)
 
                 if let playerAudioFileStatus = self.playerAudioFileStatus,
                    let voiceMessagesPlayer = self.voiceMessagesPlayer {
@@ -2609,7 +2609,7 @@ import QuickLook
 
             if let cell = self.tableView?.dequeueReusableCell(withIdentifier: cellIdentifier) as? BaseChatTableViewCell {
                 cell.delegate = self
-                cell.setup(for: message, withLastCommonReadMessage: self.room.lastCommonReadMessage)
+                cell.setup(for: message, inRoom: self.room)
 
                 return cell
             }
@@ -2620,7 +2620,7 @@ import QuickLook
 
             if let cell = self.tableView?.dequeueReusableCell(withIdentifier: cellIdentifier) as? BaseChatTableViewCell {
                 cell.delegate = self
-                cell.setup(for: message, withLastCommonReadMessage: self.room.lastCommonReadMessage)
+                cell.setup(for: message, inRoom: self.room)
 
                 return cell
             }
@@ -2631,7 +2631,7 @@ import QuickLook
 
             if let cell = self.tableView?.dequeueReusableCell(withIdentifier: cellIdentifier) as? BaseChatTableViewCell {
                 cell.delegate = self
-                cell.setup(for: message, withLastCommonReadMessage: self.room.lastCommonReadMessage)
+                cell.setup(for: message, inRoom: self.room)
 
                 return cell
             }
@@ -2647,7 +2647,7 @@ import QuickLook
 
         if let cell = self.tableView?.dequeueReusableCell(withIdentifier: cellIdentifier) as? BaseChatTableViewCell {
             cell.delegate = self
-            cell.setup(for: message, withLastCommonReadMessage: self.room.lastCommonReadMessage)
+            cell.setup(for: message, inRoom: self.room)
 
             return cell
         }

--- a/NextcloudTalkTests/Unit/Chat/UnitBaseChatTableViewCellTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitBaseChatTableViewCellTest.swift
@@ -59,10 +59,10 @@ final class UnitBaseChatTableViewCellTest: TestBaseRealm {
         }
 
         let deckCell: BaseChatTableViewCell = .fromNib()
-        deckCell.setup(for: deckMessage, withLastCommonReadMessage: 0)
+        deckCell.setup(for: deckMessage, inRoom: room)
 
         let quoteCell: BaseChatTableViewCell = .fromNib()
-        quoteCell.setup(for: quoteMessage, withLastCommonReadMessage: 0)
+        quoteCell.setup(for: quoteMessage, inRoom: room)
     }
 
 }


### PR DESCRIPTION
* Related to https://github.com/nextcloud/talk-ios/issues/1811

Since we require a room object for all ChatViewControllers, we can directly pass the object down to the cells instead of querying the room for each cell individually.
Also removed an unused messageId variable.