### PR TITLE
fix(badge): Update realm before updating the badge

### DIFF
--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -306,6 +306,10 @@ NSString * const NCDatabaseManagerRoomCapabilitiesChangedNotification = @"NCData
 
 - (NSInteger)numberOfUnreadNotifications
 {
+    // Make sure that the data on this thread is up to date.
+    // Failing to do so might result in inaccurate badge numbers when they were updated on a different thread
+    [[RLMRealm defaultRealm] refresh];
+
     NSInteger unreadNotifications = 0;
     for (TalkAccount *account in [TalkAccount allObjects]) {
         unreadNotifications += account.unreadBadgeNumber;

--- a/NextcloudTalk/NCNotificationController.m
+++ b/NextcloudTalk/NCNotificationController.m
@@ -73,17 +73,19 @@ NSString * const NCNotificationActionFederationInvitationReject     = @"REJECT_F
 
 - (void)processBackgroundPushNotification:(NCPushNotification *)pushNotification
 {
-    if (pushNotification) {
-        if (pushNotification.type == NCPushNotificationTypeDelete) {
-            NSNumber *notificationId = @(pushNotification.notificationId);
-            [self removeNotificationWithNotificationIds:@[notificationId] forAccountId:pushNotification.accountId];
-        } else if (pushNotification.type == NCPushNotificationTypeDeleteAll) {
-            [self removeAllNotificationsForAccountId:pushNotification.accountId];
-        } else if (pushNotification.type == NCPushNotificationTypeDeleteMultiple) {
-            [self removeNotificationWithNotificationIds:pushNotification.notificationIds forAccountId:pushNotification.accountId];
-        } else {
-            NSLog(@"Push Notification of an unknown type received");
-        }
+    if (!pushNotification) {
+        return;
+    }
+
+    if (pushNotification.type == NCPushNotificationTypeDelete) {
+        NSNumber *notificationId = @(pushNotification.notificationId);
+        [self removeNotificationWithNotificationIds:@[notificationId] forAccountId:pushNotification.accountId];
+    } else if (pushNotification.type == NCPushNotificationTypeDeleteAll) {
+        [self removeAllNotificationsForAccountId:pushNotification.accountId];
+    } else if (pushNotification.type == NCPushNotificationTypeDeleteMultiple) {
+        [self removeNotificationWithNotificationIds:pushNotification.notificationIds forAccountId:pushNotification.accountId];
+    } else {
+        NSLog(@"Push Notification of an unknown type received");
     }
 }
 


### PR DESCRIPTION
How to reproduce:
* Write 2 messages and see that your badge is increased by 2
* Read the messages on web, to mark them as unread
* Notice that (sometimes) the badge is not decreased by 2 again, but sometimes only by 1 or not at all

After we removed the notifications, we also update the badgenumber:
https://github.com/nextcloud/talk-ios/blob/a06a909463c813f6c2ea8920d92d14d2faba9779/NextcloudTalk/NCNotificationController.m#L308-L319

Since this is wrapped in a dispatch, it is possible that realm was not yet fully updated on the other thread:

https://github.com/nextcloud/talk-ios/blob/a06a909463c813f6c2ea8920d92d14d2faba9779/NextcloudTalk/NCNotificationController.m#L229-L231

Resulting in a wrong badge count.