### PR TITLE
Email fixes

### DIFF
--- a/NextcloudTalk/AvatarManager.swift
+++ b/NextcloudTalk/AvatarManager.swift
@@ -76,7 +76,7 @@ import SDWebImage
             if actorType == "bots" {
                 return getBotsAvatar(forId: actorId, withStyle: style, completionBlock: completionBlock)
             } else if actorType == "guests" {
-                return getGuestsAvatar(withDisplayName: actorDisplayName ?? "", completionBlock: completionBlock)
+                return getGuestsAvatar(withDisplayName: actorDisplayName ?? "", withStyle: style, completionBlock: completionBlock)
             } else if actorType == "users" {
                 return getUserAvatar(forId: actorId, withStyle: style, usingAccount: account, completionBlock: completionBlock)
             } else if actorType == "federated_users" {
@@ -112,9 +112,15 @@ import SDWebImage
         return nil
     }
 
-    private func getGuestsAvatar(withDisplayName actorDisplayName: String, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
-        let name = actorDisplayName.isEmpty ? "?" : actorDisplayName
-        let image = NCUtils.getImage(withString: name, withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true)
+    private func getGuestsAvatar(withDisplayName actorDisplayName: String, withStyle style: UIUserInterfaceStyle, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
+        if actorDisplayName.isEmpty {
+            let traitCollection = UITraitCollection(userInterfaceStyle: style)
+            completionBlock(UIImage(named: "user-avatar", in: nil, compatibleWith: traitCollection))
+
+            return nil
+        }
+
+        let image = NCUtils.getImage(withString: actorDisplayName, withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true)
 
         completionBlock(image)
 

--- a/NextcloudTalk/AvatarManager.swift
+++ b/NextcloudTalk/AvatarManager.swift
@@ -75,23 +75,21 @@ import SDWebImage
         if let actorId {
             if actorType == "bots" {
                 return getBotsAvatar(forId: actorId, withStyle: style, completionBlock: completionBlock)
-            } else if actorType == "guests" {
-                return getGuestsAvatar(withDisplayName: actorDisplayName ?? "", withStyle: style, completionBlock: completionBlock)
             } else if actorType == "users" {
                 return getUserAvatar(forId: actorId, withStyle: style, usingAccount: account, completionBlock: completionBlock)
             } else if actorType == "federated_users" {
                 return getFederatedUserAvatar(forId: actorId, withRoomToken: roomToken, withStyle: style, usingAccount: account, completionBlock: completionBlock)
-            } else if actorType == "deleted_users" {
-                return getDeletedUserAvatar(completionBlock: completionBlock)
             }
         }
 
         var image: UIImage?
 
-        if actorType == NCAttendeeTypeEmail {
-            image = self.getMailAvatar(with: style)
+        if actorType == NCAttendeeTypeEmail || actorType == NCAttendeeTypeGuest {
+            image = self.getGuestsAvatar(withDisplayName: actorDisplayName ?? "", withStyle: style)
         } else if actorType == NCAttendeeTypeGroup || actorType == NCAttendeeTypeCircle {
             image = self.getGroupAvatar(with: style)
+        } else if actorType == "deleted_users" {
+            image = self.getDeletedUserAvatar()
         } else {
             image = NCUtils.getImage(withString: "?", withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true)
         }
@@ -112,27 +110,17 @@ import SDWebImage
         return nil
     }
 
-    private func getGuestsAvatar(withDisplayName actorDisplayName: String, withStyle style: UIUserInterfaceStyle, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
+    private func getGuestsAvatar(withDisplayName actorDisplayName: String, withStyle style: UIUserInterfaceStyle) -> UIImage? {
         if actorDisplayName.isEmpty {
             let traitCollection = UITraitCollection(userInterfaceStyle: style)
-            completionBlock(UIImage(named: "user-avatar", in: nil, compatibleWith: traitCollection))
-
-            return nil
+            return UIImage(named: "user-avatar", in: nil, compatibleWith: traitCollection)
         }
 
-        let image = NCUtils.getImage(withString: actorDisplayName, withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true)
-
-        completionBlock(image)
-
-        return nil
+        return NCUtils.getImage(withString: actorDisplayName, withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true)
     }
 
-    private func getDeletedUserAvatar(completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
-        let image = NCUtils.getImage(withString: "X", withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true)
-
-        completionBlock(image)
-
-        return nil
+    private func getDeletedUserAvatar() -> UIImage? {
+        return NCUtils.getImage(withString: "X", withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true)
     }
 
     private func getUserAvatar(forId actorId: String, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount?, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {

--- a/NextcloudTalk/MentionSuggestion.swift
+++ b/NextcloudTalk/MentionSuggestion.swift
@@ -59,6 +59,8 @@ import Foundation
             messageParameter.type = "guest"
         } else if self.source == "groups" {
             messageParameter.type = "user-group"
+        } else if self.source == "emails" {
+            messageParameter.type = "email"
         }
 
         return messageParameter

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -317,7 +317,9 @@ NSString * const kSharedItemTypeRecording   = @"recording";
             NSString *replaceString = messageParameter.name;
             // Format user and call mentions
             if ([messageParameter.type isEqualToString:@"user"] || [messageParameter.type isEqualToString:@"guest"] ||
-                [messageParameter.type isEqualToString:@"user-group"] || [messageParameter.type isEqualToString:@"call"]) {
+                [messageParameter.type isEqualToString:@"user-group"] || [messageParameter.type isEqualToString:@"call"] ||
+                [messageParameter.type isEqualToString:@"email"]) {
+                
                 replaceString = [NSString stringWithFormat:@"@%@", [parameterDict objectForKey:@"name"]];
             }
             parsedMessage = [parsedMessage stringByReplacingOccurrencesOfString:parameter withString:replaceString];
@@ -349,7 +351,8 @@ NSString * const kSharedItemTypeRecording   = @"recording";
     for (NCMessageParameter *param in parameters) {
         //Set color for mentions
         if ([param.type isEqualToString:@"user"] || [param.type isEqualToString:@"guest"] ||
-            [param.type isEqualToString:@"user-group"] || [param.type isEqualToString:@"call"]) {
+            [param.type isEqualToString:@"user-group"] || [param.type isEqualToString:@"call"] ||
+            [param.type isEqualToString:@"email"]) {
 
             if (param.shouldBeHighlighted) {
                 if (!highlightedColor) {

--- a/NextcloudTalk/NCRoomParticipant.h
+++ b/NextcloudTalk/NCRoomParticipant.h
@@ -39,6 +39,7 @@ extern NSString * const NCAttendeeBridgeBotId;
 @property (nonatomic, copy) NSString *statusIcon;
 @property (nonatomic, copy) NSString *statusMessage;
 @property (nonatomic, copy) NSString *callIconImageName;
+@property (nonatomic, copy) NSString *invitedActorId;
 
 + (instancetype)participantWithDictionary:(NSDictionary *)userDict;
 - (BOOL)canModerate;

--- a/NextcloudTalk/NCRoomParticipants.m
+++ b/NextcloudTalk/NCRoomParticipants.m
@@ -61,7 +61,13 @@ NSString * const NCAttendeeBridgeBotId  = @"bridge-bot";
     if ([statusMessage isKindOfClass:[NSString class]]) {
         participant.statusMessage = statusMessage;
     }
-    
+
+    // Optional attributed for email guests
+    id invitedActorId = [participantDict objectForKey:@"invitedActorId"];
+    if ([invitedActorId isKindOfClass:[NSString class]]) {
+        participant.invitedActorId = invitedActorId;
+    }
+
     return participant;
 }
 

--- a/NextcloudTalk/NCRoomParticipants.m
+++ b/NextcloudTalk/NCRoomParticipants.m
@@ -133,8 +133,11 @@ NSString * const NCAttendeeBridgeBotId  = @"bridge-bot";
 - (NSString *)detailedName
 {
     NSString *detailedNameString = _displayName;
+
+    BOOL defaultGuestNameUsed = false;
     if ([_displayName isEqualToString:@""]) {
         if (self.isGuest) {
+            defaultGuestNameUsed = true;
             detailedNameString = NSLocalizedString(@"Guest", nil);
         } else {
             detailedNameString = NSLocalizedString(@"[Unknown username]", nil);
@@ -151,7 +154,7 @@ NSString * const NCAttendeeBridgeBotId  = @"bridge-bot";
         detailedNameString = [NSString stringWithFormat:@"%@ (%@)", detailedNameString, botString];
     }
     // Guest label
-    if (self.isGuest) {
+    if (self.isGuest && !defaultGuestNameUsed) {
         NSString *guestString = NSLocalizedString(@"guest", nil);
         detailedNameString = [NSString stringWithFormat:@"%@ (%@)", detailedNameString, guestString];
     }

--- a/NextcloudTalk/ResultMultiSelectionTableViewController.m
+++ b/NextcloudTalk/ResultMultiSelectionTableViewController.m
@@ -103,8 +103,12 @@
     
     cell.labelTitle.text = contact.name;
     
-    [cell.contactImage setActorAvatarForId:contact.userId withType:contact.source withDisplayName:contact.name withRoomToken:_room.token];
-
+    if ([contact.source isEqualToString:NCAttendeeTypeEmail]) {
+        // Only when adding new (email) participants we show the mail avatar
+        [cell.contactImage setMailAvatar];
+    } else {
+        [cell.contactImage setActorAvatarForId:contact.userId withType:contact.source withDisplayName:contact.name withRoomToken:_room.token];
+    }
     UIImage *selectionImage = [UIImage systemImageNamed:@"circle"];
     UIColor *selectionImageColor = [UIColor tertiaryLabelColor];
     for (NCUser *user in _selectedParticipants) {

--- a/NextcloudTalk/RoomInfoTableViewController.m
+++ b/NextcloudTalk/RoomInfoTableViewController.m
@@ -2300,6 +2300,11 @@ typedef enum FileAction {
                 [cell setUserStatusIconWithImage:publicRoomImage];
             }
 
+            // Email guests
+            if (participant.invitedActorId && ![participant.invitedActorId isEqualToString:@""]) {
+                [cell setUserStatusMessage:participant.invitedActorId withIcon:nil];
+            }
+
             // Online status
             if (participant.isOffline) {
                 cell.contactImage.alpha = 0.5;

--- a/NextcloudTalk/TalkActor.swift
+++ b/NextcloudTalk/TalkActor.swift
@@ -31,11 +31,16 @@ import SwiftyAttributes
     /// Takes deleted users and guests into account and returns it as `secondaryLabel`
     /// This also appends a potential `cloudId` as `tertiaryLabel` in parentheses
     public var attributedDisplayName: NSMutableAttributedString {
+        let displayName = self.displayName
         let titleLabel = displayName.withTextColor(.secondaryLabel)
 
         if let remoteServer = cloudId {
             let remoteServerString = " (\(String(remoteServer)))"
             titleLabel.append(remoteServerString.withTextColor(.tertiaryLabel))
+        } else if isGuest, !rawDisplayName.isEmpty {
+            // Show guest indication only when we did not use the default "Guest" name
+            let guestString = " (\(NSLocalizedString("guest", comment: "")))"
+            titleLabel.append(guestString.withTextColor(.tertiaryLabel))
         }
 
         return titleLabel
@@ -53,6 +58,10 @@ import SwiftyAttributes
 
     public var isFederated: Bool {
         return type == "federated_users"
+    }
+
+    public var isGuest: Bool {
+        return type == "guests" || type == "emails"
     }
 
     public var cloudId: String? {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/talk-ios/issues/1847

1. Correctly highlight email mentions
2. Always use person avatar instead of "?"-avatar
3. Only differentiate guest and email-guest when adding new participants
4. Show email to moderators as subline

Search:
<img src=https://github.com/user-attachments/assets/c9e84655-a6a2-42c3-b718-813c9bb9b983 width=250 />

Moderator:
<img src=https://github.com/user-attachments/assets/3d093751-c753-4eb3-a088-af0145549873 width=250 />

Non-Moderator:
<img src=https://github.com/user-attachments/assets/2d38c408-39f4-4ecb-ab02-30eff4fa54cd width=250 />

Chat:
<img src=https://github.com/user-attachments/assets/5b7628b0-5652-430f-8ef2-f4dd4b064291 width=250 />