### PR TITLE
fix: Add missing bundle display name to Intents target

### DIFF
--- a/TalkIntents/Info.plist
+++ b/TalkIntents/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
 	<key>EXAppExtensionAttributes</key>
 	<dict>
 		<key>EXExtensionPointIdentifier</key>


### PR DESCRIPTION
![upload-failed](https://github.com/user-attachments/assets/ea3e5b02-9f82-4405-90ae-b7722cdb81b8)
