### PR TITLE
fix: Update mentions indicator when switching to archived rooms

### DIFF
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1577,6 +1577,7 @@ typedef enum RoomsSections {
         _showingArchivedRooms = !_showingArchivedRooms;
         [UIView transitionWithView:self.tableView duration:0.2 options:UIViewAnimationOptionTransitionCrossDissolve animations:^{
             [self filterRooms];
+            [self updateMentionsIndicator];
         } completion:nil];
         return;
     }


### PR DESCRIPTION
* Have a mention in a non-archived room, ensure you see "unread mention"
* Switch to archived conversations
* Tap the "unread mention" button
* 💣 

> *** Terminating app due to uncaught exception 'NSRangeException', reason: 'Attempted to scroll the table view to an out-of-bounds row (16) when there are only 1 rows in section 2. Table view: <UITableView: 0x10c04de00; frame = (0 0; 402 874); clipsToBounds = YES; autoresize = W+H; tintColor = <UIDynamicSystemColor: 0x6000017a1f80; name = systemGray4Color>; gestureRecognizers = <NSArray: 0x600000cc0870>; backgroundColor = <UIDynamicSystemColor: 0x600001796340; name = tableBackgroundColor>; layer = <CALayer: 0x6000002aa2e0>; contentOffset: {0, -100.33333333333333}; contentSize: {402, 124}; adjustedContentInset: {100.33333333333333, 0, 34, 0}; dataSource: <RoomsTableViewController: 0x10c023000>>'
terminating due to uncaught exception of type NSException