### PR TITLE
fix: add nil check to prevent crash when adding room.token to dictionary

### DIFF
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1296,7 +1296,7 @@ typedef enum RoomsSections {
      ofType:kNCRoomTypeOneToOne
      andName:nil
      completionBlock:^(NCRoom *room, NSError *error) {
-        if (!error) {
+        if (!error && room.token != nil) {
             [self.navigationController dismissViewControllerAnimated:YES completion:^{
                 [[NSNotificationCenter defaultCenter] postNotificationName:NCSelectedUserForChatNotification
                                                                     object:self


### PR DESCRIPTION
A few crashes reported on Xcode.
Can't find the reason why `room` or `room.token` can be nil at that point :S but worth adding a nil check.