### PR TITLE
Settings fixes (hiding of old account warning)

### DIFF
--- a/NextcloudTalk/CallsFromOldAccountViewController.swift
+++ b/NextcloudTalk/CallsFromOldAccountViewController.swift
@@ -5,7 +5,13 @@
 
 import UIKit
 
+@objc protocol CallsFromOldAccountViewControllerDelegate: AnyObject {
+    func callsFromOldAccountWarningAcknowledged()
+}
+
 class CallsFromOldAccountViewController: UIViewController {
+
+    weak var delegate: CallsFromOldAccountViewControllerDelegate?
 
     @IBOutlet weak var warningTextLabel: UILabel!
     @IBOutlet weak var acknowledgeWarningButton: NCButton!
@@ -45,6 +51,7 @@ class CallsFromOldAccountViewController: UIViewController {
     @IBAction func acknowledgeWarningButtonPressed(_ sender: Any) {
         NCSettingsController.sharedInstance().setDidReceiveCallsFromOldAccount(false)
         self.navigationController?.popViewController(animated: true)
+        self.delegate?.callsFromOldAccountWarningAcknowledged()
     }
 
 }

--- a/NextcloudTalk/SettingsTableViewController.swift
+++ b/NextcloudTalk/SettingsTableViewController.swift
@@ -44,7 +44,7 @@ enum AboutSection: Int {
     case kAboutSectionSourceCode
 }
 
-class SettingsTableViewController: UITableViewController, UITextFieldDelegate, UserStatusViewDelegate {
+class SettingsTableViewController: UITableViewController, UITextFieldDelegate, UserStatusViewDelegate, CallsFromOldAccountViewControllerDelegate {
     let kPhoneTextFieldTag = 99
 
     let iconConfiguration = UIImage.SymbolConfiguration(pointSize: 18)
@@ -588,8 +588,13 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate, U
 
     func callsFromOldAccountPressed() {
         let vc = CallsFromOldAccountViewController()
+        vc.delegate = self
 
         self.navigationController?.pushViewController(vc, animated: true)
+    }
+
+    func callsFromOldAccountWarningAcknowledged() {
+        self.tableView.reloadData()
     }
 
     // MARK: - Table view data source


### PR DESCRIPTION
This PR fixes 2 small issues:
* ~~When the cache is cleared, we do not recalculate the size, resulting in the same size shown after clearing~~ Done in https://github.com/nextcloud/talk-ios/pull/1851
* When the warning about a call from an old account is acknowledged, we don't reload the table view. Tapping again on the entry crashes the app.

Best to review commit by commit