### PR TITLE
fix: Set room to read when last message is an update message

### DIFF
--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -470,14 +470,7 @@ NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotification     
                                                             object:self
                                                           userInfo:userInfo];
 
-        // Messages are already sorted by messageId here
-        NCChatMessage *lastMessage = [storedMessages lastObject];
-
-        // Make sure we update the unread flags for the room (lastMessage can already be set, but there still might be unread flags)
-        if (lastMessage.timestamp >= self->_room.lastActivity && !lastMessage.isUpdateMessage) {
-            self->_room.lastActivity = lastMessage.timestamp;
-            [[NCRoomsManager sharedInstance] updateLastMessage:lastMessage withNoUnreadMessages:YES forRoom:self->_room];
-        }
+        [self updateLastMessageIfNeededFromMessages:storedMessages];
     }
 }
 
@@ -501,15 +494,8 @@ NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotification     
         [[NSNotificationCenter defaultCenter] postNotificationName:NCChatControllerDidReceiveInitialChatHistoryNotification
                                                             object:self
                                                           userInfo:userInfo];
-        
-        // Messages are already sorted by messageId here
-        NCChatMessage *lastMessage = [storedMessages lastObject];
-        
-        // Make sure we update the unread flags for the room (lastMessage can already be set, but there still might be unread flags)
-        if (lastMessage.timestamp >= self->_room.lastActivity && !lastMessage.isUpdateMessage) {
-            self->_room.lastActivity = lastMessage.timestamp;
-            [[NCRoomsManager sharedInstance] updateLastMessage:lastMessage withNoUnreadMessages:YES forRoom:self->_room];
-        }
+
+        [self updateLastMessageIfNeededFromMessages:storedMessages];
     } else {
         _pullMessagesTask = [[NCAPIController sharedInstance] receiveChatMessagesOfRoom:_room.token fromLastMessageId:lastReadMessageId history:YES includeLastMessage:YES timeout:NO lastCommonReadMessage:_room.lastCommonReadMessage setReadMarker:YES markNotificationsAsRead:YES forAccount:_account withCompletionBlock:^(NSArray *messages, NSInteger lastKnownMessage, NSInteger lastCommonReadMessage, NSError *error, NSInteger statusCode) {
             if (self->_stopChatMessagesPoll) {
@@ -539,6 +525,34 @@ NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotification     
             
             [self checkLastCommonReadMessage:lastCommonReadMessage];
         }];
+    }
+}
+
+- (void)updateLastMessageIfNeededFromMessages:(NSArray *)storedMessages
+{
+    // Try to find the last non-update message - Messages are already sorted by messageId here
+    NCChatMessage *lastNonUpdateMessage;
+    NCChatMessage *lastMessage = [storedMessages lastObject];
+    NCChatMessage *tempMessage;
+
+    for (NSInteger i = (storedMessages.count - 1); i >= 0; i--) {
+        tempMessage = [storedMessages objectAtIndex:i];
+
+        if (![tempMessage isUpdateMessage]) {
+            lastNonUpdateMessage = tempMessage;
+            break;
+        }
+    }
+
+    // Make sure we update the unread flags for the room (lastMessage can already be set, but there still might be unread flags)
+    if (lastMessage && lastMessage.timestamp >= self->_room.lastActivity) {
+        // Make sure our local reference to the room also has the correct lastActivity set
+        if (lastNonUpdateMessage) {
+            self->_room.lastActivity = lastNonUpdateMessage.timestamp;
+        }
+
+        // We always want to set the room to have no unread messages, optionally we also want to update the last message, if there's one
+        [[NCRoomsManager sharedInstance] setNoUnreadMessagesForRoom:self->_room withLastMessage:lastNonUpdateMessage];
     }
 }
 

--- a/NextcloudTalk/NCRoomsManager.h
+++ b/NextcloudTalk/NCRoomsManager.h
@@ -60,8 +60,8 @@ typedef void (^SendOfflineMessagesCompletionBlock)(void);
 - (void)updateRoom:(NSString *)token withCompletionBlock:(GetRoomCompletionBlock)block;
 - (void)updatePendingMessage:(NSString *)message forRoom:(NCRoom *)room;
 - (void)updateLastReadMessage:(NSInteger)lastReadMessage forRoom:(NCRoom *)room;
-- (void)updateLastMessage:(NCChatMessage *)message withNoUnreadMessages:(BOOL)noUnreadMessages forRoom:(NCRoom *)room;
 - (void)updateLastCommonReadMessage:(NSInteger)messageId forRoom:(NCRoom *)room;
+- (void)setNoUnreadMessagesForRoom:(NCRoom *)room withLastMessage:(NCChatMessage * _Nullable)lastMessage;
 // Chat
 - (void)startChatInRoom:(NCRoom *)room;
 - (void)leaveChatInRoom:(NSString *)token;

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -315,20 +315,22 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
     }];
 }
 
-- (void)updateLastMessage:(NCChatMessage *)message withNoUnreadMessages:(BOOL)noUnreadMessages forRoom:(NCRoom *)room
+- (void)setNoUnreadMessagesForRoom:(NCRoom *)room withLastMessage:(NCChatMessage * _Nullable)lastMessage
 {
     RLMRealm *realm = [RLMRealm defaultRealm];
     [realm transactionWithBlock:^{
         NCRoom *managedRoom = [NCRoom objectsWhere:@"internalId = %@", room.internalId].firstObject;
-        if (managedRoom) {
-            managedRoom.lastMessageId = message.internalId;
-            managedRoom.lastActivity = message.timestamp;
-            
-            if (noUnreadMessages) {
-                managedRoom.unreadMention = NO;
-                managedRoom.unreadMentionDirect = NO;
-                managedRoom.unreadMessages = 0;
-            }
+        if (!managedRoom) {
+            return;
+        }
+
+        managedRoom.unreadMention = NO;
+        managedRoom.unreadMentionDirect = NO;
+        managedRoom.unreadMessages = 0;
+
+        if (lastMessage) {
+            managedRoom.lastMessageId = lastMessage.internalId;
+            managedRoom.lastActivity = lastMessage.timestamp;
         }
     }];
 }


### PR DESCRIPTION
* Related https://github.com/nextcloud/talk-ios/issues/1123

We set the room to read, when we enter the room or receive new messages. Currently we enforce that the last message needs to be a non-update message, so when the last message is a reaction or edit, we will not update the room. This PR changes the logic a bit, so that we
1. Always set the room to read and only update the last message in case there's one
2. Check if we can find a non-update message, instead of relying on the last message

It's still a bit problematic if the server is very slow and we receive "old" data, but it should improve things.