### PR TITLE
chore(chat): New style for reactions in chat view

### DIFF
--- a/NextcloudTalk/ReactionsViewCell.swift
+++ b/NextcloudTalk/ReactionsViewCell.swift
@@ -11,22 +11,33 @@ import UIKit
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        label.layer.borderWidth = 1.0
-        label.layer.borderColor = self.borderColor()
-        label.layer.cornerRadius = 15.0
+        label.layer.cornerRadius = 8
         label.clipsToBounds = true
-        label.backgroundColor = NCAppBranding.backgroundColor()
+        label.textColor = defaultTextColor()
+        label.backgroundColor = defaultBackgroundColor()
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
         label.text = ""
-        label.layer.borderColor = self.borderColor()
-        label.backgroundColor = NCAppBranding.backgroundColor()
+        label.textColor = defaultTextColor()
+        label.backgroundColor = defaultBackgroundColor()
     }
 
-    func borderColor() -> CGColor {
-        return UIColor.tertiaryLabel.cgColor
+    func defaultTextColor() -> UIColor {
+        return .label
+    }
+
+    func defaultBackgroundColor() -> UIColor {
+        return .secondarySystemBackground
+    }
+
+    func highlightedTextColor() -> UIColor {
+        return NCAppBranding.themeTextColor()
+    }
+
+    func highlightedBackgroundColor() -> UIColor {
+        return NCAppBranding.elementColor()
     }
 
     func sizeForReaction(reaction: NCChatReaction) -> CGSize {
@@ -42,8 +53,8 @@ import UIKit
 
     func setReaction(reaction: NCChatReaction) {
         label.text = textForReaction(reaction: reaction)
-        label.backgroundColor = reaction.userReacted ? NCAppBranding.elementColor().withAlphaComponent(0.15) : NCAppBranding.backgroundColor()
-        label.layer.borderColor = reaction.userReacted ? NCAppBranding.elementColor().cgColor : self.borderColor()
+        label.textColor = reaction.userReacted ? highlightedTextColor() : defaultTextColor()
+        label.backgroundColor = reaction.userReacted ? highlightedBackgroundColor() : defaultBackgroundColor()
     }
 
 }


### PR DESCRIPTION
| Before (dark mode) | After (dark mode) |
| --- | --- |
| ![IMG_E0167](https://github.com/user-attachments/assets/6baf5b8c-73b8-4cfc-8722-3a543f17d59a) | ![IMG_E0168](https://github.com/user-attachments/assets/68b47be7-9548-4501-9ffb-b749f0a49040) |

| Before (light mode) | After (light mode) |
| --- | --- |
| ![IMG_E0166](https://github.com/user-attachments/assets/9684c22a-19f2-48dc-9284-6b4c2a658fdd) | ![IMG_E0165](https://github.com/user-attachments/assets/f04cbb7d-f3c3-48cd-9643-47f94f61d2e9) |



