### PR TITLE
fix(textView): Disable adaptive glyph support

### DIFF
--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -108,6 +108,10 @@ import UIKit
         }
 #endif
 
+        if #available(iOS 18.0, *) {
+            self.textView.supportsAdaptiveImageGlyph = false
+        }
+
         self.textInputbar.editorTitle.textColor = .darkGray
         self.textInputbar.editorLeftButton.tintColor = .systemBlue
         self.textInputbar.editorRightButton.tintColor = .systemBlue


### PR DESCRIPTION
Otherwise we can add memojis and genmojis to the textView without handling them correctly.