### PR TITLE
fix: Always show searchbar in ShareExtension

### DIFF
--- a/ShareExtension/ShareViewController.m
+++ b/ShareExtension/ShareViewController.m
@@ -183,6 +183,7 @@
     self.navigationItem.searchController.searchBar.searchTextField.backgroundColor = [NCUtils searchbarBGColorForColor:[NCAppBranding themeColor]];
 
     self.navigationItem.preferredSearchBarPlacement = UINavigationItemSearchBarPlacementStacked;
+    self.navigationItem.hidesSearchBarWhenScrolling = NO;
 
     _searchController.searchBar.tintColor = [NCAppBranding themeTextColor];
     UITextField *searchTextField = [_searchController.searchBar valueForKey:@"searchField"];


### PR DESCRIPTION
Searchbar is hidden by default and might be hard to discover when sharing something from other apps.