### PR TITLE
fix: Use downscaled images to prevent memory issues

### DIFF
--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -104,6 +104,9 @@
 "[Unknown username]" = "[Unknown username]";
 
 /* No comment provided by engineer. */
+"A low resolution version is displayed" = "A low resolution version is displayed";
+
+/* No comment provided by engineer. */
 "About" = "About";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
* Fixes https://github.com/nextcloud/talk-ios/issues/2157
* 
<img width="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-16 at 19 39 04" src="https://github.com/user-attachments/assets/2c5cf8d5-88e9-4110-8147-240faa585b13" />
