### PR TITLE
fix: Keep highlight after switching to archived and back

### DIFF
--- a/NextcloudTalk/RoomsTableViewController.m
+++ b/NextcloudTalk/RoomsTableViewController.m
@@ -673,6 +673,7 @@ typedef enum RoomsSections {
         _rooms = [[NSMutableArray alloc] initWithArray:filteredRooms];
         [self calculateLastRoomWithMention];
         [self.tableView reloadData];
+        [self highlightSelectedRoom];
     } else {
         _resultTableViewController.rooms = [self filterRooms:filteredRooms withString:searchString];
         [self calculateLastRoomWithMention];
@@ -1685,7 +1686,6 @@ typedef enum RoomsSections {
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    [self removeRoomSelection];
     BOOL isAppInForeground = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
 
     if (!isAppInForeground) {
@@ -1737,6 +1737,7 @@ typedef enum RoomsSections {
     }
     
     // Present room chat
+    [self removeRoomSelection];
     [self presentChatForRoomAtIndexPath:indexPath];
 }
 


### PR DESCRIPTION
* Be in a room, the cell is highlighted
* Switch to archived conversations and back

Without: No room is highlighted
With: The room that is still open is also still highlighted