### PR TITLE
fix(mentions): Adjust regex

### DIFF
--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -300,7 +300,7 @@ NSString * const kSharedItemTypeRecording   = @"recording";
     static NSRegularExpression *parameterRegex;
 
     if (!parameterRegex) {
-        parameterRegex = [NSRegularExpression regularExpressionWithPattern:@"\\{([^}]+)\\}" options:NSRegularExpressionCaseInsensitive error:&error];
+        parameterRegex = [NSRegularExpression regularExpressionWithPattern:@"\\{([a-z\\-_.0-9]+)\\}" options:NSRegularExpressionCaseInsensitive error:&error];
     }
 
     NSArray *matches = [parameterRegex matchesInString:originalMessage

--- a/NextcloudTalkTests/Unit/Chat/UnitNCChatMessageTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitNCChatMessageTest.swift
@@ -19,4 +19,35 @@ final class UnitNCChatMessageTest: TestBaseRealm {
         XCTAssertFalse(message.containsURL())
     }
 
+    func testMentionRendering() throws {
+        let mentionParameters = """
+        {
+            "mention-user1": {
+                "type": "user",
+                "id": "username@nextcloud.invalid",
+                "name": "Username with space",
+                "server": "https://nextcloud.invalid"
+            }
+        }
+        """
+
+        let mentionMessage = NCChatMessage()
+        mentionMessage.messageParametersJSONString = mentionParameters
+
+        mentionMessage.message = "{mention-user1}"
+        XCTAssertEqual(mentionMessage.parsedMarkdownForChat().string, "@Username with space")
+
+        mentionMessage.message = "{\n{mention-user1}"
+        XCTAssertEqual(mentionMessage.parsedMarkdownForChat().string, "{\n@Username with space")
+
+        mentionMessage.message = "@{mention-user1}"
+        XCTAssertEqual(mentionMessage.parsedMarkdownForChat().string, "@@Username with space")
+
+        mentionMessage.message = " abc{mention-user1}abc "
+        XCTAssertEqual(mentionMessage.parsedMarkdownForChat().string, " abc@Username with spaceabc ")
+
+        mentionMessage.message = "{mention-user1}{mention-user2}"
+        XCTAssertEqual(mentionMessage.parsedMarkdownForChat().string, "@Username with space{mention-user2}")
+    }
+
 }


### PR DESCRIPTION
How to test: Send message which has a curly bracket at the beginning and a mention afterwards, e.g. `{ @test`.

Regex taken from https://github.com/nextcloud-libraries/nextcloud-vue/blob/e3a78cd42ad45e9365a3b8822036cb46e0441d42/src/components/NcRichText/NcRichText.vue#L422