### PR TITLE
Render performance

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		1F205C532CEF91C500AAA673 /* UserAbsence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F205C4F2CEF903000AAA673 /* UserAbsence.swift */; };
 		1F205C552CEFA01200AAA673 /* OutOfOfficeView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1F205C542CEFA01200AAA673 /* OutOfOfficeView.xib */; };
 		1F205C572CEFA01900AAA673 /* OutOfOfficeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F205C562CEFA01900AAA673 /* OutOfOfficeView.swift */; };
+		1F205D412CFC6DD300AAA673 /* AvatarProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F205D402CFC6DCF00AAA673 /* AvatarProtocol.swift */; };
+		1F205D442CFC70AD00AAA673 /* AvatarProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F205D402CFC6DCF00AAA673 /* AvatarProtocol.swift */; };
 		1F24B5A228E0648600654457 /* ReferenceGithubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F24B5A128E0648600654457 /* ReferenceGithubView.swift */; };
 		1F24B5A428E0649200654457 /* ReferenceGithubView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1F24B5A328E0649200654457 /* ReferenceGithubView.xib */; };
 		1F35F8E22AEEBAF900044BDA /* InputbarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5A24322ADA77DA009939FE /* InputbarViewController.swift */; };
@@ -691,6 +693,7 @@
 		1F205C4F2CEF903000AAA673 /* UserAbsence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAbsence.swift; sourceTree = "<group>"; };
 		1F205C542CEFA01200AAA673 /* OutOfOfficeView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OutOfOfficeView.xib; sourceTree = "<group>"; };
 		1F205C562CEFA01900AAA673 /* OutOfOfficeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutOfOfficeView.swift; sourceTree = "<group>"; };
+		1F205D402CFC6DCF00AAA673 /* AvatarProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarProtocol.swift; sourceTree = "<group>"; };
 		1F21A0622C77863500ED8C0C /* nb-NO */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "nb-NO"; path = "nb-NO.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		1F21A0632C77863500ED8C0C /* nb-NO */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "nb-NO"; path = "nb-NO.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		1F21A0642C77863500ED8C0C /* nb-NO */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "nb-NO"; path = "nb-NO.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
@@ -1683,9 +1686,10 @@
 				1F1C0D8829AFB89900D17C6D /* VLCKitVideoViewController.swift */,
 				1F1C0D8629AFB88800D17C6D /* VLCKitVideoViewController.xib */,
 				1F90DA0329E9A28E00E81E3D /* AvatarManager.swift */,
+				1F205D402CFC6DCF00AAA673 /* AvatarProtocol.swift */,
+				1FDCC3EF29ECB4CE00DEB39B /* AvatarButton.swift */,
 				1FDCC3D329EBF6E700DEB39B /* AvatarImageView.swift */,
 				2CF338E02CED388B0029CACC /* AvatarView.swift */,
-				1FDCC3EF29ECB4CE00DEB39B /* AvatarButton.swift */,
 				1F3C41A229EDF05700F58435 /* AvatarEditView.swift */,
 				1F3C41A429EDF0B800F58435 /* AvatarEditView.xib */,
 				2CB997C32A052449003C41AC /* EmojiAvatarPickerViewController.swift */,
@@ -2860,6 +2864,7 @@
 				1FEDE3C6257D439500853F79 /* NCChatFileController.m in Sources */,
 				1FEDE3CE257D43AB00853F79 /* NCMessageFileParameter.m in Sources */,
 				2C4446DD2658158000DF1DBC /* NCChatBlock.m in Sources */,
+				1F205D412CFC6DD300AAA673 /* AvatarProtocol.swift in Sources */,
 				1FDCC3F029ECB4CE00DEB39B /* AvatarButton.swift in Sources */,
 				2C06BF6720AC647A0031EB46 /* DateHeaderView.m in Sources */,
 				2CB6ACDA2641483800D3D641 /* NCMessageLocationParameter.m in Sources */,
@@ -3144,6 +3149,7 @@
 				2C4446F9265D5A0700DF1DBC /* NotificationCenterNotifications.m in Sources */,
 				1F35F8ED2AEEBC1600044BDA /* UIView+SLKAdditions.m in Sources */,
 				1FDFC94F2BA50B9100670DF4 /* UIFontExtension.swift in Sources */,
