### PR TITLE
fix: Reuse issue in gif image view

### DIFF
--- a/NextcloudTalk/BaseChatTableViewCell+File.swift
+++ b/NextcloudTalk/BaseChatTableViewCell+File.swift
@@ -199,7 +199,8 @@ extension BaseChatTableViewCell {
         self.filePreviewImageView?.setImageWith(previewRequest, placeholderImage: placeholderImage, success: {  [weak self] _, _, image in
             guard let self, let imageView = self.filePreviewImageView else { return }
 
-            imageView.image = image
+            // Use SwiftyGif extension method, to ensure that the gif ImageView is removed, in case there's any
+            imageView.setImage(image)
             self.adjustImageView(toImageSize: image, ofMessage: message)
         }, failure: { _, _, _ in
             self.showFallbackIcon(for: message)


### PR DESCRIPTION
When an image view is reused, that had a gif previously displayed, but should now display a normal image, the view is displayed empty. We need to use the extension method from SwiftyGif to ensure that the internal gif image view is removed in that case.