### PR TITLE
Improve login test

### DIFF
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -461,6 +461,7 @@ typedef enum RoomsSections {
 {
     UIImage *logoImage = [UIImage imageNamed:[NCAppBranding navigationLogoImageName]];
     self.navigationItem.titleView = [[UIImageView alloc] initWithImage:logoImage];
+    self.navigationItem.titleView.accessibilityLabel = talkAppName;
 }
 
 - (UIMenu *)getActiveAccountMenuOptions

--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -285,7 +285,9 @@ typedef enum RoomsSections {
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {
-    [self setProfileButton];
+    if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+        [self setProfileButton];
+    }
 }
 
 - (void)didReceiveMemoryWarning
@@ -459,8 +461,6 @@ typedef enum RoomsSections {
 {
     UIImage *logoImage = [UIImage imageNamed:[NCAppBranding navigationLogoImageName]];
     self.navigationItem.titleView = [[UIImageView alloc] initWithImage:logoImage];
-    self.navigationItem.titleView.accessibilityLabel = talkAppName;
-    self.navigationItem.titleView.accessibilityHint = NSLocalizedString(@"Double tap to change accounts or add a new one", nil);
 }
 
 - (UIMenu *)getActiveAccountMenuOptions
@@ -558,7 +558,6 @@ typedef enum RoomsSections {
     // When no elements are returned by the deferred menu, the entries / inline-menu will be hidden
     [accountPickerMenu addObject:[self getActiveAccountMenuOptions]];
     [accountPickerMenu addObject:[self getInactiveAccountMenuOptions]];
-
 
     NSMutableArray *optionItems = [[NSMutableArray alloc] init];
 

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -755,9 +755,6 @@
 "Don't clear" = "Don't clear";
 
 /* No comment provided by engineer. */
-"Double tap to change accounts or add a new one" = "Double tap to change accounts or add a new one";
-
-/* No comment provided by engineer. */
 "Double tap to dismiss authentication dialog" = "Double tap to dismiss authentication dialog";
 
 /* No comment provided by engineer. */

--- a/NextcloudTalkTests/UI/AAAALoginTest.swift
+++ b/NextcloudTalkTests/UI/AAAALoginTest.swift
@@ -15,18 +15,7 @@ final class AAAALoginTest: XCTestCase {
 
     // Tests are done in alphabetical order, so we want to always test login first
     func test_Login() {
-        let app = launchAndLogin()
-
-        // Check if the profile button is available
-        let profileButton = app.buttons["LoadedProfileButton"]
-        XCTAssert(profileButton.waitForExistence(timeout: TestConstants.timeoutLong))
-
-        // Open profile menu
-        profileButton.tap()
-
-        // At this point we should be logged in, so check if username and server is displayed somewhere
-        XCTAssert(app.buttons["Settings"].waitForExistence(timeout: TestConstants.timeoutShort))
-        XCTAssert(app.buttons["Add account"].waitForExistence(timeout: TestConstants.timeoutShort))
+        launchAndLogin()
     }
 
 }

--- a/NextcloudTalkTests/UI/Helpers.swift
+++ b/NextcloudTalkTests/UI/Helpers.swift
@@ -37,6 +37,7 @@ extension XCTestCase {
         return nil
     }
 
+    @discardableResult
     func launchAndLogin() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchArguments += ["-AppleLanguages", "(en-US)"]


### PR DESCRIPTION
We already check the existence of the profile button in `launchAndLogin`. At app launch we have multiple code paths that update the profile menu, if the menu was open at that moment, it gets closed again, leading to a failed test.

Since the existence of a `LoadedProfileButton` button already indicates that we have an account, no need to check the actual menu.