### PR TITLE
chore(realm): Explicitly set object classes

### DIFF
--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -125,6 +125,10 @@ NSString * const NCDatabaseManagerRoomCapabilitiesChangedNotification = @"NCData
         NSURL *databaseURL = [[NSURL fileURLWithPath:path] URLByAppendingPathComponent:kTalkDatabaseFileName];
         configuration.fileURL = databaseURL;
         configuration.schemaVersion = kTalkDatabaseSchemaVersion;
+        configuration.objectClasses = @[
+            TalkAccount.class, NCRoom.class, ServerCapabilities.class, FederatedCapabilities.class,
+            NCChatMessage.class, NCChatBlock.class, NCContact.class, ABContact.class
+        ];
         configuration.migrationBlock = ^(RLMMigration *migration, uint64_t oldSchemaVersion) {
             // At the very minimum we need to update the version with an empty block to indicate that the schema has been upgraded (automatically) by Realm
         };


### PR DESCRIPTION
Explicitly set the realm objects to skip the reflection part.

**Before:**
*Sim*
executionTime = 0.080615
executionTime = 0.047068
executionTime = 0.040857
executionTime = 0.039683
executionTime = 0.043307

*iPhone*
executionTime = 0.434822
executionTime = 0.075285
executionTime = 0.047228
executionTime = 0.047514
executionTime = 0.047294

**After:**
*Sim*
executionTime = 0.012980
executionTime = 0.002677
executionTime = 0.002767
executionTime = 0.003719
executionTime = 0.002734

*iPhone*
executionTime = 0.012954
executionTime = 0.012457
executionTime = 0.011931
executionTime = 0.030080
executionTime = 0.010954