### PR TITLE
Fix: Add talk metadata when sharing files

### DIFF
--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -525,7 +525,7 @@ import SwiftUI
         temporaryMessage.timestamp = Int(Date().timeIntervalSince1970)
         temporaryMessage.token = room.token
         temporaryMessage.threadId = thread?.threadId ?? 0
-        temporaryMessage.isThread = thread != nil ? true : false
+        temporaryMessage.isThread = thread != nil
 
         let referenceId = "temp-\(Date().timeIntervalSince1970 * 1000)"
         temporaryMessage.referenceId = NCUtils.sha1(fromString: referenceId)

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -1809,9 +1809,14 @@ import SwiftUI
         let tempDirectoryURL = URL(fileURLWithPath: chatFileController.tempDirectoryPath)
         let destinationFilePath = tempDirectoryURL.appendingPathComponent(audioFileName).path
 
+        var replyToMessage: NCChatMessage? = nil
+        if let replyMessageView, replyMessageView.isVisible {
+            replyToMessage = replyMessageView.message
+        }
+
         if let temporaryMessage = self.createTemporaryMessage(
             message: audioFileName,
-            replyTo: nil,
+            replyTo: replyToMessage,
             messageParameters: "\(destinationFilePath)",
             silently: false,
             isVoiceMessage: true
@@ -1832,7 +1837,10 @@ import SwiftUI
 
             NCAPIController.sharedInstance().uniqueNameForFileUpload(withName: audioFileName, originalName: true, for: activeAccount, withCompletionBlock: { fileServerURL, fileServerPath, _, _ in
                 if let fileServerURL, let fileServerPath {
-                    let talkMetaData: [String: String] = ["messageType": "voice-message"]
+                    var talkMetaData: [String: Any] = ["messageType": "voice-message"]
+                    if let replyToMessageId = replyToMessage?.messageId {
+                        talkMetaData["replyTo"] = replyToMessageId
+                    }
 
                     self.uploadFileAtPath(localPath: destinationFilePath, withFileServerURL: fileServerURL, andFileServerPath: fileServerPath, withMetaData: talkMetaData, temporaryMessage: temporaryMessage)
                 } else {
@@ -1844,7 +1852,7 @@ import SwiftUI
         }
     }
 
-    func uploadFileAtPath(localPath: String, withFileServerURL fileServerURL: String, andFileServerPath fileServerPath: String, withMetaData talkMetaData: [String: String]?, temporaryMessage: NCChatMessage?) {
+    func uploadFileAtPath(localPath: String, withFileServerURL fileServerURL: String, andFileServerPath fileServerPath: String, withMetaData talkMetaData: [String: Any]?, temporaryMessage: NCChatMessage?) {
 
         ChatFileUploader.uploadFile(localPath: localPath,
                                     fileServerURL: fileServerURL,

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -524,6 +524,8 @@ import SwiftUI
         temporaryMessage.actorType = "users"
         temporaryMessage.timestamp = Int(Date().timeIntervalSince1970)
         temporaryMessage.token = room.token
+        temporaryMessage.threadId = thread?.threadId ?? 0
+        temporaryMessage.isThread = thread != nil ? true : false
 
         let referenceId = "temp-\(Date().timeIntervalSince1970 * 1000)"
         temporaryMessage.referenceId = NCUtils.sha1(fromString: referenceId)
@@ -1086,7 +1088,12 @@ import SwiftUI
             }
             NCAPIController.sharedInstance().uniqueNameForFileUpload(withName: originalMessage, originalName: true, for: activeAccount, withCompletionBlock: { fileServerURL, fileServerPath, _, _ in
                 if let fileServerURL, let fileServerPath {
-                    let talkMetaData: [String: String] = ["messageType": "voice-message"]
+                    var talkMetaData: [String: Any] = ["messageType": "voice-message"]
+                    talkMetaData["replyTo"] = message.parentMessageId
+
+                    if let thread = self.thread {
+                        talkMetaData["threadId"] = thread.threadId
+                    }
 
                     self.uploadFileAtPath(localPath: message.file().fileStatus!.fileLocalPath!, withFileServerURL: fileServerURL, andFileServerPath: fileServerPath, withMetaData: talkMetaData, temporaryMessage: message)
                 } else {

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -2254,6 +2254,12 @@ import SwiftUI
 
     func insertMessages(messages: [NCChatMessage]) {
         for newMessage in messages {
+            // Skip thread messages when not in a thread view controller
+            // Skip non thread messages when in a normal chat view controller
+            guard (self.thread == nil && !newMessage.isThreadMessage())
+               || (self.thread != nil && (newMessage.isThreadMessage() || newMessage.isThreadOriginalMessage()))
+            else { continue }
+
             let newMessageDate = Date(timeIntervalSince1970: TimeInterval(newMessage.timestamp))
 
             if let keyDate = self.getKeyForDate(date: newMessageDate, inDictionary: self.messages),
@@ -2303,8 +2309,11 @@ import SwiftUI
             // Processing of update messages still happens when receiving new messages, so safe to skip here
             guard !newMessage.isUpdateMessage else { continue }
 
-            // Hide messages of threads when not displaying a thread
-            guard self.thread != nil || !newMessage.isThreadMessage() else { continue }
+            // Skip thread messages when not in a thread view controller
+            // Skip non thread messages when in a normal chat view controller
+            guard (self.thread == nil && !newMessage.isThreadMessage())
+               || (self.thread != nil && (newMessage.isThreadMessage() || newMessage.isThreadOriginalMessage()))
+            else { continue }
 
             let newMessageDate = Date(timeIntervalSince1970: TimeInterval(newMessage.timestamp))
             let keyDate = self.getKeyForDate(date: newMessageDate, inDictionary: dictionary)

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -1089,7 +1089,10 @@ import SwiftUI
             NCAPIController.sharedInstance().uniqueNameForFileUpload(withName: originalMessage, originalName: true, for: activeAccount, withCompletionBlock: { fileServerURL, fileServerPath, _, _ in
                 if let fileServerURL, let fileServerPath {
                     var talkMetaData: [String: Any] = ["messageType": "voice-message"]
-                    talkMetaData["replyTo"] = message.parentMessageId
+
+                    if message.parentMessageId > 0 {
+                        talkMetaData["replyTo"] = message.parentMessageId
+                    }
 
                     if let thread = self.thread {
                         talkMetaData["threadId"] = thread.threadId

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -1442,7 +1442,7 @@ import SwiftUI
 
     internal func createShareConfirmationViewController() -> (shareConfirmationVC: ShareConfirmationViewController, navController: NCNavigationController)? {
         let serverCapabilities = NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: self.account.accountId)
-        let shareConfirmationVC = ShareConfirmationViewController(room: self.room, account: self.account, serverCapabilities: serverCapabilities!)!
+        let shareConfirmationVC = ShareConfirmationViewController(room: self.room, thread: self.thread, account: self.account, serverCapabilities: serverCapabilities!)!
         shareConfirmationVC.delegate = self
         shareConfirmationVC.isModal = true
         let navigationController = NCNavigationController(rootViewController: shareConfirmationVC)

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -834,7 +834,10 @@ import SwiftUI
             objectItems.append(threadAction)
         }
 
-        items.append(UIMenu(options: .displayInline, children: objectItems))
+        // TODO: Remove this check when rich objects and polls can be shared in threads
+        if thread == nil {
+            items.append(UIMenu(options: .displayInline, children: objectItems))
+        }
 
         items.append(ncFilesAction)
         items.append(filesAction)

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -1838,8 +1838,13 @@ import SwiftUI
             NCAPIController.sharedInstance().uniqueNameForFileUpload(withName: audioFileName, originalName: true, for: activeAccount, withCompletionBlock: { fileServerURL, fileServerPath, _, _ in
                 if let fileServerURL, let fileServerPath {
                     var talkMetaData: [String: Any] = ["messageType": "voice-message"]
+
                     if let replyToMessageId = replyToMessage?.messageId {
                         talkMetaData["replyTo"] = replyToMessageId
+                    }
+
+                    if let thread = self.thread {
+                        talkMetaData["threadId"] = thread.threadId
                     }
 
                     self.uploadFileAtPath(localPath: destinationFilePath, withFileServerURL: fileServerURL, andFileServerPath: fileServerPath, withMetaData: talkMetaData, temporaryMessage: temporaryMessage)

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -873,7 +873,7 @@ import SwiftUI
     }
 
     func presentNextcloudFilesBrowser() {
-        let directoryVC = DirectoryTableViewController(path: "", inRoom: self.room.token)
+        let directoryVC = DirectoryTableViewController(path: "", inRoom: self.room.token, andThread: self.thread?.threadId ?? 0)
         self.presentWithNavigation(directoryVC, animated: true)
     }
 

--- a/NextcloudTalk/ChatFileUploader.swift
+++ b/NextcloudTalk/ChatFileUploader.swift
@@ -11,7 +11,7 @@ import NextcloudKit
     public static func uploadFile(localPath: String,
                                   fileServerURL: String,
                                   fileServerPath: String,
-                                  talkMetaData: [String: String]?,
+                                  talkMetaData: [String: Any]?,
                                   temporaryMessage: NCChatMessage?,
                                   room: NCRoom,
                                   completion: @escaping (Int, NSString?) -> Void) {

--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -527,7 +527,7 @@ import SwiftUI
         self.navigationItem.rightBarButtonItems = barButtonsItems
 
         // No sharing options in federation v1 (or thread view until implemented)
-        if room.isFederated || isThreadViewController {
+        if room.isFederated {
             // When hiding the button it is still respected in the layout constraints
             // So we need to remove the image to remove the button for now
             self.leftButton.setImage(nil, for: .normal)

--- a/NextcloudTalk/DirectoryTableViewController.h
+++ b/NextcloudTalk/DirectoryTableViewController.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface DirectoryTableViewController : UITableViewController
 
-- (instancetype)initWithPath:(NSString *)path inRoom:(NSString *)token;
+- (instancetype)initWithPath:(NSString *)path inRoom:(NSString *)token andThread:(NSInteger)threadId;
 
 @end
 

--- a/NextcloudTalk/DirectoryTableViewController.m
+++ b/NextcloudTalk/DirectoryTableViewController.m
@@ -22,6 +22,7 @@
     NSString *_path;
     NSString *_userHomePath;
     NSString *_token;
+    NSInteger _threadId;
     NSMutableArray *_itemsInDirectory;
     NSIndexPath *_selectedItem;
     UIBarButtonItem *_sortingButton;
@@ -33,13 +34,14 @@
 
 @implementation DirectoryTableViewController
 
-- (instancetype)initWithPath:(NSString *)path inRoom:(nonnull NSString *)token
+- (instancetype)initWithPath:(NSString *)path inRoom:(NSString *)token andThread:(NSInteger)threadId
 {
     self = [super init];
     
     if (self) {
         _path = path;
         _token = token;
+        _threadId = threadId;
     }
     
     return self;
@@ -176,7 +178,13 @@
 - (void)shareFileWithPath:(NSString *)path
 {
     [self setSharingFileUI];
-    [[NCAPIController sharedInstance] shareFileOrFolderForAccount:[[NCDatabaseManager sharedInstance] activeAccount] atPath:path toRoom:_token talkMetaData:nil referenceId: nil withCompletionBlock:^(NSError *error) {
+
+    NSMutableDictionary *talkMetaData = [NSMutableDictionary new];
+    if (_threadId > 0) {
+        [talkMetaData setObject:@(_threadId) forKey:@"threadId"];
+    }
+
+    [[NCAPIController sharedInstance] shareFileOrFolderForAccount:[[NCDatabaseManager sharedInstance] activeAccount] atPath:path toRoom:_token talkMetaData:talkMetaData referenceId: nil withCompletionBlock:^(NSError *error) {
         if (!error) {
             [self dismissViewControllerAnimated:YES completion:nil];
         } else {
@@ -326,7 +334,7 @@
     NSString *selectedItemPath = [NSString stringWithFormat:@"%@/%@", _path, item.fileName];
     
     if (item.directory) {
-        DirectoryTableViewController *directoryVC = [[DirectoryTableViewController alloc] initWithPath:selectedItemPath inRoom:_token];
+        DirectoryTableViewController *directoryVC = [[DirectoryTableViewController alloc] initWithPath:selectedItemPath inRoom:_token andThread:_threadId];
         [self.navigationController pushViewController:directoryVC animated:YES];
     } else {
         [self showConfirmationDialogForSharingItemWithPath:selectedItemPath andName:item.fileName];

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -979,8 +979,14 @@ NSString * const NCChatControllerDidReceiveThreadMessageNotification            
             if (fileServerURL && fileServerPath) {
                 NSMutableDictionary *talkMetaData = [NSMutableDictionary new];
                 [talkMetaData setObject:@"voice-message" forKey:@"messageType"];
-                [talkMetaData setObject:@(message.parentMessageId) forKey:@"replyTo"];
-                [talkMetaData setObject:@(self.threadId) forKey:@"replyTo"];
+
+                if (message.parentMessageId > 0) {
+                    [talkMetaData setObject:@(message.parentMessageId) forKey:@"replyTo"];
+                }
+
+                if ([self isThreadController]) {
+                    [talkMetaData setObject:@(self.threadId) forKey:@"threadId"];
+                }
 
                 [ChatFileUploader uploadFileWithLocalPath:message.file.fileStatus.fileLocalPath
                                             fileServerURL:fileServerURL

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -977,7 +977,9 @@ NSString * const NCChatControllerDidReceiveThreadMessageNotification            
                                                                forAccount:activeAccount
                                                       withCompletionBlock:^(NSString *fileServerURL, NSString *fileServerPath, NSInteger _, NSString *__) {
             if (fileServerURL && fileServerPath) {
-                NSDictionary *talkMetaData = @{@"messageType": @"voice-message"};
+                NSMutableDictionary *talkMetaData = [NSMutableDictionary new];
+                [talkMetaData setObject:@"voice-message" forKey:@"messageType"];
+                [talkMetaData setObject:@(message.parentMessageId) forKey:@"replyTo"];
 
                 [ChatFileUploader uploadFileWithLocalPath:message.file.fileStatus.fileLocalPath
                                             fileServerURL:fileServerURL
@@ -1001,7 +1003,7 @@ NSString * const NCChatControllerDidReceiveThreadMessageNotification            
                             NSLog(@"User storage quota exceeded.");
                             break;
                         default:
-                            NSLog(@"Failed to upload voice message with error code: %d", statusCode);
+                            NSLog(@"Failed to upload voice message with error code: %ld", (long)statusCode);
                             break;
                     }
                 }];

--- a/NextcloudTalk/NCChatController.m
+++ b/NextcloudTalk/NCChatController.m
@@ -980,6 +980,7 @@ NSString * const NCChatControllerDidReceiveThreadMessageNotification            
                 NSMutableDictionary *talkMetaData = [NSMutableDictionary new];
                 [talkMetaData setObject:@"voice-message" forKey:@"messageType"];
                 [talkMetaData setObject:@(message.parentMessageId) forKey:@"replyTo"];
+                [talkMetaData setObject:@(self.threadId) forKey:@"replyTo"];
 
                 [ChatFileUploader uploadFileWithLocalPath:message.file.fileStatus.fileLocalPath
                                             fileServerURL:fileServerURL

--- a/NextcloudTalk/NCRoomsManagerExtensions.swift
+++ b/NextcloudTalk/NCRoomsManagerExtensions.swift
@@ -401,9 +401,14 @@ import Foundation
                 NotificationCenter.default.post(name: .NCChatControllerDidSendChatMessage, object: self, userInfo: userInfo)
             } else {
                 if let accountId = offlineMessage.accountId,
-                   let room = NCDatabaseManager.sharedInstance().room(withToken: offlineMessage.token, forAccountId: accountId),
-                   let chatController = NCChatController(for: room) {
-                    chatController.send(offlineMessage)
+                   let room = NCDatabaseManager.sharedInstance().room(withToken: offlineMessage.token, forAccountId: accountId) {
+                    if offlineMessage.threadId > 0 && offlineMessage.isThread {
+                        guard let chatController = NCChatController(forThreadId: offlineMessage.threadId, in: room) else { return }
+                        chatController.send(offlineMessage)
+                    } else {
+                        guard let chatController = NCChatController(for: room) else { return }
+                        chatController.send(offlineMessage)
+                    }
                 }
             }
         }

--- a/ShareExtension/ShareConfirmationViewController.swift
+++ b/ShareExtension/ShareConfirmationViewController.swift
@@ -219,10 +219,11 @@ import MBProgressHUD
 
     // MARK: - Init.
 
-    public init?(room: NCRoom, account: TalkAccount, serverCapabilities: ServerCapabilities) {
+    public init?(room: NCRoom, thread: NCThread?, account: TalkAccount, serverCapabilities: ServerCapabilities) {
         self.serverCapabilities = serverCapabilities
 
         super.init(forRoom: room, withAccount: account, withView: self.shareContentView)
+        self.thread = thread
 
         self.shareContentView.addSubview(self.toLabelView)
         NSLayoutConstraint.activate([
@@ -646,6 +647,10 @@ import MBProgressHUD
 
                 if self.shareSilently {
                     talkMetaData["silent"] = self.shareSilently
+                }
+
+                if let thread = self.thread {
+                    talkMetaData["threadId"] = thread.threadId
                 }
 
                 NCAPIController.sharedInstance().shareFileOrFolder(for: self.account, atPath: filePath, toRoom: self.room.token, talkMetaData: talkMetaData, referenceId: nil) { error in

--- a/ShareExtension/ShareViewController.m
+++ b/ShareExtension/ShareViewController.m
@@ -138,7 +138,7 @@
             if (managedAccount) {
                 TalkAccount *intentAccount = [[TalkAccount alloc] initWithValue:managedAccount];
                 [self setupShareViewForAccount:intentAccount];
-                ShareConfirmationViewController *shareConfirmationVC = [[ShareConfirmationViewController alloc] initWithRoom:room account:intentAccount serverCapabilities:_serverCapabilities];
+                ShareConfirmationViewController *shareConfirmationVC = [[ShareConfirmationViewController alloc] initWithRoom:room thread:nil account:intentAccount serverCapabilities:_serverCapabilities];
                 shareConfirmationVC.delegate = self;
                 shareConfirmationVC.isModal = YES;
                 [self setSharedItemToShareConfirmationViewController:shareConfirmationVC];
@@ -534,7 +534,7 @@
         return;
     }
 
-    ShareConfirmationViewController *shareConfirmationVC = [[ShareConfirmationViewController alloc] initWithRoom:room account:_shareAccount serverCapabilities:_serverCapabilities];
+    ShareConfirmationViewController *shareConfirmationVC = [[ShareConfirmationViewController alloc] initWithRoom:room thread:nil account:_shareAccount serverCapabilities:_serverCapabilities];
     shareConfirmationVC.delegate = self;
     if (_forwardMessage) {
         shareConfirmationVC.delegate = (id<ShareConfirmationViewControllerDelegate>)_chatViewController;


### PR DESCRIPTION
Add talk metadata when sharing files, so they can be directly shared in threads.