### PR TITLE
fix(gif): Remove gif on cell re-use

### DIFF
--- a/NextcloudTalk/BaseChatTableViewCell+File.swift
+++ b/NextcloudTalk/BaseChatTableViewCell+File.swift
@@ -109,6 +109,9 @@ extension BaseChatTableViewCell {
         self.filePreviewImageView?.image = nil
         self.filePreviewPlayIconImageView?.isHidden = true
 
+        // Remove a potential gif
+        self.filePreviewImageView?.clear()
+
         self.clearFileStatusView()
     }
 


### PR DESCRIPTION
The gif itself still lives in the imageview and is not removed. On re-use it overlays any other preview, showing the wrong image.

(`clear()` is a method of SwiftyGif)