### PR TITLE
perf: Read number of pending invitations from header

### DIFF
--- a/NextcloudTalk/FederationInvitationTableViewController.swift
+++ b/NextcloudTalk/FederationInvitationTableViewController.swift
@@ -3,6 +3,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 
+extension Notification.Name {
+    static let FederationInvitationDidAcceptNotification = Notification.Name(rawValue: "FederationInvitationDidAccept")
+}
+
+@objc extension NSNotification {
+    public static let FederationInvitationDidAcceptNotification = Notification.Name.FederationInvitationDidAcceptNotification
+}
+
 class FederationInvitationTableViewController: UITableViewController, FederationInvitationCellDelegate {
 
     private let federationInvitationCellIdentifier = "FederationInvitationCell"
@@ -120,6 +128,8 @@ class FederationInvitationTableViewController: UITableViewController, Federation
         NCAPIController.sharedInstance().acceptFederationInvitation(for: invitation.accountId, with: invitation.invitationId) { [weak self] success in
             if !success {
                 NotificationPresenter.shared().present(text: NSLocalizedString("Failed to accept invitation", comment: ""), dismissAfterDelay: 5.0, includedStyle: .error)
+            } else {
+                NotificationCenter.default.post(name: .FederationInvitationDidAcceptNotification, object: self, userInfo: nil)
             }
 
             self?.getData()

--- a/NextcloudTalk/NCDatabaseManager.h
+++ b/NextcloudTalk/NCDatabaseManager.h
@@ -148,7 +148,6 @@ extern NSString * const NCDatabaseManagerRoomCapabilitiesChangedNotification;
 - (void)increasePendingFederationInvitationForAccountId:(NSString *)accountId;
 - (void)decreasePendingFederationInvitationForAccountId:(NSString *)accountId;
 - (void)setPendingFederationInvitationForAccountId:(NSString *)accountId with:(NSInteger)numberOfPendingInvitations;
-- (void)updateLastFederationInvitationUpdateForAccountId:(NSString *)accountId withTimestamp:(NSInteger)timestamp;
 
 @end
 

--- a/NextcloudTalk/NCDatabaseManager.m
+++ b/NextcloudTalk/NCDatabaseManager.m
@@ -16,7 +16,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 74;
+uint64_t const kTalkDatabaseSchemaVersion           = 75;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";
@@ -806,18 +806,6 @@ NSString * const NCDatabaseManagerRoomCapabilitiesChangedNotification = @"NCData
     [[NSNotificationCenter defaultCenter] postNotificationName:NCDatabaseManagerPendingFederationInvitationsDidChange
                                                         object:self
                                                       userInfo:nil];
-}
-
-- (void)updateLastFederationInvitationUpdateForAccountId:(NSString *)accountId withTimestamp:(NSInteger)timestamp
-{
-    BGTaskHelper *bgTask = [BGTaskHelper startBackgroundTaskWithName:@"updateLastFederationInvitationUpdateForAccountId" expirationHandler:nil];
-    RLMRealm *realm = [RLMRealm defaultRealm];
-    [realm beginWriteTransaction];
-    NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@", accountId];
-    TalkAccount *account = [TalkAccount objectsWithPredicate:query].firstObject;
-    account.lastPendingFederationInvitationFetch = timestamp;
-    [realm commitWriteTransaction];
-    [bgTask stopBackgroundTask];
 }
 
 @end

--- a/NextcloudTalk/NCRoomsManagerExtensions.swift
+++ b/NextcloudTalk/NCRoomsManagerExtensions.swift
@@ -440,31 +440,4 @@ import Foundation
         completionBlock?()
     }
 
-    // MARK: - Federation invitations
-
-    public func checkUpdateNeededForPendingFederationInvitations() {
-        guard NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityFederationV1) else { return }
-
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        let tenMinutesAgo = Int(Date().timeIntervalSince1970 - (10 * 60))
-
-        if activeAccount.lastPendingFederationInvitationFetch == 0 || activeAccount.lastPendingFederationInvitationFetch < tenMinutesAgo {
-            self.updatePendingFederationInvitations()
-        }
-    }
-
-    public func updatePendingFederationInvitations() {
-        guard NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityFederationV1) else { return }
-
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-
-        NCAPIController.sharedInstance().getFederationInvitations(for: activeAccount.accountId) { invitations in
-            guard let invitations else { return }
-            let pendingInvitations = invitations.filter { $0.invitationState != .accepted }
-
-            if activeAccount.pendingFederationInvitations != pendingInvitations.count {
-                NCDatabaseManager.sharedInstance().setPendingFederationInvitationForAccountId(activeAccount.accountId, with: pendingInvitations.count)
-            }
-        }
-    }
 }

--- a/NextcloudTalk/TalkAccount.h
+++ b/NextcloudTalk/TalkAccount.h
@@ -41,7 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSString *lastReceivedModifiedSince;
 @property NSInteger lastNotificationId;
 @property NSString *lastNotificationETag;
-@property NSInteger lastPendingFederationInvitationFetch;
 @property NSInteger pendingFederationInvitations;
 @property NSString *frequentlyUsedEmojisJSONString;
 


### PR DESCRIPTION
* With https://github.com/nextcloud/spreed/pull/11944 we can read the pending invites from the room request and don't need to separately query the invites endpoint.

~~* Might even make more sense with https://github.com/nextcloud/spreed/pull/14168, if we can add that.~~

If the header is not there, we don't have pending invitations.