+				1F205D442CFC70AD00AAA673 /* AvatarProtocol.swift in Sources */,
 				1F35F8EA2AEEBC0E00044BDA /* SLKTextViewController.m in Sources */,
 				2C6955132B0CE1A20070F6E1 /* NCUtils.swift in Sources */,
 				1F8AAC342C518B8A004DA20A /* SignalingSettings.swift in Sources */,

--- a/NextcloudTalk/AvatarButton.swift
+++ b/NextcloudTalk/AvatarButton.swift
@@ -6,7 +6,7 @@
 import UIKit
 import SDWebImage
 
-@objcMembers class AvatarButton: UIButton {
+@objcMembers class AvatarButton: UIButton, AvatarProtocol {
 
     private var currentRequest: SDWebImageCombinedOperation?
 
@@ -63,8 +63,7 @@ import SDWebImage
 
     // MARK: - User avatars
 
-    public func setActorAvatar(forMessage message: NCChatMessage) {
-        guard let account = message.account else { return }
+    public func setActorAvatar(forMessage message: NCChatMessage, withAccount account: TalkAccount) {
         self.setActorAvatar(forId: message.actorId, withType: message.actorType, withDisplayName: message.actorDisplayName, withRoomToken: message.token, using: account)
     }
 

--- a/NextcloudTalk/AvatarImageView.swift
+++ b/NextcloudTalk/AvatarImageView.swift
@@ -6,7 +6,7 @@
 import UIKit
 import SDWebImage
 
-@objcMembers class AvatarImageView: UIImageView {
+@objcMembers class AvatarImageView: UIImageView, AvatarProtocol {
 
     private var currentRequest: SDWebImageCombinedOperation?
 
@@ -60,8 +60,7 @@ import SDWebImage
 
     // MARK: - User avatars
 
-    public func setActorAvatar(forMessage message: NCChatMessage) {
-        guard let account = message.account else { return }
+    public func setActorAvatar(forMessage message: NCChatMessage, withAccount account: TalkAccount) {
         self.setActorAvatar(forId: message.actorId, withType: message.actorType, withDisplayName: message.actorDisplayName, withRoomToken: message.token, using: account)
     }
 

--- a/NextcloudTalk/AvatarProtocol.swift
+++ b/NextcloudTalk/AvatarProtocol.swift
@@ -1,0 +1,18 @@
+//
+// SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+protocol AvatarProtocol {
+
+    func cancelCurrentRequest()
+
+    // MARK: - Conversation avatars
+    func setAvatar(for room: NCRoom)
+    func setGroupAvatar()
+
+    // MARK: - User avatars
+    func setActorAvatar(forMessage message: NCChatMessage, withAccount account: TalkAccount)
+    func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, using account: TalkAccount)
+
+}

--- a/NextcloudTalk/AvatarView.swift
+++ b/NextcloudTalk/AvatarView.swift
@@ -6,7 +6,7 @@
 import UIKit
 import SDWebImage
 
-@objcMembers class AvatarView: UIView {
+@objcMembers class AvatarView: UIView, AvatarProtocol {
 
     private let userStatusSizePercentage = 0.38
 
@@ -92,6 +92,10 @@ import SDWebImage
         userStatusLabel.text = nil
     }
 
+    func cancelCurrentRequest() {
+        self.avatarImageView.cancelCurrentRequest()
+    }
+
     // MARK: - Conversation avatars
 
     public func setAvatar(for room: NCRoom) {
@@ -108,8 +112,8 @@ import SDWebImage
 
     // MARK: - User avatars
 
-    public func setActorAvatar(forMessage message: NCChatMessage) {
-        self.avatarImageView.setActorAvatar(forMessage: message)
+    public func setActorAvatar(forMessage message: NCChatMessage, withAccount account: TalkAccount) {
+        self.avatarImageView.setActorAvatar(forMessage: message, withAccount: account)
     }
 
     public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, using account: TalkAccount) {

--- a/NextcloudTalk/BaseChatTableViewCell+Message.swift
+++ b/NextcloudTalk/BaseChatTableViewCell+Message.swift
@@ -26,8 +26,4 @@ extension BaseChatTableViewCell {
 
         messageTextView.attributedText = message.parsedMarkdownForChat()
     }
-
-    func prepareForReuseMessageCell() {
-        self.messageTextView?.text = ""
-    }
 }

--- a/NextcloudTalk/BaseChatTableViewCell+Poll.swift
+++ b/NextcloudTalk/BaseChatTableViewCell+Poll.swift
@@ -37,10 +37,6 @@ extension BaseChatTableViewCell {
         pollMessageView.pollTitleTextView.text = message.parsedMessage().string
     }
 
-    func prepareForReusePollCell() {
-        self.pollMessageView?.pollTitleTextView.text = ""
-    }
-
     @objc func pollViewTapped() {
         guard let poll = message?.poll else {
             return

--- a/NextcloudTalk/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/BaseChatTableViewCell.swift
@@ -200,6 +200,8 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
 
         if message.isGroupMessage, message.parent == nil {
             self.headerPart.isHidden = true
+        } else {
+            self.headerPart.isHidden = false
         }
 
         // Make sure the status view is empty, when no delivery state should be set

--- a/NextcloudTalk/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/BaseChatTableViewCell.swift
@@ -77,6 +77,7 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
 
     public var message: NCChatMessage?
     public var room: NCRoom?
+    public var account: TalkAccount?
 
     internal var quotedMessageView: QuotedMessageView?
     internal var reactionView: ReactionsView?
@@ -144,11 +145,12 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
     }
 
     // swiftlint:disable:next cyclomatic_complexity
-    public func setup(for message: NCChatMessage, inRoom room: NCRoom) {
+    public func setup(for message: NCChatMessage, inRoom room: NCRoom, withAccount account: TalkAccount) {
         self.message = message
         self.room = room
+        self.account = account
 
-        self.avatarButton.setActorAvatar(forMessage: message)
+        self.avatarButton.setActorAvatar(forMessage: message, withAccount: account)
         self.avatarButton.menu = self.getDeferredUserMenu()
         self.avatarButton.showsMenuAsPrimaryAction = true
 
@@ -176,9 +178,6 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
 
         self.titleLabel.attributedText = titleLabel
 
-        guard let account = message.account
-        else { return }
-
         let shouldShowDeliveryStatus = NCDatabaseManager.sharedInstance().roomHasTalkCapability(kCapabilityChatReadStatus, for: room)
         var shouldShowReadStatus = false
 
@@ -194,7 +193,7 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
             self.quotedMessageView?.messageLabel.text = quoteString
             self.quotedMessageView?.actorLabel.attributedText = parent.actor.attributedDisplayName
             self.quotedMessageView?.highlighted = parent.isMessage(from: account.userId)
-            self.quotedMessageView?.avatarView.setActorAvatar(forMessage: parent)
+            self.quotedMessageView?.avatarView.setActorAvatar(forMessage: parent, withAccount: account)
         } else {
             self.hideQuotePart()
         }

--- a/NextcloudTalk/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/BaseChatTableViewCell.swift
@@ -132,6 +132,11 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
         self.quotedMessageView?.avatarView.cancelCurrentRequest()
         self.quotedMessageView?.avatarView.image = nil
 
+        self.headerPart.isHidden = false
+        self.quotePart.isHidden = true
+        self.referencePart.isHidden = true
+        self.reactionPart.isHidden = true
+
         self.referenceView?.prepareForReuse()
 
         self.prepareForReuseFileCell()
@@ -194,14 +199,10 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
             self.quotedMessageView?.actorLabel.attributedText = parent.actor.attributedDisplayName
             self.quotedMessageView?.highlighted = parent.isMessage(from: account.userId)
             self.quotedMessageView?.avatarView.setActorAvatar(forMessage: parent, withAccount: account)
-        } else {
-            self.hideQuotePart()
         }
 
         if message.isGroupMessage, message.parent == nil {
             self.headerPart.isHidden = true
-        } else {
-            self.headerPart.isHidden = false
         }
 
         // Make sure the status view is empty, when no delivery state should be set
@@ -228,8 +229,6 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
         if !reactionsArray.isEmpty {
             self.showReactionsPart()
             self.reactionView?.updateReactions(reactions: reactionsArray)
-        } else {
-            self.hideReactionsPart()
         }
 
         if message.containsURL() {
@@ -249,8 +248,6 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
                     self.referenceView?.update(for: referenceData, and: url)
                 }
             }
-        } else {
-            self.hideReferencePart()
         }
 
         if message.isReplyable, !message.isDeleting {
@@ -392,10 +389,6 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
         }
     }
 
-    func hideQuotePart() {
-        self.quotePart.isHidden = true
-    }
-
     @objc func quoteTapped(_ sender: UITapGestureRecognizer?) {
         if let parent = self.message?.parent {
             self.delegate?.cellWantsToScroll(to: parent)
@@ -424,10 +417,6 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
         }
     }
 
-    func hideReferencePart() {
-        self.referencePart.isHidden = true
-    }
-
     // MARK: - ReactionsPart
 
     func showReactionsPart() {
@@ -452,10 +441,6 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
                 reactionView.bottomAnchor.constraint(equalTo: self.reactionPart.bottomAnchor, constant: -10)
             ])
         }
-    }
-
-    func hideReactionsPart() {
-        self.reactionPart.isHidden = true
     }
 
     // MARK: - ReactionsView Delegate

--- a/NextcloudTalk/BaseChatTableViewCell.xib
+++ b/NextcloudTalk/BaseChatTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -70,16 +70,8 @@
                             <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X2q-XX-H1j" userLabel="ContentPart">
                                 <rect key="frame" x="0.0" y="100" width="422" height="257"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="TkE-V6-ePd" userLabel="StatusView">
+                                    <stackView opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="20" placeholderIntrinsicHeight="20" axis="vertical" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="TkE-V6-ePd" userLabel="StatusView">
                                         <rect key="frame" x="15" y="5" width="20" height="20"/>
-                                        <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="F90-3N-Ecf" userLabel="PlaceholderForInterfaceBuilder">
-                                                <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="20" id="swq-f4-Rot"/>
-                                                </constraints>
-                                            </view>
-                                        </subviews>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="20" id="kDD-1M-lbC"/>
                                         </constraints>

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -192,8 +192,8 @@ import SwiftUI
 
     // MARK: - Init/Deinit
 
-    public init?(for room: NCRoom) {
-        super.init(for: room, tableViewStyle: .plain)
+    public init?(forRoom room: NCRoom, withAccount account: TalkAccount) {
+        super.init(forRoom: room, withAccount: account, tableViewStyle: .plain)
 
         self.hidesBottomBarWhenPushed = true
         self.tableView?.estimatedRowHeight = 0
@@ -209,8 +209,8 @@ import SwiftUI
 
     // Not using an optional here, because it is not available from ObjC
     // Pass "0" as highlightMessageId to not highlight a message
-    public convenience init?(for room: NCRoom, withMessage messages: [NCChatMessage], withHighlightId highlightMessageId: Int) {
-        self.init(for: room)
+    public convenience init?(forRoom room: NCRoom, withAccount account: TalkAccount, withMessage messages: [NCChatMessage], withHighlightId highlightMessageId: Int) {
+        self.init(forRoom: room, withAccount: account)
 
         // When we pass in a fixed number of messages, we hide the inputbar by default
         self.textInputbar.isHidden = true
@@ -2765,7 +2765,7 @@ import SwiftUI
 
             if let cell = self.tableView?.dequeueReusableCell(withIdentifier: cellIdentifier) as? BaseChatTableViewCell {
                 cell.delegate = self
-                cell.setup(for: message, inRoom: self.room)
+                cell.setup(for: message, inRoom: self.room, withAccount: self.account)
 
                 if let playerAudioFileStatus = self.playerAudioFileStatus,
                    let voiceMessagesPlayer = self.voiceMessagesPlayer {
@@ -2788,7 +2788,7 @@ import SwiftUI
 
             if let cell = self.tableView?.dequeueReusableCell(withIdentifier: cellIdentifier) as? BaseChatTableViewCell {
                 cell.delegate = self
-                cell.setup(for: message, inRoom: self.room)
+                cell.setup(for: message, inRoom: self.room, withAccount: self.account)
 
                 return cell
             }
@@ -2799,7 +2799,7 @@ import SwiftUI
 
             if let cell = self.tableView?.dequeueReusableCell(withIdentifier: cellIdentifier) as? BaseChatTableViewCell {
                 cell.delegate = self
-                cell.setup(for: message, inRoom: self.room)
+                cell.setup(for: message, inRoom: self.room, withAccount: self.account)
 
                 return cell
             }
@@ -2810,7 +2810,7 @@ import SwiftUI
 
             if let cell = self.tableView?.dequeueReusableCell(withIdentifier: cellIdentifier) as? BaseChatTableViewCell {
                 cell.delegate = self
-                cell.setup(for: message, inRoom: self.room)
+                cell.setup(for: message, inRoom: self.room, withAccount: self.account)
 
                 return cell
             }
@@ -2826,7 +2826,7 @@ import SwiftUI
 
         if let cell = self.tableView?.dequeueReusableCell(withIdentifier: cellIdentifier) as? BaseChatTableViewCell {
             cell.delegate = self
-            cell.setup(for: message, inRoom: self.room)
+            cell.setup(for: message, inRoom: self.room, withAccount: self.account)
 
             return cell
         }

--- a/NextcloudTalk/CallViewController.swift
+++ b/NextcloudTalk/CallViewController.swift
@@ -1907,7 +1907,8 @@ class CallViewController: UIViewController,
     func showChat() {
         if chatNavigationController == nil {
             guard let room = NCDatabaseManager.sharedInstance().room(withToken: room.token, forAccountId: room.accountId),
-                  let chatViewController = ChatViewController(for: room)
+                  let account = room.account,
+                  let chatViewController = ChatViewController(forRoom: room, withAccount: account)
             else { return }
 
             chatViewController.presentedInCall = true

--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -120,10 +120,10 @@ import SwiftyAttributes
 
     private var messageExpirationTimer: Timer?
 
-    public override init?(for room: NCRoom) {
+    public override init?(forRoom room: NCRoom, withAccount account: TalkAccount) {
         self.chatController = NCChatController(for: room)
 
-        super.init(for: room)
+        super.init(forRoom: room, withAccount: account)
 
         NotificationCenter.default.addObserver(self, selector: #selector(didUpdateRoom(notification:)), name: NSNotification.Name.NCRoomsManagerDidUpdateRoom, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didJoinRoom(notification:)), name: NSNotification.Name.NCRoomsManagerDidJoinRoom, object: nil)

--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -312,9 +312,7 @@ import UIKit
         if suggestion.id == "all" {
             cell.avatarButton.setAvatar(for: self.room)
         } else {
-            if let account = room.account {
-                cell.avatarButton.setActorAvatar(forId: suggestion.id, withType: suggestion.source, withDisplayName: suggestion.label, withRoomToken: self.room.token, using: account)
-            }
+            cell.avatarButton.setActorAvatar(forId: suggestion.id, withType: suggestion.source, withDisplayName: suggestion.label, withRoomToken: self.room.token, using: self.account)
         }
 
         cell.accessibilityIdentifier = AutoCompletionCellIdentifier

--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -12,6 +12,7 @@ import UIKit
 
     // MARK: - Public var
     public var room: NCRoom
+    public var account: TalkAccount
 
     // MARK: - Internal var
     internal var titleView: NCChatTitleView?
@@ -19,16 +20,18 @@ import UIKit
     internal var mentionsDict: [String: NCMessageParameter] = [:]
     internal var contentView: UIView?
 
-    public init?(for room: NCRoom, tableViewStyle style: UITableView.Style) {
+    public init?(forRoom room: NCRoom, withAccount account: TalkAccount, tableViewStyle style: UITableView.Style) {
         self.room = room
+        self.account = account
 
         super.init(tableViewStyle: style)
 
         self.commonInit()
     }
 
-    public init?(for room: NCRoom, withView view: UIView) {
+    public init?(forRoom room: NCRoom, withAccount account: TalkAccount, withView view: UIView) {
         self.room = room
+        self.account = account
         self.contentView = view
 
         super.init(tableViewStyle: .plain)

--- a/NextcloudTalk/NCAPIController.h
+++ b/NextcloudTalk/NCAPIController.h
@@ -128,6 +128,7 @@ extern NSInteger const kReceivedChatMessagesLimit;
 
 + (instancetype)sharedInstance;
 - (void)createAPISessionManagerForAccount:(TalkAccount *)account;
+- (void)removeAPISessionManagerForAccount:(TalkAccount *)account;
 - (void)setupNCCommunicationForAccount:(TalkAccount *)account;
 - (NSInteger)conversationAPIVersionForAccount:(TalkAccount *)account;
 - (NSInteger)callAPIVersionForAccount:(TalkAccount *)account;

--- a/NextcloudTalk/NCAppBranding.m
+++ b/NextcloudTalk/NCAppBranding.m
@@ -160,7 +160,13 @@ BOOL const useServerThemimg = YES;
 
 + (UIColor *)chatForegroundColor
 {
-    return [self getDynamicColor:[UIColor darkGrayColor] withDarkMode:[UIColor labelColor]];
+    static UIColor *color;
+
+    if (!color) {
+        color = [self getDynamicColor:[UIColor darkGrayColor] withDarkMode:[UIColor labelColor]];
+    }
+
+    return color;
 }
 
 + (UIStatusBarStyle)statusBarStyleForBrandColor

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -297,7 +297,12 @@ NSString * const kSharedItemTypeRecording   = @"recording";
     NSString *parsedMessage = originalMessage;
     NSError *error = nil;
 
-    NSRegularExpression *parameterRegex = [NSRegularExpression regularExpressionWithPattern:@"\\{([^}]+)\\}" options:NSRegularExpressionCaseInsensitive error:&error];
+    static NSRegularExpression *parameterRegex;
+
+    if (!parameterRegex) {
+        parameterRegex = [NSRegularExpression regularExpressionWithPattern:@"\\{([^}]+)\\}" options:NSRegularExpressionCaseInsensitive error:&error];
+    }
+
     NSArray *matches = [parameterRegex matchesInString:originalMessage
                                                options:0
                                                  range:NSMakeRange(0, [originalMessage length])];

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -39,6 +39,7 @@ NSString * const kSharedItemTypeRecording   = @"recording";
     NSString *_urlDetected;
     BOOL _referenceDataDone;
     NSDictionary *_referenceData;
+    NSMutableAttributedString *_parsedMarkdownForChat;
 }
 
 @end
@@ -398,6 +399,10 @@ NSString * const kSharedItemTypeRecording   = @"recording";
 
 - (NSMutableAttributedString *)parsedMarkdownForChat
 {
+    if (_parsedMarkdownForChat) {
+        return _parsedMarkdownForChat;
+    }
+
     // In some circumstances we want/need to hide the message in the chat, but still want to show it in other parts like the conversation list
     if ([self getDeckCardUrlForReferenceProvider]) {
         return nil;
@@ -413,7 +418,9 @@ NSString * const kSharedItemTypeRecording   = @"recording";
         return parsedMessage;
     }
 
-    return [SwiftMarkdownObjCBridge parseMarkdownWithMarkdownString:parsedMessage];
+    _parsedMarkdownForChat = [SwiftMarkdownObjCBridge parseMarkdownWithMarkdownString:parsedMessage];
+
+    return _parsedMarkdownForChat;
 }
 
 - (NSMutableArray *)temporaryReactions

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -352,11 +352,11 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
         NSLog(@"Not starting chat due to in a call.");
         return;
     }
-    
+
+    TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
     NCRoomController *roomController = [_activeRooms objectForKey:room.token];
     if (!roomController) {
         // Workaround until external signaling supports multi-room
-        TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
         NCExternalSignalingController *extSignalingController = [[NCSettingsController sharedInstance] externalSignalingControllerForAccountId:activeAccount.accountId];
         if (extSignalingController) {
             NSString *currentRoom = extSignalingController.currentRoom;
@@ -374,7 +374,7 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
         //[[NCRoomsManager sharedInstance].chatViewController leaveChat];
 
         NSLog(@"Creating new chat view controller.");
-        _chatViewController = [[ChatViewController alloc] initFor:room];
+        _chatViewController = [[ChatViewController alloc] initForRoom:room withAccount:activeAccount];
         if (_highlightMessageDict && [[_highlightMessageDict objectForKey:@"token"] isEqualToString:room.token]) {
             _chatViewController.highlightMessageId = [[_highlightMessageDict objectForKey:@"messageId"] integerValue];
             _highlightMessageDict = nil;

--- a/NextcloudTalk/NCSettingsController.m
+++ b/NextcloudTalk/NCSettingsController.m
@@ -435,6 +435,7 @@ NSString * const kDidReceiveCallsFromOldAccount = @"receivedCallsFromOldAccount"
     NCExternalSignalingController *extSignalingController = [self externalSignalingControllerForAccountId:removingAccount.accountId];
     [extSignalingController disconnect];
     [[NCAPIController sharedInstance] removeProfileImageForAccount:removingAccount];
+    [[NCAPIController sharedInstance] removeAPISessionManagerForAccount:removingAccount];
     [[NCDatabaseManager sharedInstance] removeAccountWithAccountId:removingAccount.accountId];
     [[[NCChatFileController alloc] init] deleteDownloadDirectoryForAccount:removingAccount];
     [[[NCRoomsManager sharedInstance] chatViewController] leaveChat];

--- a/NextcloudTalk/ReplyMessageView.m
+++ b/NextcloudTalk/ReplyMessageView.m
@@ -156,7 +156,12 @@
     self.quotedMessageView.actorLabel.text = ([message.actorDisplayName isEqualToString:@""]) ? NSLocalizedString(@"Guest", nil) : message.actorDisplayName;
     self.quotedMessageView.messageLabel.text = message.parsedMarkdownForChat.string;
     self.quotedMessageView.highlighted = [message isMessageFrom:userId];
-    [self.quotedMessageView.avatarView setActorAvatarForMessage:message];
+
+    TalkAccount *account = message.account;
+    if (account) {
+        [self.quotedMessageView.avatarView setActorAvatarForMessage:message withAccount:account];
+    }
+
     [self.cancelButton setHidden:NO];
 
     // Reset button size to 44 in case it was hidden before

--- a/NextcloudTalk/RoomSharedItemsTableViewController.swift
+++ b/NextcloudTalk/RoomSharedItemsTableViewController.swift
@@ -405,7 +405,7 @@ import QuickLook
         return UIContextMenuConfiguration(identifier: indexPath as NSCopying, previewProvider: {
 
             // Init the BaseChatViewController without message to directly show a preview
-            if let chatViewController = ContextChatViewController(for: self.room, withMessage: [], withHighlightId: 0) {
+            if let account = self.room.account, let chatViewController = ContextChatViewController(forRoom: self.room, withAccount: account, withMessage: [], withHighlightId: 0) {
                 self.previewChatViewController = chatViewController
 
                 // Fetch the context of the message and update the BaseChatViewController

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1283,7 +1283,13 @@ typedef enum RoomsSections {
 
 - (void)presentContextChatInRoom:(NCRoom *)room forMessageId:(NSInteger)messageId
 {
-    ContextChatViewController *contextChatViewController = [[ContextChatViewController alloc] initFor:room withMessage:@[] withHighlightId:0];
+    TalkAccount *account = room.account;
+
+    if (!account) {
+        return;
+    }
+
+    ContextChatViewController *contextChatViewController = [[ContextChatViewController alloc] initForRoom:room withAccount:account withMessage:@[] withHighlightId:0];
     contextChatViewController.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(closeContextChat)];
 
     NCChatController *chatController = [[NCChatController alloc] initForRoom:room];

--- a/NextcloudTalk/SystemMessageTableViewCell.h
+++ b/NextcloudTalk/SystemMessageTableViewCell.h
@@ -12,7 +12,6 @@
 static CGFloat kSystemMessageCellMinimumHeight  = 30.0;
 
 static NSString *SystemMessageCellIdentifier            = @"SystemMessageCellIdentifier";
-static NSString *InvisibleSystemMessageCellIdentifier   = @"InvisibleSystemMessageCellIdentifier";
 
 @protocol SystemMessageTableViewCellDelegate <ChatTableViewCellDelegate>
 

--- a/NextcloudTalk/SystemMessageTableViewCell.m
+++ b/NextcloudTalk/SystemMessageTableViewCell.m
@@ -27,10 +27,6 @@
 
 - (void)configureSubviews
 {
-    if ([self.reuseIdentifier isEqualToString:InvisibleSystemMessageCellIdentifier]) {
-        return;
-    }
-
     [self.contentView addSubview:self.dateLabel];
     [self.contentView addSubview:self.bodyTextView];
     [self.contentView addSubview:self.collapseButton];
@@ -58,7 +54,7 @@
     [super prepareForReuse];
 
     if (!self.didCreateSubviews) {
-        [self configureSubviews];
+        return;
     }
     
     self.selectionStyle = UITableViewCellSelectionStyleNone;

--- a/NextcloudTalkTests/Unit/Chat/UnitBaseChatTableViewCellTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitBaseChatTableViewCellTest.swift
@@ -59,10 +59,10 @@ final class UnitBaseChatTableViewCellTest: TestBaseRealm {
         }
 
         let deckCell: BaseChatTableViewCell = .fromNib()
-        deckCell.setup(for: deckMessage, inRoom: room)
+        deckCell.setup(for: deckMessage, inRoom: room, withAccount: activeAccount)
 
         let quoteCell: BaseChatTableViewCell = .fromNib()
-        quoteCell.setup(for: quoteMessage, inRoom: room)
+        quoteCell.setup(for: quoteMessage, inRoom: room, withAccount: activeAccount)
     }
 
 }

--- a/NextcloudTalkTests/Unit/Chat/UnitBaseChatViewControllerTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitBaseChatViewControllerTest.swift
@@ -42,17 +42,6 @@ final class UnitBaseChatViewControllerTest: TestBaseRealm {
         testMessage = NCChatMessage(dictionary: [:], andAccountId: UnitBaseChatViewControllerTest.fakeAccountId)
     }
 
-    func testInvisibleCellHeight() throws {
-        // Empty message should have a height of 0
-        testMessage.message = ""
-        XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 0.0)
-
-        // Test update message
-        testMessage.message = "System Message"
-        testMessage.systemMessage = "message_deleted"
-        XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 0.0)
-    }
-
     func testSystemMessageCellHeight() throws {
         testMessage.message = "System Message"
         testMessage.systemMessage = "test_system_message"

--- a/NextcloudTalkTests/Unit/Chat/UnitBaseChatViewControllerTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitBaseChatViewControllerTest.swift
@@ -38,8 +38,9 @@ final class UnitBaseChatViewControllerTest: TestBaseRealm {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        baseController = BaseChatViewController(for: NCRoom())!
-        testMessage = NCChatMessage(dictionary: [:], andAccountId: UnitBaseChatViewControllerTest.fakeAccountId)
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        baseController = BaseChatViewController(forRoom: NCRoom(), withAccount: activeAccount)!
+        testMessage = NCChatMessage(dictionary: [:], andAccountId: activeAccount.accountId)
     }
 
     func testSystemMessageCellHeight() throws {

--- a/NextcloudTalkTests/Unit/Chat/UnitChatViewControllerTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitChatViewControllerTest.swift
@@ -51,7 +51,7 @@ final class UnitChatViewControllerTest: TestBaseRealm {
 
         XCTAssertEqual(NCChatMessage.allObjects().count, 2)
 
-        let chatViewController = ChatViewController(for: room)!
+        let chatViewController = ChatViewController(forRoom: room, withAccount: activeAccount)!
         let messageArray = [expMessage1, expMessage2].map { NCChatMessage(value: $0) }
 
         chatViewController.appendMessages(messages: messageArray)

--- a/ShareExtension/ShareConfirmationViewController.swift
+++ b/ShareExtension/ShareConfirmationViewController.swift
@@ -30,7 +30,6 @@ import MBProgressHUD
 
     // MARK: - Public var
 
-    public var account: TalkAccount
     public var isModal: Bool = false
     public var forwardingMessage: Bool = false
 
@@ -220,10 +219,9 @@ import MBProgressHUD
     // MARK: - Init.
 
     public init?(room: NCRoom, account: TalkAccount, serverCapabilities: ServerCapabilities) {
-        self.account = account
         self.serverCapabilities = serverCapabilities
 
-        super.init(for: room, withView: self.shareContentView)
+        super.init(forRoom: room, withAccount: account, withView: self.shareContentView)
 
         self.shareContentView.addSubview(self.toLabelView)
         NSLayoutConstraint.activate([


### PR DESCRIPTION
I noticed a few issues when scrolling and found some places where we can improve the time needed for each cell. Especially the invisible cells still needed quite some computing, even though they are not displayed:

CPU cycles before:
<img width="246" alt="Bildschirmfoto 2024-11-30 um 17 15 55" src="https://github.com/user-attachments/assets/2832a9c2-293c-4f9b-99e0-b047349f1c05">

After:
<img width="248" alt="Bildschirmfoto 2024-11-30 um 17 18 56" src="https://github.com/user-attachments/assets/234a8ac3-b430-4f9d-bb7b-19059fe41417">

So this PR:
* Does not include invisible messages in the table view
* Caches parsed markdown
* Caches auth parameters (before we queried the keychain for each avatar/message)
* Simplifies cell prepareForReuse
* Pass down TalkAccount (so we don't query it for each cell multiple times). Since we indirectly require a TalkAccount for the chat view controllers, we can also make it mandatory and pass it down.
