### PR TITLE
Clearer Mark as Read/Unread icons

### DIFF
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -1410,7 +1410,7 @@ typedef enum RoomsSections {
             completionHandler(true);
         }];
 
-        NSString *markImageName = (room.unreadMessages > 0) ? @"eye" : @"eye.slash";
+        NSString *markImageName = (room.unreadMessages > 0) ? @"app.badge.checkmark" : @"app.badge";
         markReadAction.image = [UIImage systemImageNamed:markImageName];
         markReadAction.backgroundColor = [UIColor systemBlueColor];
 


### PR DESCRIPTION
These are more consistent with other apps and thus clearer to users. We can't use bubble as there is no badge symbol for it unfortunately.