### PR TITLE
fix(search): Reset titleOnly in RoomTableViewCell in cell reuse

### DIFF
--- a/NextcloudTalk/RoomTableViewCell.swift
+++ b/NextcloudTalk/RoomTableViewCell.swift
@@ -40,6 +40,7 @@ import Foundation
 
         self.subtitleLabel.text = ""
         self.dateLabel.text = ""
+        self.titleOnly = false
 
         self.unreadMessagesView.setBadgeNumber(0)
     }


### PR DESCRIPTION
Fixes this issue:

![IMG_E0132](https://github.com/user-attachments/assets/2d5b51f0-46e7-45b8-a252-ba4eea8f6440)

This can happen if when searching there are some contacts results (which has titleOnly = true).
When those cells from contacts are resused, this issue appears.