### PR TITLE
fix: Adjust DND icon to be similiar to the web interface one

### DIFF
--- a/NextcloudTalk/AvatarView.swift
+++ b/NextcloudTalk/AvatarView.swift
@@ -159,11 +159,7 @@ import SDWebImage
                 setUserStatusImage(statusImage, with: backgroundColor)
             }
         } else if userStatus == "dnd" {
-            var dndImageName = "minus.circle.fill"
-            if #available(iOS 16.1, *) {
-                dndImageName = "wrongwaysign.fill"
-            }
-            if let statusImage = statusImageWith(name: dndImageName, color: .systemRed, secondaryColor: .white, padding: 2) {
+            if let statusImage = statusImageWith(name: "minus.circle.fill", color: .systemRed, padding: 2) {
                 setUserStatusImage(statusImage, with: backgroundColor)
             }
         }

--- a/NextcloudTalk/NCUserStatus.m
+++ b/NextcloudTalk/NCUserStatus.m
@@ -85,13 +85,7 @@ NSString * const kUserStatusOffline     = @"offline";
 
 + (UIImage *)getDoNotDisturbSFIcon
 {
-    UIImageSymbolConfiguration *conf = [UIImageSymbolConfiguration configurationWithPaletteColors:@[[UIColor whiteColor], [UIColor systemRedColor]]];
-
-    if (@available(iOS 16.1, *)) {
-        return [[UIImage systemImageNamed:@"wrongwaysign.fill"] imageByApplyingSymbolConfiguration:conf];
-    }
-
-    return [[UIImage systemImageNamed:@"minus.circle.fill"] imageByApplyingSymbolConfiguration:conf];
+    return [[UIImage systemImageNamed:@"minus.circle.fill"] imageWithTintColor:[UIColor systemRedColor] renderingMode:UIImageRenderingModeAlwaysOriginal];
 }
 
 + (UIImage *)getInvisibleSFIcon

--- a/NextcloudTalk/NCUserStatus.m
+++ b/NextcloudTalk/NCUserStatus.m
@@ -90,7 +90,7 @@ NSString * const kUserStatusOffline     = @"offline";
 
 + (UIImage *)getInvisibleSFIcon
 {
-    UIImageSymbolConfiguration *conf = [UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightBlack];
+    UIImageSymbolConfiguration *conf = [UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightBold];
     return [[[UIImage systemImageNamed:@"circle"] imageByApplyingSymbolConfiguration:conf] imageWithTintColor:[UIColor labelColor] renderingMode:UIImageRenderingModeAlwaysOriginal];
 }
 

--- a/NextcloudTalk/NCUserStatusExtensions.swift
+++ b/NextcloudTalk/NCUserStatusExtensions.swift
@@ -25,7 +25,7 @@ extension NCUserStatus {
     }
 
     static func getInvisibleIcon() -> some View {
-        return Image(systemName: "circle").font(.system(size: 16, weight: .black)).foregroundColor(.primary)
+        return Image(systemName: "circle").font(.system(size: 16, weight: .bold)).foregroundColor(.primary)
     }
 
     static func getUserStatusIcon(userStatus: String) -> any View {

--- a/NextcloudTalk/NCUserStatusExtensions.swift
+++ b/NextcloudTalk/NCUserStatusExtensions.swift
@@ -21,11 +21,7 @@ extension NCUserStatus {
     }
 
     static func getDoNotDisturbIcon() -> some View {
-        if #available(iOS 16.1, *) {
-            return Image(systemName: "wrongwaysign.fill").font(.system(size: 16)).symbolRenderingMode(.palette).foregroundStyle(.white, .red)
-        }
-
-        return Image(systemName: "minus.circle.fill").font(.system(size: 16)).symbolRenderingMode(.palette).foregroundStyle(.white, .red)
+        return Image(systemName: "minus.circle.fill").font(.system(size: 16)).symbolRenderingMode(.monochrome).foregroundStyle(.red)
     }
 
     static func getInvisibleIcon() -> some View {


### PR DESCRIPTION
Ref: https://github.com/nextcloud-libraries/nextcloud-vue/pull/7392

| Before (Light) | After (Light) |
| --- | --- |
| <img width="1125" height="2436" alt="IMG_0189" src="https://github.com/user-attachments/assets/c2c70535-b8fb-4929-8302-c6c430d7a46c" /> | <img width="1125" height="2436" alt="IMG_0186" src="https://github.com/user-attachments/assets/6637d286-c904-4b50-adf4-b1e9cec52625" /> |

| Before (Dark) | After (Dark) |
| --- | --- |
| <img width="1125" height="2436" alt="IMG_0188" src="https://github.com/user-attachments/assets/4360751f-7f77-4eae-aadb-f573483aa0d0" /> | <img width="1125" height="2436" alt="IMG_0187" src="https://github.com/user-attachments/assets/5b5aacee-12bc-45fa-a50b-41dfaf14969e" /> |





