### PR TITLE
fix(lastMessage): Don't update when inaccurate

### DIFF
--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -147,7 +147,7 @@ NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotification     
         
         NCChatMessage *managedMessage = [NCChatMessage objectsWhere:@"internalId = %@", message.internalId].firstObject;
         if (managedMessage) {
-            [NCChatMessage updateChatMessage:managedMessage withChatMessage:message isRoomLastMessage:NO];
+            [NCChatMessage updateChatMessage:managedMessage withChatMessage:message];
         } else if (message) {
             [realm addObject:message];
         }
@@ -156,7 +156,7 @@ NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotification     
         NCChatMessage *managedParentMessage = [NCChatMessage objectsWhere:@"internalId = %@", parent.internalId].firstObject;
         if (managedParentMessage) {
             // updateChatMessage takes care of not setting a parentId to nil if there was one before
-            [NCChatMessage updateChatMessage:managedParentMessage withChatMessage:parent isRoomLastMessage:NO];
+            [NCChatMessage updateChatMessage:managedParentMessage withChatMessage:parent];
         } else if (parent) {
             [realm addObject:parent];
         }

--- a/NextcloudTalk/NCChatMessage.h
+++ b/NextcloudTalk/NCChatMessage.h
@@ -89,7 +89,7 @@ typedef void (^GetReferenceDataCompletionBlock)(NCChatMessage *message, NSDictio
 
 + (instancetype)messageWithDictionary:(NSDictionary *)messageDict;
 + (instancetype)messageWithDictionary:(NSDictionary *)messageDict andAccountId:(NSString *)accountId;
-+ (void)updateChatMessage:(NCChatMessage *)managedChatMessage withChatMessage:(NCChatMessage *)chatMessage isRoomLastMessage:(BOOL)isRoomLastMessage;
++ (void)updateChatMessage:(NCChatMessage *)managedChatMessage withChatMessage:(NCChatMessage *)chatMessage;
 
 - (NCMessageFileParameter *)file;
 - (NCMessageLocationParameter * _Nullable)geoLocation;

--- a/NextcloudTalk/NCChatMessage.m
+++ b/NextcloudTalk/NCChatMessage.m
@@ -138,7 +138,7 @@ NSString * const kSharedItemTypeRecording   = @"recording";
     return message;
 }
 
-+ (void)updateChatMessage:(NCChatMessage *)managedChatMessage withChatMessage:(NCChatMessage *)chatMessage isRoomLastMessage:(BOOL)isRoomLastMessage
++ (void)updateChatMessage:(NCChatMessage *)managedChatMessage withChatMessage:(NCChatMessage *)chatMessage
 {
     int previewImageHeight = 0;
     int previewImageWidth = 0;
@@ -173,9 +173,9 @@ NSString * const kSharedItemTypeRecording   = @"recording";
     managedChatMessage.lastEditActorDisplayName = chatMessage.lastEditActorDisplayName;
     managedChatMessage.lastEditTimestamp = chatMessage.lastEditTimestamp;
 
-    if (!isRoomLastMessage) {
-        managedChatMessage.reactionsSelfJSONString = chatMessage.reactionsSelfJSONString;
-    }
+    // Note: `reactionsSelfJSONString` should not be updated when done from `lastMessage`
+    // The code-path to do that was removed, but keeping a note for future reference
+    managedChatMessage.reactionsSelfJSONString = chatMessage.reactionsSelfJSONString;
     
     if (!managedChatMessage.parentId && chatMessage.parentId) {
         managedChatMessage.parentId = chatMessage.parentId;
@@ -656,7 +656,7 @@ NSString * const kSharedItemTypeRecording   = @"recording";
 
         void (^update)(void) = ^void(){
             NCChatMessage *managedMessage = [NCChatMessage objectsWhere:@"internalId = %@", self.internalId].firstObject;
-            [NCChatMessage updateChatMessage:managedMessage withChatMessage:self isRoomLastMessage:NO];
+            [NCChatMessage updateChatMessage:managedMessage withChatMessage:self];
         };
 
         if ([realm inWriteTransaction]) {

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -280,9 +280,7 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
 
     if (lastMessage) {
         NCChatMessage *managedLastMessage = [NCChatMessage objectsWhere:@"internalId = %@", lastMessage.internalId].firstObject;
-        if (managedLastMessage) {
-            [NCChatMessage updateChatMessage:managedLastMessage withChatMessage:lastMessage isRoomLastMessage:YES];
-        } else {
+        if (!managedLastMessage) {
             NCChatController *chatController = [[NCChatController alloc] initForRoom:room];
             [chatController storeMessages:@[messageDict] withRealm:realm];
         }


### PR DESCRIPTION
* Ref https://github.com/nextcloud/spreed/pull/14771

Since the referenced server PR we don't receive the full path of a file share in the last message of a room. But whenever we receive a last message on the room update, we update that message in realm (which is questionable in general). This PR ensures that we only store inaccurate last messages, when it wasn't previously stored.

This PR can only be considered a hot fix, to ensure the "old" behavior. Generally it is wrong to rely on a locally stored path, since that could change at any time on the server. We should use the file id to always determine the correct path upfront (or even download the file based on the fileid, if possible):

* Ref https://github.com/nextcloud/talk-ios/issues/2054