### PR TITLE
Improve avatar caching

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -4313,7 +4313,7 @@
 			repositoryURL = "https://github.com/SDWebImage/SDWebImage.git";
 			requirement = {
 				kind = exactVersion;
-				version = 5.15.7;
+				version = 5.20.1;
 			};
 		};
 		1F45A11F2A01D8BA005FE87D /* XCRemoteSwiftPackageReference "SDWebImageSVGKitPlugin" */ = {

--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -150,6 +150,11 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     // Don't set the path to an app group in order to prevent crashes
     [SDImageCache sharedImageCache].config.shouldDisableiCloud = YES;
     [SDImageCache sharedImageCache].config.maxDiskSize = 100 * 1024 * 1024;
+    [SDImageCache sharedImageCache].config.maxDiskAge = 60 * 60 * 24 * 7 * 4; // 4 weeks
+
+    // We expire the cache once on app launch, see AppDelegate
+    [SDImageCache sharedImageCache].config.shouldRemoveExpiredDataWhenTerminate = NO;
+    [SDImageCache sharedImageCache].config.shouldRemoveExpiredDataWhenEnterBackground = NO;
 
     NSString *userAgent = [NSString stringWithFormat:@"Mozilla/5.0 (iOS) Nextcloud-Talk v%@",
                   [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"]];

--- a/NextcloudTalk/NCSettingsController.h
+++ b/NextcloudTalk/NCSettingsController.h
@@ -77,5 +77,6 @@ typedef NS_ENUM(NSInteger, NCPreferredFileSorting) {
 - (void)setContactSync:(BOOL)enabled;
 - (BOOL)didReceiveCallsFromOldAccount;
 - (void)setDidReceiveCallsFromOldAccount:(BOOL)receivedOldCalls;
+- (void)createAccountsFile;
 
 @end

--- a/NextcloudTalk/NCSettingsController.m
+++ b/NextcloudTalk/NCSettingsController.m
@@ -95,13 +95,6 @@ NSString * const kDidReceiveCallsFromOldAccount = @"receivedCallsFromOldAccount"
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(tokenRevokedResponseReceived:) name:NCTokenRevokedResponseReceivedNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(upgradeRequiredResponseReceived:) name:NCUpgradeRequiredResponseReceivedNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(talkConfigurationHasChanged:) name:NCTalkConfigurationHashChangedNotification object:nil];
-
-        // No need to create the file immediately -> dispatch to background
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^(void){
-            @autoreleasepool {
-                [self createAccountsFile];
-            }
-        });
     }
     return self;
 }


### PR DESCRIPTION
* Update SDWebImage to 5.20.1 (mainly because of a bug fixed regarding caching, see SDWebImage/pull/3759)
* Don't check cache expire on every move to the background, do it on app start once
* `maxDiskAge` is set to 1 week by default, use 4 weeks (we still re-evaluate based on cache buster and cache header, so that should not have a negative impact on how current an avatar is)