### PR TITLE
fix(search): Open conversations search results

### DIFF
--- a/NextcloudTalk/RoomSearchTableViewController.m
+++ b/NextcloudTalk/RoomSearchTableViewController.m
@@ -315,7 +315,14 @@ typedef enum RoomSearchSection {
     }
     NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:room.lastActivity];
     cell.dateLabel.text = [NCUtils readableTimeOrDateFromDate:date];
-    
+
+    // Open conversations
+    if (searchSection == RoomSearchSectionListable) {
+        cell.titleOnly = NO;
+        cell.subtitleLabel.text = room.roomDescription;
+        cell.dateLabel.text = @"";
+    }
+
     // Set unread messages
     if ([[NCDatabaseManager sharedInstance] serverHasTalkCapability:kCapabilityDirectMentionFlag]) {
         BOOL mentioned = room.unreadMentionDirect || room.type == kNCRoomTypeOneToOne || room.type == kNCRoomTypeFormerOneToOne;


### PR DESCRIPTION
- [x] Show conversation description
- [x] Remove date from last activity

Before:

![IMG_E0135](https://github.com/user-attachments/assets/e36b14bb-20ca-49b3-bed8-713dd06c57ea)

After:

![IMG_E0136](https://github.com/user-attachments/assets/ddacfcbb-8596-4af6-af76-cd1cd3106d59)
