### PR TITLE
fix: Avatar caching in NSURLCache

### DIFF
--- a/NextcloudTalk/NCAPIController.m
+++ b/NextcloudTalk/NCAPIController.m
@@ -141,6 +141,14 @@ NSInteger const kReceivedChatMessagesLimit = 100;
                                maximumActiveDownloads:4
                                             imageCache:nil];
 
+    // The defaults for the shared url cache are very low, use some sane values for caching. Apple only caches assets <= 5% of the available space.
+    // Otherwise some (user) avatars will never be cached and always requested
+    NSURLCache *sharedURLCache = [[NSURLCache alloc] initWithMemoryCapacity:20 * 1024 * 1024
+                                                               diskCapacity:100 * 1024 * 1024
+                                                                   diskPath:nil];
+
+    [NSURLCache setSharedURLCache:sharedURLCache];
+
     // By default SDWebImageDownloader defaults to 6 concurrent downloads (see SDWebImageDownloaderConfig)
 
     // Make sure we support download SVGs with SDImageDownloader
@@ -148,12 +156,6 @@ NSInteger const kReceivedChatMessagesLimit = 100;
 
     // Make sure we support self-signed certificates we trusted before
     [[SDWebImageDownloader sharedDownloader].config setOperationClass:[NCWebImageDownloaderOperation class]];
-
-    // Try to remove legacy avatar cache in app group
-    NSURL *legacyCacheURL = [[[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:groupIdentifier] URLByAppendingPathComponent:@"AvatarCache"];
-    if (legacyCacheURL != nil) {
-        [[NSFileManager defaultManager] removeItemAtURL:legacyCacheURL error:nil];
-    }
 
     // Limit the cache size to 100 MB and prevent uploading to iCloud
     // Don't set the path to an app group in order to prevent crashes

--- a/NextcloudTalk/SettingsTableViewController.swift
+++ b/NextcloudTalk/SettingsTableViewController.swift
@@ -545,6 +545,7 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate, U
         let clearAction = UIAlertAction(title: NSLocalizedString("Clear cache", comment: ""), style: .destructive) { _ in
             NCImageSessionManager.shared.cache.removeAllCachedResponses()
 
+            URLCache.shared.removeAllCachedResponses()
             SDImageCache.shared.clearMemory()
             SDImageCache.shared.clearDisk {
                 self.updateTotalImageCacheSize()
@@ -1028,8 +1029,9 @@ extension SettingsTableViewController {
 
     func updateTotalImageCacheSize() {
         let imageCacheSize = NCImageSessionManager.shared.cache.currentDiskUsage
+        let sharedUrlCache = URLCache.shared.currentDiskUsage
         let sdImageCacheSize = SDImageCache.shared.totalDiskSize()
-        self.totalImageCacheSize = imageCacheSize + Int(sdImageCacheSize)
+        self.totalImageCacheSize = imageCacheSize + sharedUrlCache + Int(sdImageCacheSize)
     }
 
     func updateTotalFileCacheSize() {


### PR DESCRIPTION
Defaults for shared NSURLCache are very low (10MB disk and 512KB memory in simulator and on my iPhone). iOS only caches assets that are below 5% of the cache, so any avatar that is 512KB in size for example, will never be cached and always requested from the server. This affects user avatars, as those don't have an avatarVersion and we need to rely on the cache header.
Therefore we should use some sane defaults for the shared cache in general and also take the size into account in the settings.