### PR TITLE
Fixes for displaying context chats

### DIFF
--- a/NextcloudTalk/ContextChatViewController.swift
+++ b/NextcloudTalk/ContextChatViewController.swift
@@ -7,8 +7,8 @@ import Foundation
 
 @objcMembers public class ContextChatViewController: BaseChatViewController {
 
-    public override func viewDidLoad() {
-        super.viewDidLoad()
+    override func setTitleView() {
+        super.setTitleView()
 
         self.titleView?.longPressGestureRecognizer.isEnabled = false
     }

--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -179,14 +179,8 @@ import UIKit
             self.textView.layer.borderColor = UIColor.systemGray4.cgColor
             self.textView.tintColor = UIColor(cgColor: UIColor.systemBlue.cgColor)
         }
-    }
 
-    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-
-        coordinator.animate(alongsideTransition: nil) { _ in
-            self.setTitleView()
-        }
+        self.setTitleView()
     }
 
     // MARK: - Configuration

--- a/NextcloudTalk/NCMediaViewerViewController.swift
+++ b/NextcloudTalk/NCMediaViewerViewController.swift
@@ -42,7 +42,7 @@ import UIKit
     private lazy var showMessageButton = {
         let showMessageButton = UIBarButtonItem(title: nil, style: .plain, target: nil, action: nil)
         showMessageButton.isEnabled = false
-        showMessageButton.primaryAction = UIAction(title: "", image: .init(systemName: "text.magnifyingglass"), handler: { [unowned self, unowned showMessageButton] _ in
+        showMessageButton.primaryAction = UIAction(title: "", image: .init(systemName: "text.magnifyingglass"), handler: { [unowned self] _ in
             guard let mediaPageViewController = self.getCurrentPageViewController() else { return }
 
             let message = mediaPageViewController.message
@@ -55,7 +55,6 @@ import UIKit
 
                     chatViewController.appendMessages(messages: messages)
                     chatViewController.reloadDataAndHighlightMessage(messageId: message.messageId)
-
                 }
 
                 let navController = NCNavigationController(rootViewController: chatViewController)

--- a/NextcloudTalk/NCMediaViewerViewController.swift
+++ b/NextcloudTalk/NCMediaViewerViewController.swift
@@ -57,6 +57,10 @@ import UIKit
                     chatViewController.reloadDataAndHighlightMessage(messageId: message.messageId)
                 }
 
+                chatViewController.navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Close", comment: ""), primaryAction: UIAction { [weak chatViewController] _ in
+                    chatViewController?.dismiss(animated: true)
+                })
+
                 let navController = NCNavigationController(rootViewController: chatViewController)
                 self.present(navController, animated: true)
             }

--- a/NextcloudTalk/RoomSharedItemsTableViewController.swift
+++ b/NextcloudTalk/RoomSharedItemsTableViewController.swift
@@ -446,7 +446,7 @@ import QuickLook
 
         self.present(previewNavigationChatViewController, animated: false)
 
-        previewChatViewController.navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .cancel, primaryAction: UIAction { [weak previewChatViewController] _ in
+        previewChatViewController.navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Close", comment: ""), primaryAction: UIAction { [weak previewChatViewController] _ in
             previewChatViewController?.dismiss(animated: true)
         })
     }


### PR DESCRIPTION
* Follow-up to https://github.com/nextcloud/talk-ios/pull/1916
<br>

* The longPressGesture was disabled on `viewDidLoad` only. Rotating the screen would call `setTitleView` which then again had an enabled longPressGesture.
* We reset the title view when the view transitions, but it's actually enough (and more smooth), to do so when the traitCollection changes.
* Removed unused capture that wasn't used in the methods body
* Added a close button to `ContextChatViewController` when being displayed from the media viewer.
* Noticed that we still use `Cancel` when displaying the context from the shared items tab -> changed to `Close`.