### PR TITLE
chore: Remove xcbeautify and rename the test file

### DIFF
--- a/.github/workflows/talk-ios-tests.yml
+++ b/.github/workflows/talk-ios-tests.yml
@@ -167,8 +167,7 @@ jobs:
         -derivedDataPath 'DerivedData' \
         -test-iterations 3 \
         -retry-tests-on-failure \
-        -resultBundlePath 'testResult.xcresult' \
-        | xcbeautify --quieter
+        -resultBundlePath 'testResult.xcresult'
 
     - name: Upload test results
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
* Since `uitests` do more than ui tests, we should rename that file
* `xcbeautify` is not needed when running the tests