### PR TITLE
Fix/noid/dont hangup call when already joined

### DIFF
--- a/NextcloudTalk/CallKitManager.m
+++ b/NextcloudTalk/CallKitManager.m
@@ -395,7 +395,11 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
             return;
         } else if (state == CallNotificationStateParticipantJoined) {
             // Account is already in a call (answered the call on a different device) -> no need to keep ringing
-            [self endCallWithUUID:call.uuid];
+
+            if (![[NCRoomsManager sharedInstance] isCallOngoingWithCallToken:call.token]) {
+                [self endCallWithUUID:call.uuid];
+            }
+
             return;
         }
 

--- a/NextcloudTalk/CallViewController.swift
+++ b/NextcloudTalk/CallViewController.swift
@@ -1737,8 +1737,8 @@ class CallViewController: UIViewController,
         }
 
         // Make sure there's no menu interfering with our dismissal
-        self.moreMenuButton.contextMenuInteraction?.dismissMenu()
-        self.hangUpButton.contextMenuInteraction?.dismissMenu()
+        self.moreMenuButton?.contextMenuInteraction?.dismissMenu()
+        self.hangUpButton?.contextMenuInteraction?.dismissMenu()
 
         self.delegate?.callViewControllerWantsToBeDismissed(self)
 

--- a/NextcloudTalk/NCRoomsManager.h
+++ b/NextcloudTalk/NCRoomsManager.h
@@ -68,6 +68,7 @@ typedef void (^SendOfflineMessagesCompletionBlock)(void);
 - (void)startChatWithRoomToken:(NSString *)token;
 // Call
 - (void)joinCallWithCallToken:(NSString *)token withVideo:(BOOL)video asInitiator:(BOOL)initiator recordingConsent:(BOOL)recordingConsent;
+- (BOOL)isCallOngoingWithCallToken:(NSString *)token;
 // Switch to
 - (void)prepareSwitchToAnotherRoomFromRoom:(NSString *)token withCompletionBlock:(ExitRoomCompletionBlock)block;
 

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -485,6 +485,15 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
     }];
 }
 
+- (BOOL)isCallOngoingWithCallToken:(NSString *)token
+{
+    if (!self.callViewController) {
+        return false;
+    }
+
+    return [self.callViewController.room.token isEqualToString:token];
+}
+
 - (void)startCallWithCallToken:(NSString *)token withVideo:(BOOL)video enabledAtStart:(BOOL)enabled asInitiator:(BOOL)initiator silently:(BOOL)silently recordingConsent:(BOOL)recordingConsent andVoiceChatMode:(BOOL)voiceChatMode
 {
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];


### PR DESCRIPTION
This is not a perfect fix, because as soon as we try to accept the second call via call, we always end the call. But that already seems to happen on the CallKit side, so I don't see a good way of preventing that right now. At least we should not try to automatically hangup the call.