### PR TITLE
fix: Don't retry polling on 429

### DIFF
--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -694,6 +694,12 @@ NSString * const NCChatControllerDidReceiveMessagesInBackgroundNotification     
                 [self notifyChatIsBlocked];
                 return;
             }
+
+            if (statusCode == 429) {
+                [NCUtils log:@"Brute-force protected, received 429 while receiving messages. No further polling."];
+                return;
+            }
+
             if (statusCode != 304) {
                 NSLog(@"Could not get new chat messages. Error: %@", error.description);
             }


### PR DESCRIPTION
When we are bruteforce protected, we end up in an infinite loop of requests -> we shouldn't do that. It is unlikely that a 429 will resolve in a few seconds anyway.